### PR TITLE
Accept commit targets which are just store refs

### DIFF
--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/containers/image/storage"
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/projectatomic/buildah"
@@ -66,7 +67,11 @@ func commitCmd(c *cli.Context) error {
 
 	dest, err := alltransports.ParseImageName(image)
 	if err != nil {
-		return fmt.Errorf("error parsing target image name %q: %v", image, err)
+		dest2, err2 := storage.Transport.ParseStoreReference(store, image)
+		if err2 != nil {
+			return fmt.Errorf("error parsing target image name %q: %v", image, err)
+		}
+		dest = dest2
 	}
 
 	options := buildah.CommitOptions{

--- a/examples/all-the-things.sh
+++ b/examples/all-the-things.sh
@@ -60,7 +60,7 @@ echo yay > $mountpoint2/another-file-in-root
 read
 : "[1m Produce an image from the new container[0m"
 read
-buildah commit "$container2" containers-storage:${3:-second-new-image}
+buildah commit "$container2" ${3:-second-new-image}
 read
 : "[1m Unmount our new working container and delete it [0m"
 read

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -66,7 +66,7 @@ load helpers
   run buildah commit $newcid --signature-policy ${TESTSDIR}/policy.json containers-storage:rejected-new-image
   [ "$status" -eq 1 ]
   buildah commit --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:another-new-image
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:yet-another-new-image
+  buildah commit --signature-policy ${TESTSDIR}/policy.json $newcid yet-another-new-image
   buildah unmount $newcid
   buildah delete $newcid
 


### PR DESCRIPTION
Accept commit target names which don't include a transport name by checking if they parse as valid containers-storage references after they fail to parse as a general reference.