### PR TITLE
Remove --mount from buildah-from

### DIFF
--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -37,10 +37,6 @@ var (
 			Name:  "signature-policy",
 			Usage: "`pathname` of signature policy file (not usually used)",
 		},
-		cli.BoolFlag{
-			Name:  "mount",
-			Usage: "mount the working container",
-		},
 	}
 	fromDescription = "Creates a new working container, either from scratch or using a specified\n   image as a starting point"
 
@@ -90,10 +86,6 @@ func fromCmd(c *cli.Context) error {
 	if c.IsSet("name") {
 		name = c.String("name")
 	}
-	mount := false
-	if c.IsSet("mount") {
-		mount = c.Bool("mount")
-	}
 	signaturePolicy := ""
 	if c.IsSet("signature-policy") {
 		signaturePolicy = c.String("signature-policy")
@@ -108,7 +100,6 @@ func fromCmd(c *cli.Context) error {
 		FromImage:           image,
 		Container:           name,
 		PullPolicy:          pullPolicy,
-		Mount:               mount,
 		Registry:            registry,
 		SignaturePolicyPath: signaturePolicy,
 	}
@@ -119,9 +110,5 @@ func fromCmd(c *cli.Context) error {
 	}
 
 	fmt.Printf("%s\n", builder.Container)
-	if options.Mount {
-		fmt.Printf("%s\n", builder.MountPoint)
-	}
-
 	return builder.Save()
 }

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -522,7 +522,6 @@ return 1
      -h
      --pull
      --pull-always
-     --mount
   "
 
      local options_with_args="

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -15,10 +15,6 @@ The container ID of the container that was created.  On error, -1 is returned an
 
 ## OPTIONS
 
-**--mount**
-
-Mount the working container printing the mount point upon successful completion.
-
 **--name** *name*
 
 A *name* for the working container
@@ -46,7 +42,9 @@ option be used, as the default behavior of using the system-wide default policy
 
 ## EXAMPLE
 
-buildah from imagename --pull --registry "myregistry://" --mount
+buildah from imagename --pull --registry "myregistry://"
+
+buildah from myregistry://imagename --pull
 
 buildah from imagename --signature-policy /etc/containers/policy.json
 


### PR DESCRIPTION
We don't have a good way of identifying to a user where a container
was mounted on the file system when doing a buildah from.

A user can just do a buildah mount CID /mnt, after the from line to
handle this.