### PR TITLE
rm/rmi: Don't exit until we've tried them all

### DIFF
--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/urfave/cli"
 )
@@ -28,17 +29,28 @@ func rmCmd(c *cli.Context) error {
 		return err
 	}
 
+	var e error
 	for _, name := range args {
 		builder, err := openBuilder(store, name)
+		if e == nil {
+			e = err
+		}
 		if err != nil {
-			return fmt.Errorf("error reading build container %q: %v", name, err)
+			fmt.Fprintf(os.Stderr, "error reading build container %q: %v\n", name, err)
+			continue
 		}
 
+		id := builder.ContainerID
 		err = builder.Delete()
-		if err != nil {
-			return fmt.Errorf("error removing container %q: %v", builder.Container, err)
+		if e == nil {
+			e = err
 		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error removing container %q: %v\n", builder.Container, err)
+			continue
+		}
+		fmt.Printf("%s\n", id)
 	}
 
-	return nil
+	return e
 }

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/storage"
@@ -33,6 +34,7 @@ func rmiCmd(c *cli.Context) error {
 		return err
 	}
 
+	var e error
 	for _, id := range args {
 		// If it's an exact name or ID match with the underlying
 		// storage library's information about the image, then it's
@@ -92,11 +94,15 @@ func rmiCmd(c *cli.Context) error {
 				err = ref.DeleteImage(nil)
 			}
 		}
+		if e == nil {
+			e = err
+		}
 		if err != nil {
-			return fmt.Errorf("error removing image %q: %v", id, err)
+			fmt.Fprintf(os.Stderr, "error removing image %q: %v\n", id, err)
+			continue
 		}
 		fmt.Printf("%s\n", id)
 	}
 
-	return nil
+	return e
 }


### PR DESCRIPTION
If we're told to remove more than one container or image, actually try to remove them all, but still return an error if we fail at any of them.