### PR TITLE
Tweak ADDing/COPYing directories to copy contents

### DIFF
--- a/tests/add.bats
+++ b/tests/add.bats
@@ -14,9 +14,9 @@ load helpers
   buildah add $cid ${TESTDIR}/randomfile
   # Copy a file to a specific subdirectory
   buildah add $cid ${TESTDIR}/randomfile /subdir
-  # Copy a file two files to a specific subdirectory
+  # Copy two files to a specific subdirectory
   buildah add $cid ${TESTDIR}/randomfile ${TESTDIR}/other-randomfile /other-subdir
-  # Copy a file two files to a specific location, which fails because it's not a directory.
+  # Copy two files to a specific location, which fails because it's not a directory.
   run buildah add ${TESTDIR}/randomfile ${TESTDIR}/other-randomfile $cid /notthereyet-subdir
   [ $status -ne 0 ]
   run buildah add ${TESTDIR}/randomfile $cid ${TESTDIR}/other-randomfile /randomfile

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -45,3 +45,24 @@ load helpers
   cmp ${TESTDIR}/other-randomfile $newroot/other-randomfile
   buildah rm $newcid
 }
+
+@test "copy-local-subdirectory" {
+  mkdir -p ${TESTDIR}/subdir
+  createrandom ${TESTDIR}/subdir/randomfile
+  createrandom ${TESTDIR}/subdir/other-randomfile
+
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah config --workingdir /container-subdir $cid
+  buildah copy $cid ${TESTDIR}/subdir
+  root=$(buildah mount $cid)
+  test -s $root/container-subdir/randomfile
+  cmp ${TESTDIR}/subdir/randomfile $root/container-subdir/randomfile
+  test -s $root/container-subdir/other-randomfile
+  cmp ${TESTDIR}/subdir/other-randomfile $root/container-subdir/other-randomfile
+  buildah copy $cid ${TESTDIR}/subdir /other-subdir
+  test -s $root/other-subdir/randomfile
+  cmp ${TESTDIR}/subdir/randomfile $root/other-subdir/randomfile
+  test -s $root/other-subdir/other-randomfile
+  cmp ${TESTDIR}/subdir/other-randomfile $root/other-subdir/other-randomfile
+  buildah rm $cid
+}


### PR DESCRIPTION
When copying or adding a source directory, copy the directory's contents to the destination directory, to better match Dockerfile COPY behavior.