### PR TITLE
Add support for images as well as containers to buildah list & delete

### DIFF
--- a/cmd/buildah/delete.go
+++ b/cmd/buildah/delete.go
@@ -7,10 +7,10 @@ import (
 )
 
 var (
-	deleteDescription = "Deletes working container(s), unmounting them if necessary"
+	deleteDescription = "Deletes images and working container(s), unmounting them if necessary"
 	deleteCommand     = cli.Command{
 		Name:        "delete",
-		Usage:       "Deletes working container(s)",
+		Usage:       "Deletes images and working container(s)",
 		Description: deleteDescription,
 		Action:      deleteCmd,
 		ArgsUsage:   "CONTAINER-NAME-OR-ID [...]",
@@ -30,12 +30,16 @@ func deleteCmd(c *cli.Context) error {
 	for _, name := range args {
 		builder, err := openBuilder(store, name)
 		if err != nil {
-			return fmt.Errorf("error reading build container %q: %v", name, err)
+			/* Maybe this was an image attempt to delete it */
+			_, err = store.DeleteImage(name, true)
+			return fmt.Errorf("error deleting image or container %q: %v", name, err)
 		}
 
 		err = builder.Delete()
 		if err != nil {
-			return fmt.Errorf("error deleting container %q: %v", builder.Container, err)
+			if err != nil {
+				return fmt.Errorf("error deleting container %q: %v", name, err)
+			}
 		}
 	}
 

--- a/cmd/buildah/list.go
+++ b/cmd/buildah/list.go
@@ -14,6 +14,18 @@ var (
 			Name:  "quiet",
 			Usage: "omit column headings",
 		},
+		cli.BoolFlag{
+			Name:  "containers",
+			Usage: "print containers only",
+		},
+		cli.BoolFlag{
+			Name:  "images",
+			Usage: "print images only",
+		},
+		cli.BoolFlag{
+			Name:  "no-trunc",
+			Usage: "don't truncate output",
+		},
 	}
 	listDescription = "Lists containers which appear to be " + buildah.Package + " working containers, their\n   names and IDs, and the names and IDs of the images from which they were\n   initialized"
 
@@ -38,19 +50,76 @@ func listCmd(c *cli.Context) error {
 		quiet = c.Bool("quiet")
 	}
 
-	builders, err := openBuilders(store)
-	if err != nil {
-		return fmt.Errorf("error reading build containers: %v", err)
-	}
-	if len(builders) > 0 && !quiet {
-		fmt.Printf("%-64s %-64s %-10s %s\n", "CONTAINER ID", "IMAGE ID", "IMAGE NAME", "CONTAINER NAME")
-	}
-	for _, builder := range builders {
-		if builder.FromImage == "" {
-			builder.FromImage = buildah.BaseImageFakeName
-		}
-		fmt.Printf("%-64s %-64s %-10s %s\n", builder.ContainerID, builder.FromImageID, builder.FromImage, builder.Container)
+	truncate := true
+	if c.IsSet("no-trunc") {
+		truncate = !c.Bool("no-trunc")
 	}
 
+	containers := true
+	if c.IsSet("images") {
+		containers = !c.Bool("images")
+	}
+
+	images := true
+	if c.IsSet("containers") {
+		images = !c.Bool("containers")
+	}
+
+	if images {
+		images, err := store.Images()
+		if err != nil {
+			return err
+		}
+
+		if len(images) > 0 && !quiet {
+			fmt.Printf("\nIMAGES\n\n")
+			if truncate {
+				fmt.Printf("%-12s %-64s\n", "IMAGE ID", "IMAGE NAME")
+			} else {
+				fmt.Printf("%-64s %-64s\n", "IMAGE ID", "IMAGE NAME")
+			}
+		}
+		for _, image := range images {
+			if quiet {
+				fmt.Printf("%s\n", image.ID)
+				continue
+			}
+			names := []string{""}
+			if len(image.Names) > 0 {
+				names = image.Names
+			}
+			for _, name := range names {
+				if truncate {
+					fmt.Printf("%-12.12s %s\n", image.ID, name)
+				} else {
+					fmt.Printf("%-64s %s\n", image.ID, name)
+				}
+			}
+		}
+	}
+	if containers {
+		builders, err := openBuilders(store)
+		if err != nil {
+			return fmt.Errorf("error reading build containers: %v", err)
+		}
+		if len(builders) > 0 && !quiet {
+			fmt.Printf("\nCONTAINERS\n\n")
+			if truncate {
+				fmt.Printf("%.12s %.12s %-10s %s\n", "CONTAINER ID", "IMAGE ID", "IMAGE NAME", "CONTAINER NAME")
+			} else {
+				fmt.Printf("%.64s %.64s %-10s %s\n", "CONTAINER ID", "IMAGE ID", "IMAGE NAME", "CONTAINER NAME")
+			}
+		}
+		for _, builder := range builders {
+			if builder.FromImage == "" {
+				builder.FromImage = buildah.BaseImageFakeName
+			}
+			if truncate {
+				fmt.Printf("%-12.12s %-12.12s %-10s %s\n", builder.ContainerID, builder.FromImageID, builder.FromImage, builder.Container)
+			} else {
+				fmt.Printf("%.64s %.64s %-10s %s\n", builder.ContainerID, builder.FromImageID, builder.FromImage, builder.Container)
+			}
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
This patch set will cleanup the output of buildah list adding truncate
flags as well as support images.