### PR TITLE
Make Run() use a terminal only if it has one

### DIFF
--- a/tests/run.bats
+++ b/tests/run.bats
@@ -11,11 +11,9 @@ load helpers
 	root=$(buildah mount $cid)
 	buildah config $cid --workingdir /tmp
 	run buildah --debug=false run $cid pwd
-	output=$(echo "$output" | tr -d '\r')
 	[ "$output" = /tmp ]
 	buildah config $cid --workingdir /root
 	run buildah --debug=false run        $cid pwd
-	output=$(echo "$output" | tr -d '\r')
 	[ "$output" = /root ]
 	cp ${TESTDIR}/randomfile $root/tmp/
 	buildah run        $cid cp /tmp/randomfile /tmp/other-randomfile


### PR DESCRIPTION
Make Run() run the command with a terminal if we're being run with a terminal.  This lets us avoid a weird workaround in the tests.