### PR TITLE
hook up to redhat-ci

### DIFF
--- a/.redhat-ci.sh
+++ b/.redhat-ci.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -xeuo pipefail
+
+export GOPATH=$HOME/gopath
+export PATH=$HOME/gopath/bin:$PATH
+export GOSRC=$HOME/gopath/src/github.com/projectatomic/buildah
+
+(mkdir -p $GOSRC && cd /code && cp -r . $GOSRC)
+
+dnf install -y \
+  make \
+  golang \
+  bats \
+  btrfs-progs-devel \
+  device-mapper-devel \
+  gpgme-devel \
+  libassuan-devel \
+  bzip2
+
+make -C $GOSRC
+$GOSRC/tests/test_runner.sh

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -1,0 +1,12 @@
+branches:
+  - master
+  - auto
+  - try
+
+host:
+  distro: fedora/25/atomic
+
+required: true
+
+tests:
+  - docker run --privileged -v $PWD:/code fedora:25 /code/.redhat-ci.sh


### PR DESCRIPTION
Add a YAML file to hook up this repo to redhat-ci. I ported over the
tests and environment from the .travis.yml file, though feel free to
customize it to your needs. For more information on supported YAML
fields, please see:

https://github.com/jlebon/redhat-ci/blob/master/sample.redhat-ci.yml

RHCI does also support containerized builds, though the container
environment is unprivileged, which means the tests won't be able to e.g.
mount things. Instead, I set it up so it provisions an Atomic Host on
which we run a privileged container. This is a workflow that will be
made easier in the future.