### PR TITLE
bud: Add flags for specifying the runtime command

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/storage/pkg/archive"
+	"github.com/projectatomic/buildah"
 	"github.com/projectatomic/buildah/imagebuildah"
 	"github.com/urfave/cli"
 )
@@ -38,6 +39,15 @@ var (
 		cli.StringSliceFlag{
 			Name:  "build-arg",
 			Usage: "`argument=value` to supply to the builder",
+		},
+		cli.StringFlag{
+			Name:  "runtime",
+			Usage: "`path` to an alternate runtime",
+			Value: buildah.DefaultRuntime,
+		},
+		cli.StringSliceFlag{
+			Name:  "runtime-flag",
+			Usage: "add global flags for the container runtime",
 		},
 		cli.StringFlag{
 			Name:  "tag, t",
@@ -76,6 +86,14 @@ func budCmd(c *cli.Context) error {
 	pullAlways := false
 	if c.IsSet("pull-always") {
 		pull = c.Bool("pull-always")
+	}
+	runtimeFlags := []string{}
+	if c.IsSet("runtime-flag") {
+		runtimeFlags = c.StringSlice("runtime-flag")
+	}
+	runtime := ""
+	if c.IsSet("runtime") {
+		runtime = c.String("runtime")
 	}
 
 	pullPolicy := imagebuildah.PullNever
@@ -178,6 +196,8 @@ func budCmd(c *cli.Context) error {
 		SignaturePolicyPath: signaturePolicy,
 		Args:                args,
 		Output:              output,
+		Runtime:             runtime,
+		RuntimeArgs:         runtimeFlags,
 	}
 
 	return imagebuildah.BuildDockerfiles(store, options, dockerfiles...)

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -55,8 +55,8 @@ resulting image's configuration.
 
 **--runtime** *path*
 
-The *path* to an alternate runtime, which will be used to run commands
-specified by the **RUN** instruction.
+The *path* to an alternate OCI-compatible runtime, which will be used to run
+commands specified by the **RUN** instruction.
 
 **--runtime-flag** *flag*
 

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -16,7 +16,7 @@ the *buildah config* command.
 
 **--runtime** *path*
 
-The *path* to an alternate runtime.
+The *path* to an alternate OCI-compatible runtime.
 
 **--runtime-flag** *flag*
 


### PR DESCRIPTION
So long as it's possible to have an incompatible version of runc installed, we're going to want to easily point to another version, as we already allow for with the "run" command.