### PR TITLE
Small cleanup on buildah rmi to make code cleaner

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -65,17 +65,17 @@ func imagesCmd(c *cli.Context) error {
 	for _, image := range images {
 		if quiet {
 			fmt.Printf("%s\n", image.ID)
-		} else {
-			names := []string{""}
-			if len(image.Names) > 0 {
-				names = image.Names
-			}
-			for _, name := range names {
-				if truncate {
-					fmt.Printf("%-12.12s %s\n", image.ID, name)
-				} else {
-					fmt.Printf("%-64s %s\n", image.ID, name)
-				}
+			continue
+		}
+		names := []string{""}
+		if len(image.Names) > 0 {
+			names = image.Names
+		}
+		for _, name := range names {
+			if truncate {
+				fmt.Printf("%-12.12s %s\n", image.ID, name)
+			} else {
+				fmt.Printf("%-64s %s\n", image.ID, name)
 			}
 		}
 	}


### PR DESCRIPTION
While adding rmi to ocid, I was asked to make this change, so want
to keep the code in buildah and ocid for these functions as close as
possible to the same.