### PR TITLE
Strip the image name down more for container names

### DIFF
--- a/new.go
+++ b/new.go
@@ -2,6 +2,7 @@ package buildah
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	is "github.com/containers/image/storage"
@@ -28,7 +29,20 @@ func newBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
 		name = options.Container
 	} else {
 		if image != "" {
-			name = image + "-" + name
+			prefix := image
+			s := strings.Split(prefix, "/")
+			if len(s) > 0 {
+				prefix = s[len(s)-1]
+			}
+			s = strings.Split(prefix, ":")
+			if len(s) > 0 {
+				prefix = s[0]
+			}
+			s = strings.Split(prefix, "@")
+			if len(s) > 0 {
+				prefix = s[0]
+			}
+			name = prefix + "-" + name
 		}
 	}
 	if name != "" {


### PR DESCRIPTION
When computing a default container name from the name of a source image, drop tags and any leading components from the image name before attempting to use it as part of a container name.