### PR TITLE
Turn off Travis builds against 1.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-    - 1.6
     - 1.7
+    - 1.8
     - tip
 dist: trusty
 sudo: required


### PR DESCRIPTION
Some of our dependencies (will) expect 1.7's "context" package and fields of http.Transport which aren't in 1.6.