### PR TITLE
Enable bash completion in the CLI tool

### DIFF
--- a/autocomplete/README.md
+++ b/autocomplete/README.md
@@ -1,0 +1,4 @@
+These files are copied from the github.com/urfave/cli package, with the names
+of shell functions which they define modified to avoid stepping on other
+packages.  Install them with the name "buildah" in locations where they'll be
+sourced by the corresponding shells.

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+_buildah_bash_autocomplete() {
+     local cur opts base
+     COMPREPLY=()
+     cur="${COMP_WORDS[COMP_CWORD]}"
+     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+     return 0
+ }
+  
+ complete -F _buildah_bash_autocomplete $PROG

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -1,0 +1,5 @@
+autoload -U compinit && compinit
+autoload -U bashcompinit && bashcompinit
+
+script_dir=$(dirname $0)
+source ${script_dir}/bash_autocomplete

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -134,5 +134,6 @@ func main() {
 			Action:      deleteCmd,
 		},
 	}
+	app.EnableBashCompletion = true
 	app.Run(os.Args)
 }


### PR DESCRIPTION
This adds the shell snippets for adding autocompletion for the buildah, and enables the supporting logic in the tool itself.