### PR TITLE
Touch up README.md to include go-md2man

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Prior to installing buildah, install the following packages on your linux distro
 * libassuan-devel 
 * git 
 * bzip2
+* go-md2man 
 
 In Fedora, you can use this command:
 
@@ -38,7 +39,8 @@ In Fedora, you can use this command:
     gpgme-devel \ 
     libassuan-devel \ 
     git \ 
-    bzip2 
+    bzip2 \
+    go-md2man
 ```
 
 Then to install buildah follow the steps in this example: 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Touches up the README.md file to includ go-md2man.  On a recent test on Fedora 25, go-md2man was not included based on installation dependencies as expected.