### PR TITLE
Rename "list" and "delete" to "containers" and "rm"; add "images" and "rmi" commands

### DIFF
--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -8,30 +8,28 @@ import (
 )
 
 var (
-	// TODO implement
-	listFlags = []cli.Flag{
+	containersFlags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "quiet, q",
-			Usage: "list only container image id's",
+			Usage: "display only container IDs",
 		},
 		cli.BoolFlag{
 			Name:  "noheading, n",
 			Usage: "do not print column headings",
 		},
 	}
-	listDescription = "Lists containers which appear to be " + buildah.Package + " working containers, their\n   names and IDs, and the names and IDs of the images from which they were\n   initialized"
-
-	listCommand = cli.Command{
-		Name:        "list",
+	containersDescription = "Lists containers which appear to be " + buildah.Package + " working containers, their\n   names and IDs, and the names and IDs of the images from which they were\n   initialized"
+	containersCommand     = cli.Command{
+		Name:        "containers",
 		Usage:       "List working containers and their base images",
-		Description: listDescription,
-		Flags:       listFlags,
-		Action:      listCmd,
+		Description: containersDescription,
+		Flags:       containersFlags,
+		Action:      containersCmd,
 		ArgsUsage:   " ",
 	}
 )
 
-func listCmd(c *cli.Context) error {
+func containersCmd(c *cli.Context) error {
 	store, err := getStore(c)
 	if err != nil {
 		return err
@@ -41,7 +39,6 @@ func listCmd(c *cli.Context) error {
 	if c.IsSet("quiet") {
 		quiet = c.Bool("quiet")
 	}
-
 	noheading := false
 	if c.IsSet("noheading") {
 		noheading = c.Bool("noheading")
@@ -59,7 +56,7 @@ func listCmd(c *cli.Context) error {
 			builder.FromImage = buildah.BaseImageFakeName
 		}
 		if quiet {
-			fmt.Printf("%-64s\n", builder.ContainerID)
+			fmt.Printf("%s\n", builder.ContainerID)
 		} else {
 			fmt.Printf("%-64s %-64s %-10s %s\n", builder.ContainerID, builder.FromImageID, builder.FromImage, builder.Container)
 		}

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
+var (
+	imagesFlags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "display only container IDs",
+		},
+		cli.BoolFlag{
+			Name:  "noheading, n",
+			Usage: "do not print column headings",
+		},
+	}
+	imagesDescription = "Lists locally stored images."
+	imagesCommand     = cli.Command{
+		Name:        "images",
+		Usage:       "List images in local storage",
+		Description: imagesDescription,
+		Flags:       imagesFlags,
+		Action:      imagesCmd,
+		ArgsUsage:   " ",
+	}
+)
+
+func imagesCmd(c *cli.Context) error {
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	quiet := false
+	if c.IsSet("quiet") {
+		quiet = c.Bool("quiet")
+	}
+	noheading := false
+	if c.IsSet("noheading") {
+		noheading = c.Bool("noheading")
+	}
+
+	images, err := store.Images()
+	if err != nil {
+		return fmt.Errorf("error reading images: %v", err)
+	}
+
+	if len(images) > 0 && !noheading && !quiet {
+		fmt.Printf("%-64s %s\n", "IMAGE ID", "IMAGE NAME")
+	}
+	for _, image := range images {
+		if quiet {
+			fmt.Printf("%s\n", image.ID)
+		} else {
+			names := []string{""}
+			if len(image.Names) > 0 {
+				names = image.Names
+			}
+			for _, name := range names {
+				fmt.Printf("%-64s %s\n", image.ID, name)
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -73,12 +73,14 @@ func main() {
 		commitCommand,
 		configCommand,
 		copyCommand,
-		deleteCommand,
+		rmCommand,
 		fromCommand,
-		listCommand,
+		containersCommand,
 		mountCommand,
 		runCommand,
 		umountCommand,
+		imagesCommand,
+		rmiCommand,
 	}
 	err := app.Run(os.Args)
 	if err != nil {

--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -7,17 +7,18 @@ import (
 )
 
 var (
-	deleteDescription = "Deletes working container(s), unmounting them if necessary"
-	deleteCommand     = cli.Command{
-		Name:        "delete",
-		Usage:       "Deletes working container(s)",
-		Description: deleteDescription,
-		Action:      deleteCmd,
+	rmDescription = "Removes one or more working containers, unmounting them if necessary"
+	rmCommand     = cli.Command{
+		Name:        "rm",
+		Aliases:     []string{"delete"},
+		Usage:       "Remove one or more working containers",
+		Description: rmDescription,
+		Action:      rmCmd,
 		ArgsUsage:   "CONTAINER-NAME-OR-ID [...]",
 	}
 )
 
-func deleteCmd(c *cli.Context) error {
+func rmCmd(c *cli.Context) error {
 	args := c.Args()
 	if len(args) == 0 {
 		return fmt.Errorf("container ID must be specified")
@@ -35,7 +36,7 @@ func deleteCmd(c *cli.Context) error {
 
 		err = builder.Delete()
 		if err != nil {
-			return fmt.Errorf("error deleting container %q: %v", builder.Container, err)
+			return fmt.Errorf("error removing container %q: %v", builder.Container, err)
 		}
 	}
 

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
+var (
+	rmiDescription = "Removes one or more locally stored images."
+	rmiCommand     = cli.Command{
+		Name:        "rmi",
+		Usage:       "Removes one or more images from local storage",
+		Description: rmiDescription,
+		Action:      rmiCmd,
+		ArgsUsage:   "IMAGE-NAME-OR-ID [...]",
+	}
+)
+
+func rmiCmd(c *cli.Context) error {
+	args := c.Args()
+	if len(args) == 0 {
+		return fmt.Errorf("container ID must be specified")
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	for _, id := range args {
+		_, err := store.DeleteImage(id, true)
+		if err != nil {
+			return fmt.Errorf("error removing image %q: %v", id, err)
+		}
+		fmt.Printf("%s\n", id)
+	}
+
+	return nil
+}

--- a/examples/all-the-things.sh
+++ b/examples/all-the-things.sh
@@ -33,7 +33,7 @@ read
 : "[1m Unmount our working container and delete it [0m"
 read
 buildah umount "$container1"
-buildah delete "$container1"
+buildah rm "$container1"
 read
 : "[1m Now try it with ocid not running! [0m"
 read
@@ -65,7 +65,7 @@ read
 : "[1m Unmount our new working container and delete it [0m"
 read
 buildah umount "$container2"
-buildah delete "$container2"
+buildah rm "$container2"
 read
 : "[1m Verify that our new new image is there[0m"
 read

--- a/examples/copy.sh
+++ b/examples/copy.sh
@@ -101,4 +101,4 @@ read
 : "[1m Clean up, because I ran this like fifty times while testing [0m"
 read
 echo '[buildah delete $container1]'
-buildah delete $container1
+buildah rm $container1

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -26,7 +26,7 @@ load helpers
   buildah add $cid ${TESTDIR}/randomfile
   buildah unmount $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
-  buildah delete $cid
+  buildah rm $cid
 
   newcid=$(buildah from new-image)
   newroot=$(buildah mount $newcid)
@@ -41,7 +41,7 @@ load helpers
   test -d $newroot/cwd
   test -s $newroot/cwd/randomfile
   cmp ${TESTDIR}/randomfile $newroot/cwd/randomfile
-  buildah delete $newcid
+  buildah rm $newcid
 }
 
 @test "add-local-archive" {
@@ -73,7 +73,7 @@ load helpers
   buildah add $cid ${TESTDIR}/tarball4.tar.bz2
   buildah unmount $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
-  buildah delete $cid
+  buildah rm $cid
 
   newcid=$(buildah from new-image)
   newroot=$(buildah mount $newcid)
@@ -93,5 +93,5 @@ load helpers
   cmp ${TESTDIR}/tarball4/tarball4.random1 $newroot/tarball4/tarball4.random1
   test -s $newroot/tarball4/tarball4.random2
   cmp ${TESTDIR}/tarball4/tarball4.random2 $newroot/tarball4/tarball4.random2
-  buildah delete $newcid
+  buildah rm $newcid
 }

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -4,16 +4,16 @@ load helpers
 
 @test "from" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  buildah delete $cid
+  buildah rm $cid
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json         alpine)
-  buildah delete $cid
+  buildah rm $cid
   cid=$(buildah from alpine --pull --signature-policy ${TESTSDIR}/policy.json --name i-love-naming-things)
-  buildah delete i-love-naming-things
+  buildah rm i-love-naming-things
 }
 
 @test "from-defaultpull" {
   cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
-  buildah delete $cid
+  buildah rm $cid
 }
 
 @test "from-nopull" {
@@ -28,21 +28,21 @@ load helpers
   root=$(buildah mount $cid)
   touch $root/foobar
   buildah unmount $cid
-  buildah delete $cid
+  buildah rm $cid
 }
 
 @test "by-name" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --name alpine-working-image-for-test alpine)
   root=$(buildah mount alpine-working-image-for-test)
   buildah unmount alpine-working-image-for-test
-  buildah delete alpine-working-image-for-test
+  buildah rm alpine-working-image-for-test
 }
 
 @test "by-root" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   root=$(buildah mount $cid)
   buildah unmount $cid
-  buildah delete $cid
+  buildah rm $cid
 }
 
 @test "commit" {
@@ -54,7 +54,7 @@ load helpers
   cp ${TESTDIR}/randomfile $root/randomfile
   buildah unmount $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
-  buildah delete $cid
+  buildah rm $cid
 
   newcid=$(buildah from new-image)
   newroot=$(buildah mount $newcid)
@@ -68,7 +68,7 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:another-new-image
   buildah commit --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:yet-another-new-image
   buildah unmount $newcid
-  buildah delete $newcid
+  buildah rm $newcid
 
   othernewcid=$(buildah from other-new-image)
   othernewroot=$(buildah mount $othernewcid)
@@ -76,7 +76,7 @@ load helpers
   cmp ${TESTDIR}/randomfile $othernewroot/randomfile
   test -s $othernewroot/other-randomfile
   cmp ${TESTDIR}/other-randomfile $othernewroot/other-randomfile
-  buildah delete $othernewcid
+  buildah rm $othernewcid
 
   anothernewcid=$(buildah from another-new-image)
   anothernewroot=$(buildah mount $anothernewcid)
@@ -84,7 +84,7 @@ load helpers
   cmp ${TESTDIR}/randomfile $anothernewroot/randomfile
   test -s $anothernewroot/other-randomfile
   cmp ${TESTDIR}/other-randomfile $anothernewroot/other-randomfile
-  buildah delete $anothernewcid
+  buildah rm $anothernewcid
 
   yetanothernewcid=$(buildah from yet-another-new-image)
   yetanothernewroot=$(buildah mount $yetanothernewcid)
@@ -92,5 +92,5 @@ load helpers
   cmp ${TESTDIR}/randomfile $yetanothernewroot/randomfile
   test -s $yetanothernewroot/other-randomfile
   cmp ${TESTDIR}/other-randomfile $yetanothernewroot/other-randomfile
-  buildah delete $yetanothernewcid
+  buildah rm $yetanothernewcid
 }

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -13,14 +13,14 @@ load helpers
   buildah copy $cid ${TESTDIR}/randomfile
   run buildah copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile
   [ "$status" -eq 1 ]
-  buildah delete $cid
+  buildah rm $cid
 
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   root=$(buildah mount $cid)
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile
   buildah copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile /etc
-  buildah delete $cid
+  buildah rm $cid
 }
 
 @test "copy-local-plain" {
@@ -35,7 +35,7 @@ load helpers
   buildah copy $cid ${TESTDIR}/other-randomfile
   buildah unmount $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
-  buildah delete $cid
+  buildah rm $cid
 
   newcid=$(buildah from new-image)
   newroot=$(buildah mount $newcid)
@@ -43,5 +43,5 @@ load helpers
   cmp ${TESTDIR}/randomfile $newroot/randomfile
   test -s $newroot/other-randomfile
   cmp ${TESTDIR}/other-randomfile $newroot/other-randomfile
-  buildah delete $newcid
+  buildah rm $newcid
 }

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -22,5 +22,5 @@ load helpers
 	test -s $root/tmp/other-randomfile
 	cmp ${TESTDIR}/randomfile $root/tmp/other-randomfile
 	buildah unmount $cid
-	buildah delete $cid
+	buildah rm $cid
 }


### PR DESCRIPTION
Add some minimal image management commands.  Neither is really in scope for a building tool, but it reduces the number of use cases where we need additional tools.