### PR TITLE
Report pull/commit progress by default

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -3,6 +3,7 @@ package buildah
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -134,6 +135,9 @@ type BuilderOptions struct {
 	// specified, indicating that the shared, system-wide default policy
 	// should be used.
 	SignaturePolicyPath string
+	// ReportWriter is an io.Writer which will be used to log the reading
+	// of the source image from a registry, if we end up pulling the image.
+	ReportWriter io.Writer
 }
 
 // ImportOptions are used to initialize a Builder.

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -15,7 +15,7 @@ var (
 	budFlags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "quiet, q",
-			Usage: "refrain from announcing build instructions",
+			Usage: "refrain from announcing build instructions and image read/write progress",
 		},
 		cli.StringFlag{
 			Name:  "registry",
@@ -202,6 +202,9 @@ func budCmd(c *cli.Context) error {
 		AdditionalTags:      tags,
 		Runtime:             runtime,
 		RuntimeArgs:         runtimeFlags,
+	}
+	if !quiet {
+		options.ReportWriter = os.Stderr
 	}
 
 	return imagebuildah.BuildDockerfiles(store, options, dockerfiles...)

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/containers/image/storage"
 	"github.com/containers/image/transports/alltransports"
@@ -19,6 +20,10 @@ var (
 		cli.StringFlag{
 			Name:  "signature-policy",
 			Usage: "`pathname` of signature policy file (not usually used)",
+		},
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "don't output progress information when writing images",
 		},
 	}
 	commitDescription = "Writes a new image using the container's read-write layer and, if it is based\n   on an image, the layers of that image"
@@ -55,6 +60,10 @@ func commitCmd(c *cli.Context) error {
 	if !c.IsSet("disable-compression") || !c.Bool("disable-compression") {
 		compress = archive.Gzip
 	}
+	quiet := false
+	if c.IsSet("quiet") {
+		quiet = c.Bool("quiet")
+	}
 	store, err := getStore(c)
 	if err != nil {
 		return err
@@ -77,6 +86,9 @@ func commitCmd(c *cli.Context) error {
 	options := buildah.CommitOptions{
 		Compression:         compress,
 		SignaturePolicyPath: signaturePolicy,
+	}
+	if !quiet {
+		options.ReportWriter = os.Stderr
 	}
 	err = builder.Commit(dest, options)
 	if err != nil {

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/projectatomic/buildah"
 	"github.com/urfave/cli"
@@ -36,6 +37,10 @@ var (
 		cli.StringFlag{
 			Name:  "signature-policy",
 			Usage: "`pathname` of signature policy file (not usually used)",
+		},
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "don't output progress information when pulling images",
 		},
 	}
 	fromDescription = "Creates a new working container, either from scratch or using a specified\n   image as a starting point"
@@ -91,6 +96,11 @@ func fromCmd(c *cli.Context) error {
 		signaturePolicy = c.String("signature-policy")
 	}
 
+	quiet := false
+	if c.IsSet("quiet") {
+		quiet = c.Bool("quiet")
+	}
+
 	store, err := getStore(c)
 	if err != nil {
 		return err
@@ -102,6 +112,9 @@ func fromCmd(c *cli.Context) error {
 		PullPolicy:          pullPolicy,
 		Registry:            registry,
 		SignaturePolicyPath: signaturePolicy,
+	}
+	if !quiet {
+		options.ReportWriter = os.Stderr
 	}
 
 	builder, err := buildah.NewBuilder(store, options)

--- a/commit.go
+++ b/commit.go
@@ -2,6 +2,7 @@ package buildah
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/containers/image/copy"
 	"github.com/containers/image/docker/reference"
@@ -27,6 +28,9 @@ type CommitOptions struct {
 	// the transport to which we're writing the image gives us a way to add
 	// them.
 	AdditionalTags []string
+	// ReportWriter is an io.Writer which will be used to log the writing
+	// of the new image.
+	ReportWriter io.Writer
 }
 
 func expandTags(tags []string) ([]string, error) {
@@ -62,7 +66,7 @@ func (b *Builder) Commit(dest types.ImageReference, options CommitOptions) error
 	if err != nil {
 		return err
 	}
-	err = copy.Image(policyContext, dest, src, getCopyOptions())
+	err = copy.Image(policyContext, dest, src, getCopyOptions(options.ReportWriter))
 	switch dest.Transport().Name() {
 	case storage.Transport.Name():
 		tags, err := expandTags(options.AdditionalTags)

--- a/common.go
+++ b/common.go
@@ -1,12 +1,16 @@
 package buildah
 
 import (
+	"io"
+
 	"github.com/containers/image/copy"
 	"github.com/containers/image/types"
 )
 
-func getCopyOptions() *copy.Options {
-	return &copy.Options{}
+func getCopyOptions(reportWriter io.Writer) *copy.Options {
+	return &copy.Options{
+		ReportWriter: reportWriter,
+	}
 }
 
 func getSystemContext(signaturePolicyPath string) *types.SystemContext {

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -287,6 +287,8 @@ return 1
           --help
           -h
           --disable-compression
+          --quiet
+          -q
   "
 
      local options_with_args="
@@ -329,6 +331,8 @@ return 1
      -h
      --pull
      --pull-always
+     --quiet
+     -q
   "
 
      local options_with_args="
@@ -522,6 +526,8 @@ return 1
      -h
      --pull
      --pull-always
+     --quiet
+     -q
   "
 
      local options_with_args="

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -67,6 +67,12 @@ Adds global flags for the container rutime.
 Specifies the name which will be assigned to the resulting image if the build
 process completes successfully.
 
+**--quiet**
+
+Suppress output messages which indicate which instruction is being processed,
+and of progress when pulling images from a registry, and when writing the
+output image.
+
 ## EXAMPLE
 
 buildah bud .

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -23,6 +23,10 @@ Pathname of a signature policy file to use.  It is not recommended that this
 option be used, as the default behavior of using the system-wide default policy
 (frequently */etc/containers/policy.json*) is most often preferred.
 
+**--quiet**
+
+When writing the output image, suppress progress output.
+
 ## EXAMPLE
 
 buildah commit containerID

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -40,6 +40,10 @@ Pathname of a signature policy file to use.  It is not recommended that this
 option be used, as the default behavior of using the system-wide default policy
 (frequently */etc/containers/policy.json*) is most often preferred.
 
+**--quiet**
+
+If an image needs to be pulled from the registry, suppress progress output.
+
 ## EXAMPLE
 
 buildah from imagename --pull --registry "myregistry://"

--- a/pull.go
+++ b/pull.go
@@ -54,6 +54,6 @@ func pullImage(store storage.Store, options BuilderOptions, sc *types.SystemCont
 
 	logrus.Debugf("copying %q to %q", spec, name)
 
-	err = copy.Image(policyContext, destRef, srcRef, getCopyOptions())
+	err = copy.Image(policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter))
 	return err
 }


### PR DESCRIPTION
Have `from`, `commit`, and `build-using-dockerfile` report progress via stderr (so that capturing output from `from` and `commit` still works as expected) unless `--quiet` is used to suppress the reporting.  Should fix #94.