### PR TITLE
Cleanup `buildah from` CLI

### DIFF
--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -20,10 +20,6 @@ var (
 			Name:  "name",
 			Usage: "`name` for the working container",
 		},
-		cli.StringFlag{
-			Name:  "image",
-			Usage: fmt.Sprintf("name of the starting `image`, or %q", buildah.BaseImageFakeName),
-		},
 		cli.BoolTFlag{
 			Name:  "pull",
 			Usage: "pull the image if not present",
@@ -54,22 +50,21 @@ var (
 		Description: fromDescription,
 		Flags:       fromFlags,
 		Action:      fromCmd,
-		ArgsUsage:   "IMAGE [CONTAINER-NAME]",
+		ArgsUsage:   "IMAGE",
 	}
 )
 
 func fromCmd(c *cli.Context) error {
+
 	args := c.Args()
-	image := ""
-	if c.IsSet("image") {
-		image = c.String("image")
-	} else {
-		if len(args) == 0 {
-			return fmt.Errorf("an image name (or \"scratch\") must be specified")
-		}
-		image = args[0]
-		args = args.Tail()
+	if len(args) == 0 {
+		return fmt.Errorf("an image name (or \"scratch\") must be specified")
 	}
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments specified")
+	}
+	image := args[0]
+
 	registry := DefaultRegistry
 	if c.IsSet("registry") {
 		registry = c.String("registry")
@@ -85,11 +80,6 @@ func fromCmd(c *cli.Context) error {
 	name := ""
 	if c.IsSet("name") {
 		name = c.String("name")
-	} else {
-		if len(args) > 0 {
-			name = args[0]
-			args = args.Tail()
-		}
 	}
 	mount := false
 	if c.IsSet("mount") {

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -6,7 +6,7 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --image alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   root=$(buildah mount $cid)
   mkdir $root/subdir $root/other-subdir
   # Copy a file to the working directory
@@ -28,7 +28,7 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   buildah delete $cid
 
-  newcid=$(buildah from --image new-image)
+  newcid=$(buildah from new-image)
   newroot=$(buildah mount $newcid)
   test -s $newroot/randomfile
   cmp ${TESTDIR}/randomfile $newroot/randomfile
@@ -48,7 +48,7 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --image alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   root=$(buildah mount $cid)
   dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/random1
   dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/random2
@@ -75,7 +75,7 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   buildah delete $cid
 
-  newcid=$(buildah from --image new-image)
+  newcid=$(buildah from new-image)
   newroot=$(buildah mount $newcid)
   test -s $newroot/random1
   cmp ${TESTDIR}/random1 $newroot/random1

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -3,42 +3,43 @@
 load helpers
 
 @test "from" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --image alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah delete $cid
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json         alpine)
   buildah delete $cid
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json         alpine  i-love-naming-things)
+  cid=$(buildah from alpine --pull --signature-policy ${TESTSDIR}/policy.json --name i-love-naming-things)
   buildah delete i-love-naming-things
 }
 
 @test "from-defaultpull" {
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json --image alpine)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah delete $cid
 }
 
 @test "from-nopull" {
-  run buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json --image alpine
+  run buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   [ "$status" -eq 1 ]
 }
 
 @test "mount" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --image alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   root=$(buildah mount $cid)
   buildah unmount $cid
   root=$(buildah mount $cid)
+  touch $root/foobar
   buildah unmount $cid
   buildah delete $cid
 }
 
 @test "by-name" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --image alpine alpine-working-image-for-test)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --name alpine-working-image-for-test alpine)
   root=$(buildah mount alpine-working-image-for-test)
   buildah unmount alpine-working-image-for-test
   buildah delete alpine-working-image-for-test
 }
 
 @test "by-root" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --image alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   root=$(buildah mount $cid)
   buildah unmount $cid
   buildah delete $cid
@@ -48,14 +49,14 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --image alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   root=$(buildah mount $cid)
   cp ${TESTDIR}/randomfile $root/randomfile
   buildah unmount $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   buildah delete $cid
 
-  newcid=$(buildah from --image new-image)
+  newcid=$(buildah from new-image)
   newroot=$(buildah mount $newcid)
   test -s $newroot/randomfile
   cmp ${TESTDIR}/randomfile $newroot/randomfile
@@ -69,7 +70,7 @@ load helpers
   buildah unmount $newcid
   buildah delete $newcid
 
-  othernewcid=$(buildah from --image other-new-image)
+  othernewcid=$(buildah from other-new-image)
   othernewroot=$(buildah mount $othernewcid)
   test -s $othernewroot/randomfile
   cmp ${TESTDIR}/randomfile $othernewroot/randomfile
@@ -77,7 +78,7 @@ load helpers
   cmp ${TESTDIR}/other-randomfile $othernewroot/other-randomfile
   buildah delete $othernewcid
 
-  anothernewcid=$(buildah from --image another-new-image)
+  anothernewcid=$(buildah from another-new-image)
   anothernewroot=$(buildah mount $anothernewcid)
   test -s $anothernewroot/randomfile
   cmp ${TESTDIR}/randomfile $anothernewroot/randomfile
@@ -85,7 +86,7 @@ load helpers
   cmp ${TESTDIR}/other-randomfile $anothernewroot/other-randomfile
   buildah delete $anothernewcid
 
-  yetanothernewcid=$(buildah from --image yet-another-new-image)
+  yetanothernewcid=$(buildah from yet-another-new-image)
   yetanothernewroot=$(buildah mount $yetanothernewcid)
   test -s $yetanothernewroot/randomfile
   cmp ${TESTDIR}/randomfile $yetanothernewroot/randomfile

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -7,7 +7,7 @@ load helpers
   createrandom ${TESTDIR}/other-randomfile
   createrandom ${TESTDIR}/third-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --image alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   root=$(buildah mount $cid)
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile
@@ -15,7 +15,7 @@ load helpers
   [ "$status" -eq 1 ]
   buildah delete $cid
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --image alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   root=$(buildah mount $cid)
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile
@@ -28,7 +28,7 @@ load helpers
   createrandom ${TESTDIR}/other-randomfile
   createrandom ${TESTDIR}/third-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --image alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   root=$(buildah mount $cid)
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile
@@ -37,7 +37,7 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   buildah delete $cid
 
-  newcid=$(buildah from --image new-image)
+  newcid=$(buildah from new-image)
   newroot=$(buildah mount $newcid)
   test -s $newroot/randomfile
   cmp ${TESTDIR}/randomfile $newroot/randomfile

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -7,7 +7,7 @@ load helpers
 		skip
 	fi
 	createrandom ${TESTDIR}/randomfile
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --image alpine)
+	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
 	root=$(buildah mount $cid)
 	buildah config $cid --workingdir /tmp
 	run buildah --debug=false run $cid pwd


### PR DESCRIPTION
Remove --image since image is an argument
Remove --mount, since I don't see a case where you would not want to do this.