### PR TITLE
Always make sure the working directory exists

### DIFF
--- a/add.go
+++ b/add.go
@@ -50,6 +50,9 @@ func (b *Builder) Add(destination string, extract bool, source ...string) error 
 	if destination != "" && filepath.IsAbs(destination) {
 		dest = filepath.Join(dest, destination)
 	} else {
+		if err := os.MkdirAll(filepath.Join(dest, b.Workdir), 0755); err != nil {
+			return fmt.Errorf("error ensuring directory %q exists: %v)", b.Workdir, err)
+		}
 		dest = filepath.Join(dest, b.Workdir, destination)
 	}
 	// Make sure the destination is usable.

--- a/run.go
+++ b/run.go
@@ -108,6 +108,9 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	if spec.Process.Cwd == "" {
 		spec.Process.Cwd = DefaultWorkingDir
 	}
+	if err := os.MkdirAll(filepath.Join(mountPoint, b.Workdir), 0755); err != nil {
+		return fmt.Errorf("error ensuring working directory %q exists: %v)", b.Workdir, err)
+	}
 	mounts := options.Mounts
 	for _, specMount := range spec.Mounts {
 		override := false


### PR DESCRIPTION
Always make sure the working directory exists before attempting to run anything inside of it, and before attempting to copy contents into it or one of its subdirectories.