### PR TITLE
imagebuildah: Reexport some things

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/containers/storage/pkg/archive"
-	"github.com/projectatomic/buildah"
 	"github.com/projectatomic/buildah/imagebuildah"
 	"github.com/urfave/cli"
 )
@@ -43,7 +41,7 @@ var (
 		cli.StringFlag{
 			Name:  "runtime",
 			Usage: "`path` to an alternate runtime",
-			Value: buildah.DefaultRuntime,
+			Value: imagebuildah.DefaultRuntime,
 		},
 		cli.StringSliceFlag{
 			Name:  "runtime-flag",
@@ -191,7 +189,7 @@ func budCmd(c *cli.Context) error {
 		ContextDirectory:    contextDir,
 		PullPolicy:          pullPolicy,
 		Registry:            registry,
-		Compression:         archive.Gzip,
+		Compression:         imagebuildah.Gzip,
 		Quiet:               quiet,
 		SignaturePolicyPath: signaturePolicy,
 		Args:                args,

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/containers/storage/pkg/reexec"
 	"github.com/containers/storage/storage"
 	"github.com/projectatomic/buildah"
 	"github.com/urfave/cli"
@@ -12,7 +11,7 @@ import (
 
 func main() {
 	var defaultStoreDriverOptions *cli.StringSlice
-	if reexec.Init() {
+	if buildah.InitReexec() {
 		return
 	}
 

--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/storage/pkg/chrootarchive"
+	"github.com/projectatomic/buildah"
 )
 
 func cloneToDirectory(url, dir string) error {
@@ -84,4 +85,11 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 		logrus.Debugf("error removing temporary directory %q: %v", name, err2)
 	}
 	return "", "", fmt.Errorf("unreachable code reached")
+}
+
+// InitReexec is a wrapper for buildah.InitReexec().  It should be called at
+// the start of main(), and if it returns true, main() should return
+// immediately.
+func InitReexec() bool {
+	return buildah.InitReexec()
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,12 @@
+package buildah
+
+import (
+	"github.com/containers/storage/pkg/reexec"
+)
+
+// InitReexec is a wrapper for reexec.Init().  It should be called at
+// the start of main(), and if it returns true, main() should return
+// immediately.
+func InitReexec() bool {
+	return reexec.Init()
+}


### PR DESCRIPTION
Have imagebuildah reexport some constants and its own Mount type, to reduce the number of our dependencies that a prospective consumer of this package would also need to import directly.