### PR TITLE
Correctly report errors returned by commands

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -149,5 +149,9 @@ func main() {
 			ArgsUsage:   "CONTAINER-NAME-OR-ID",
 		},
 	}
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		logrus.Errorf("%v", err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
When running our various subcommands, report errors that they return correctly, and ensure that in those cases we don't exit with status 0.