### PR TITLE
Use "scratch" for tests where we never "run"

### DIFF
--- a/tests/add.bats
+++ b/tests/add.bats
@@ -6,7 +6,7 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   root=$(buildah mount $cid)
   mkdir $root/subdir $root/other-subdir
   # Copy a file to the working directory
@@ -48,7 +48,7 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   root=$(buildah mount $cid)
   dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/random1
   dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/random2

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -5,7 +5,7 @@ load helpers
 @test "from" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm $cid
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json         alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah rm $cid
   cid=$(buildah from alpine --pull --signature-policy ${TESTSDIR}/policy.json --name i-love-naming-things)
   buildah rm i-love-naming-things
@@ -16,13 +16,20 @@ load helpers
   buildah rm $cid
 }
 
+@test "from-scratch" {
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah rm $cid
+  cid=$(buildah from --pull=true  --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah rm $cid
+}
+
 @test "from-nopull" {
   run buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   [ "$status" -eq 1 ]
 }
 
 @test "mount" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
   root=$(buildah mount $cid)
   buildah unmount $cid
   root=$(buildah mount $cid)
@@ -32,24 +39,17 @@ load helpers
 }
 
 @test "by-name" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --name alpine-working-image-for-test alpine)
-  root=$(buildah mount alpine-working-image-for-test)
-  buildah unmount alpine-working-image-for-test
-  buildah rm alpine-working-image-for-test
-}
-
-@test "by-root" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  root=$(buildah mount $cid)
-  buildah unmount $cid
-  buildah rm $cid
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --name scratch-working-image-for-test scratch)
+  root=$(buildah mount scratch-working-image-for-test)
+  buildah unmount scratch-working-image-for-test
+  buildah rm scratch-working-image-for-test
 }
 
 @test "commit" {
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
   root=$(buildah mount $cid)
   cp ${TESTDIR}/randomfile $root/randomfile
   buildah unmount $cid

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -7,7 +7,7 @@ load helpers
   createrandom ${TESTDIR}/other-randomfile
   createrandom ${TESTDIR}/third-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
   root=$(buildah mount $cid)
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile
@@ -28,7 +28,7 @@ load helpers
   createrandom ${TESTDIR}/other-randomfile
   createrandom ${TESTDIR}/third-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
   root=$(buildah mount $cid)
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile
@@ -51,7 +51,7 @@ load helpers
   createrandom ${TESTDIR}/subdir/randomfile
   createrandom ${TESTDIR}/subdir/other-randomfile
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah config --workingdir /container-subdir $cid
   buildah copy $cid ${TESTDIR}/subdir
   root=$(buildah mount $cid)


### PR DESCRIPTION
We can use "scratch" now as a source for building images, so it should speed things up a bit if we use it instead of pulling alpine in tests where it isn't expected to affect the test result.