### PR TITLE
Teach "copy" to allow copying to a destination file

### DIFF
--- a/tests/add.bats
+++ b/tests/add.bats
@@ -16,8 +16,11 @@ load helpers
 	buildah add --name=$cid --dest=/subdir ${TESTDIR}/randomfile
 	# Copy a file two files to a specific subdirectory
 	buildah add --name=$cid --dest=/other-subdir ${TESTDIR}/randomfile ${TESTDIR}/other-randomfile
-	# Copy a file two files to a specific location, created as a subdirectory
-	buildah add --name=$cid --dest=/notthereyet-subdir ${TESTDIR}/randomfile ${TESTDIR}/other-randomfile
+	# Copy a file two files to a specific location, which fails because it's not a directory.
+	run buildah add --name=$cid --dest=/notthereyet-subdir ${TESTDIR}/randomfile ${TESTDIR}/other-randomfile
+	[ $status -ne 0 ]
+	run buildah add --name=$cid --dest=/randomfile ${TESTDIR}/randomfile ${TESTDIR}/other-randomfile
+	[ $status -ne 0 ]
 	# Copy a file to a different working directory
 	buildah config --workingdir=/cwd --name=$cid
 	buildah add --name=$cid ${TESTDIR}/randomfile
@@ -35,11 +38,6 @@ load helpers
 	cmp ${TESTDIR}/randomfile $newroot/other-subdir/randomfile
 	test -s $newroot/other-subdir/other-randomfile
 	cmp ${TESTDIR}/other-randomfile $newroot/other-subdir/other-randomfile
-	test -d $newroot/notthereyet-subdir
-	test -s $newroot/notthereyet-subdir/randomfile
-	cmp ${TESTDIR}/randomfile $newroot/notthereyet-subdir/randomfile
-	test -s $newroot/notthereyet-subdir/other-randomfile
-	cmp ${TESTDIR}/other-randomfile $newroot/notthereyet-subdir/other-randomfile
 	test -d $newroot/cwd
 	test -s $newroot/cwd/randomfile
 	cmp ${TESTDIR}/randomfile $newroot/cwd/randomfile


### PR DESCRIPTION
The current Copy() mplementation assumes that the destination location is (or is intended to be) a directory, because I thought that was how the COPY instruction worked.  On reading example Dockerfiles, it looks like that was incorrect.  Building on #30, this changes Copy() to default to creating a file when the item being copied is a file and the destination name doesn't exist yet, which is more in line with the `cp` command.