### PR TITLE
Handle ADD/COPY where the destination ends with '/'

### DIFF
--- a/add.go
+++ b/add.go
@@ -62,6 +62,14 @@ func (b *Builder) Add(destination string, extract bool, source ...string) error 
 		}
 		dest = filepath.Join(dest, b.Workdir, destination)
 	}
+	// If the destination was explicitly marked as a directory by ending it
+	// with a '/', create it so that we can be sure that it's a directory,
+	// and any files we're copying will be placed in the directory.
+	if len(destination) > 0 && destination[len(destination)-1] == os.PathSeparator {
+		if err := os.MkdirAll(dest, 0755); err != nil {
+			return fmt.Errorf("error ensuring directory %q exists: %v)", dest, err)
+		}
+	}
 	// Make sure the destination's parent directory is usable.
 	if fi, err := os.Stat(filepath.Dir(dest)); err == nil && !fi.Mode().IsDir() {
 		return fmt.Errorf("%q already exists, but is not a subdirectory)", filepath.Dir(dest))

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -66,3 +66,23 @@ load helpers
   cmp ${TESTDIR}/subdir/other-randomfile $root/other-subdir/other-randomfile
   buildah rm $cid
 }
+
+@test "copy-local-force-directory" {
+  createrandom ${TESTDIR}/randomfile
+
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah config --workingdir / $cid
+  buildah copy $cid ${TESTDIR}/randomfile /randomfile
+  root=$(buildah mount $cid)
+  test -s $root/randomfile
+  cmp ${TESTDIR}/randomfile $root/randomfile
+  buildah rm $cid
+
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah config --workingdir / $cid
+  buildah copy $cid ${TESTDIR}/randomfile /randomsubdir/
+  root=$(buildah mount $cid)
+  test -s $root/randomsubdir/randomfile
+  cmp ${TESTDIR}/randomfile $root/randomsubdir/randomfile
+  buildah rm $cid
+}


### PR DESCRIPTION
When the destination for an ADD or COPY operation ends with a path separator, take that as an indicator that the destination should be a directory, that we should create it if it doesn't already exist, and that any files we're copying should be placed in the directory.