### PR TITLE
Only attempt to shut down a Store if we opened one

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -10,6 +10,8 @@ import (
 	"github.com/urfave/cli"
 )
 
+var needToShutdownStore = false
+
 func getStore(c *cli.Context) (storage.Store, error) {
 	options := storage.DefaultStoreOptions
 	if c.GlobalIsSet("root") || c.GlobalIsSet("runroot") {
@@ -29,6 +31,7 @@ func getStore(c *cli.Context) (storage.Store, error) {
 	if store != nil {
 		is.Transport.SetStore(store)
 	}
+	needToShutdownStore = true
 	return store, err
 }
 

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -59,11 +59,13 @@ func main() {
 		return nil
 	}
 	app.After = func(c *cli.Context) error {
-		store, err := getStore(c)
-		if err != nil {
-			return err
+		if needToShutdownStore {
+			store, err := getStore(c)
+			if err != nil {
+				return err
+			}
+			store.Shutdown(false)
 		}
-		store.Shutdown(false)
 		return nil
 	}
 	app.Commands = []cli.Command{


### PR DESCRIPTION
Only attempt to Shutdown() the default storage.Store if we actually opened it to begin with.  This avoids some unnecessary churn with storage in cases where argument parsing flags an invocation error.