### PR TITLE
Correctly set tags on the names of pulled images

### DIFF
--- a/pull.go
+++ b/pull.go
@@ -31,7 +31,10 @@ func pullImage(store storage.Store, options BuilderOptions, sc *types.SystemCont
 	}
 
 	if ref := srcRef.DockerReference(); ref != nil {
-		name = reference.Domain(ref) + "/" + reference.Path(ref)
+		name = srcRef.DockerReference().Name()
+		if tagged, ok := srcRef.DockerReference().(reference.NamedTagged); ok {
+			name = name + ":" + tagged.Tag()
+		}
 	}
 
 	destRef, err := is.Transport.ParseStoreReference(store, name)


### PR DESCRIPTION
Correctly set the tag portion of the name that we assign to images that we've pulled, mimicking the change made in https://github.com/kubernetes-incubator/cri-o/pull/405.