### PR TITLE
Clarify a comment

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 )
 
-// Delete removes the working container.  The Builder object should not be used
-// after this method is called.
+// Delete removes the working container.  The buildah.Builder object should not
+// be used after this method is called.
 func (b *Builder) Delete() error {
 	if err := b.store.DeleteContainer(b.ContainerID); err != nil {
 		return fmt.Errorf("error deleting build container: %v", err)


### PR DESCRIPTION
Clarify that we're referring to a buildah.Builder object here, and it's not a capitalization mistake.