### PR TITLE
Give Run() commands access to the host's network

### DIFF
--- a/run.go
+++ b/run.go
@@ -104,6 +104,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	}()
 	g.SetRootPath(mountPoint)
 	g.SetProcessTerminal(true)
+	g.RemoveLinuxNamespace("network")
 	spec := g.Spec()
 	if spec.Process.Cwd == "" {
 		spec.Process.Cwd = DefaultWorkingDir


### PR DESCRIPTION
These changes put commands that we Run() in the host's network namespace, and defaults to giving it a read-only bind mounted copy of /etc/hosts and /etc/resolv.conf.