### PR TITLE
Switch back to our own name for "scratch"

### DIFF
--- a/new.go
+++ b/new.go
@@ -7,13 +7,12 @@ import (
 	"github.com/Sirupsen/logrus"
 	is "github.com/containers/image/storage"
 	"github.com/containers/storage/storage"
-	"github.com/openshift/imagebuilder"
 )
 
 const (
 	// BaseImageFakeName is the "name" of a source image which we interpret
 	// as "no image".
-	BaseImageFakeName = imagebuilder.NoBaseImageSpecifier
+	BaseImageFakeName = "scratch"
 )
 
 func newBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {


### PR DESCRIPTION
Don't import `github.com/openshift/imagebuilder` just so that we can reference its `NoBaseImageSpecifier` definition of "scratch".  That would create a cycle if imagebuilder tried to import _us_.