### PR TITLE
Improve handling of image configuration in build-using-dockerfile

### DIFF
--- a/add.go
+++ b/add.go
@@ -72,10 +72,10 @@ func (b *Builder) Add(destination string, extract bool, source ...string) error 
 	if destination != "" && filepath.IsAbs(destination) {
 		dest = filepath.Join(dest, destination)
 	} else {
-		if err = os.MkdirAll(filepath.Join(dest, b.Workdir), 0755); err != nil {
-			return fmt.Errorf("error ensuring directory %q exists: %v)", filepath.Join(dest, b.Workdir), err)
+		if err = os.MkdirAll(filepath.Join(dest, b.WorkDir()), 0755); err != nil {
+			return fmt.Errorf("error ensuring directory %q exists: %v)", filepath.Join(dest, b.WorkDir()), err)
 		}
-		dest = filepath.Join(dest, b.Workdir, destination)
+		dest = filepath.Join(dest, b.WorkDir(), destination)
 	}
 	// If the destination was explicitly marked as a directory by ending it
 	// with a '/', create it so that we can be sure that it's a directory,

--- a/docker/types.go
+++ b/docker/types.go
@@ -7,7 +7,7 @@ package docker
 import (
 	"time"
 
-	"github.com/docker/docker/api/types/container"
+	"github.com/containers/image/pkg/strslice"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -44,6 +44,70 @@ type History struct {
 // ID is the content-addressable ID of an image.
 type ID digest.Digest
 
+// github.com/docker/docker/api/types/container/config.go
+// HealthConfig holds configuration settings for the HEALTHCHECK feature.
+type HealthConfig struct {
+	// Test is the test to perform to check that the container is healthy.
+	// An empty slice means to inherit the default.
+	// The options are:
+	// {} : inherit healthcheck
+	// {"NONE"} : disable healthcheck
+	// {"CMD", args...} : exec arguments directly
+	// {"CMD-SHELL", command} : run command with system's default shell
+	Test []string `json:",omitempty"`
+
+	// Zero means to inherit. Durations are expressed as integer nanoseconds.
+	Interval time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout  time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+
+	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
+	// Zero means inherit.
+	Retries int `json:",omitempty"`
+}
+
+// github.com/docker/go-connections/nat/nat.go
+// PortSet is a collection of structs indexed by Port
+type PortSet map[Port]struct{}
+
+// github.com/docker/go-connections/nat/nat.go
+// Port is a string containing port number and protocol in the format "80/tcp"
+type Port string
+
+// github.com/docker/docker/api/types/container/config.go
+// Config contains the configuration data about a container.
+// It should hold only portable information about the container.
+// Here, "portable" means "independent from the host we are running on".
+// Non-portable information *should* appear in HostConfig.
+// All fields added to this struct must be marked `omitempty` to keep getting
+// predictable hashes from the old `v1Compatibility` configuration.
+type Config struct {
+	Hostname        string              // Hostname
+	Domainname      string              // Domainname
+	User            string              // User that will run the command(s) inside the container, also support user:group
+	AttachStdin     bool                // Attach the standard input, makes possible user interaction
+	AttachStdout    bool                // Attach the standard output
+	AttachStderr    bool                // Attach the standard error
+	ExposedPorts    PortSet             `json:",omitempty"` // List of exposed ports
+	Tty             bool                // Attach standard streams to a tty, including stdin if it is not closed.
+	OpenStdin       bool                // Open stdin
+	StdinOnce       bool                // If true, close stdin after the 1 attached client disconnects.
+	Env             []string            // List of environment variable to set in the container
+	Cmd             strslice.StrSlice   // Command to run when starting the container
+	Healthcheck     *HealthConfig       `json:",omitempty"` // Healthcheck describes how to check the container is healthy
+	ArgsEscaped     bool                `json:",omitempty"` // True if command is already escaped (Windows specific)
+	Image           string              // Name of the image as it was passed by the operator (e.g. could be symbolic)
+	Volumes         map[string]struct{} // List of volumes (mounts) used for the container
+	WorkingDir      string              // Current directory (PWD) in the command will be launched
+	Entrypoint      strslice.StrSlice   // Entrypoint to run when starting the container
+	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
+	MacAddress      string              `json:",omitempty"` // Mac Address of the container
+	OnBuild         []string            // ONBUILD metadata that were defined on the image Dockerfile
+	Labels          map[string]string   // List of labels set to this container
+	StopSignal      string              `json:",omitempty"` // Signal to stop a container
+	StopTimeout     *int                `json:",omitempty"` // Timeout (in seconds) to stop a container
+	Shell           strslice.StrSlice   `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
+}
+
 // github.com/docker/docker/image/image.go
 // V1Image stores the V1 image configuration.
 type V1Image struct {
@@ -58,13 +122,13 @@ type V1Image struct {
 	// Container is the id of the container used to commit
 	Container string `json:"container,omitempty"`
 	// ContainerConfig is the configuration of the container that is committed into the image
-	ContainerConfig container.Config `json:"container_config,omitempty"`
+	ContainerConfig Config `json:"container_config,omitempty"`
 	// DockerVersion specifies the version of Docker that was used to build the image
 	DockerVersion string `json:"docker_version,omitempty"`
 	// Author is the name of the author that was specified when committing the image
 	Author string `json:"author,omitempty"`
 	// Config is the configuration of the container received from the client
-	Config *container.Config `json:"config,omitempty"`
+	Config *Config `json:"config,omitempty"`
 	// Architecture is the hardware that the image is build and runs on
 	Architecture string `json:"architecture,omitempty"`
 	// OS is the operating system used to build and run the image

--- a/docker/types.go
+++ b/docker/types.go
@@ -11,10 +11,10 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
-// github.com/docker/docker/image/rootfs.go
+// github.com/moby/moby/image/rootfs.go
 const TypeLayers = "layers"
 
-// github.com/docker/docker/image/rootfs.go
+// github.com/moby/moby/image/rootfs.go
 // RootFS describes images root filesystem
 // This is currently a placeholder that only supports layers. In the future
 // this can be made into an interface that supports different implementations.
@@ -23,7 +23,7 @@ type RootFS struct {
 	DiffIDs []digest.Digest `json:"diff_ids,omitempty"`
 }
 
-// github.com/docker/docker/image/image.go
+// github.com/moby/moby/image/image.go
 // History stores build commands that were used to create an image
 type History struct {
 	// Created is the timestamp at which the image was created
@@ -40,11 +40,11 @@ type History struct {
 	EmptyLayer bool `json:"empty_layer,omitempty"`
 }
 
-// github.com/docker/docker/image/image.go
+// github.com/moby/moby/image/image.go
 // ID is the content-addressable ID of an image.
 type ID digest.Digest
 
-// github.com/docker/docker/api/types/container/config.go
+// github.com/moby/moby/api/types/container/config.go
 // HealthConfig holds configuration settings for the HEALTHCHECK feature.
 type HealthConfig struct {
 	// Test is the test to perform to check that the container is healthy.
@@ -73,7 +73,7 @@ type PortSet map[Port]struct{}
 // Port is a string containing port number and protocol in the format "80/tcp"
 type Port string
 
-// github.com/docker/docker/api/types/container/config.go
+// github.com/moby/moby/api/types/container/config.go
 // Config contains the configuration data about a container.
 // It should hold only portable information about the container.
 // Here, "portable" means "independent from the host we are running on".
@@ -108,7 +108,7 @@ type Config struct {
 	Shell           strslice.StrSlice   `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
 }
 
-// github.com/docker/docker/image/image.go
+// github.com/moby/moby/image/image.go
 // V1Image stores the V1 image configuration.
 type V1Image struct {
 	// ID is a unique 64 character identifier of the image
@@ -137,7 +137,7 @@ type V1Image struct {
 	Size int64 `json:",omitempty"`
 }
 
-// github.com/docker/docker/image/image.go
+// github.com/moby/moby/image/image.go
 // Image stores the image configuration
 type Image struct {
 	V1Image

--- a/image.go
+++ b/image.go
@@ -321,14 +321,18 @@ func (b *Builder) makeContainerImageRef(compress archive.Compression) (types.Ima
 			name = nil
 		}
 	}
+	config, err := json.Marshal(&b.OCIv1)
+	if err != nil {
+		return nil, err
+	}
 	ref := &containerImageRef{
 		store:       b.store,
 		container:   container,
 		compression: compress,
 		name:        name,
-		config:      b.updatedConfig(),
-		createdBy:   b.CreatedBy,
-		annotations: b.Annotations,
+		config:      config,
+		createdBy:   b.CreatedBy(),
+		annotations: b.Annotations(),
 	}
 	return ref, nil
 }

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -439,11 +439,13 @@ func (b *Executor) Prepare(ib *imagebuilder.Builder, node *parser.Node, from str
 	if err != nil {
 		return fmt.Errorf("error creating build container: %v", err)
 	}
+	dConfig := docker.Config{
+		Env:   builder.Env(),
+		Image: from,
+	}
 	dImage := docker.Image{
-		Config: &docker.Config{
-			Env:   builder.UpdatedEnv(),
-			Image: from,
-		},
+		Config:          &dConfig,
+		ContainerConfig: dConfig,
 	}
 	err = ib.FromImage(&dImage, node)
 	if err != nil {

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -516,6 +516,9 @@ func (b *Executor) Commit(ib *imagebuilder.Builder) (err error) {
 	} else {
 		imageRef, err = is.Transport.ParseStoreReference(b.store, "@"+stringid.GenerateRandomID())
 	}
+	if err != nil {
+		return fmt.Errorf("error parsing reference for image to be written: %v", err)
+	}
 	if imageRef != nil {
 		logName := transports.ImageName(imageRef)
 		logrus.Debugf("COMMIT %q", logName)
@@ -527,9 +530,6 @@ func (b *Executor) Commit(ib *imagebuilder.Builder) (err error) {
 		if !b.quiet {
 			b.log("COMMIT")
 		}
-	}
-	if err != nil {
-		return err
 	}
 	options := buildah.CommitOptions{
 		Compression:         b.compression,

--- a/import.go
+++ b/import.go
@@ -53,25 +53,20 @@ func importBuilder(store storage.Store, options ImportOptions) (*Builder, error)
 	name := options.Container
 
 	builder := &Builder{
-		store:       store,
-		Type:        containerType,
-		FromImage:   imageName,
-		FromImageID: image,
-		Config:      config,
-		Manifest:    manifest,
-		Container:   name,
-		ContainerID: c.ID,
-		Mounts:      []string{},
-		Annotations: map[string]string{},
-		Env:         []string{},
-		Cmd:         []string{},
-		Entrypoint:  []string{},
-		Expose:      map[string]interface{}{},
-		Labels:      map[string]string{},
-		Volumes:     []string{},
-		Arg:         map[string]string{},
+		store:            store,
+		Type:             containerType,
+		FromImage:        imageName,
+		FromImageID:      image,
+		Config:           config,
+		Manifest:         manifest,
+		Container:        name,
+		ContainerID:      c.ID,
+		Mounts:           []string{},
+		ImageAnnotations: map[string]string{},
+		ImageCreatedBy:   "",
 	}
 
+	builder.initConfig()
 	err = builder.Save()
 	if err != nil {
 		return nil, fmt.Errorf("error saving builder state: %v", err)

--- a/new.go
+++ b/new.go
@@ -123,23 +123,17 @@ func newBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
 	}()
 
 	builder := &Builder{
-		store:       store,
-		Type:        containerType,
-		FromImage:   image,
-		FromImageID: imageID,
-		Config:      config,
-		Manifest:    manifest,
-		Container:   name,
-		ContainerID: container.ID,
-		Mounts:      []string{},
-		Annotations: map[string]string{},
-		Env:         []string{},
-		Cmd:         []string{},
-		Entrypoint:  []string{},
-		Expose:      map[string]interface{}{},
-		Labels:      map[string]string{},
-		Volumes:     []string{},
-		Arg:         map[string]string{},
+		store:            store,
+		Type:             containerType,
+		FromImage:        image,
+		FromImageID:      imageID,
+		Config:           config,
+		Manifest:         manifest,
+		Container:        name,
+		ContainerID:      container.ID,
+		Mounts:           []string{},
+		ImageAnnotations: map[string]string{},
+		ImageCreatedBy:   "",
 	}
 
 	if options.Mount {
@@ -149,6 +143,7 @@ func newBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
 		}
 	}
 
+	builder.initConfig()
 	err = builder.Save()
 	if err != nil {
 		return nil, fmt.Errorf("error saving builder state: %v", err)

--- a/util.go
+++ b/util.go
@@ -10,3 +10,17 @@ import (
 func InitReexec() bool {
 	return reexec.Init()
 }
+
+func copyStringStringMap(m map[string]string) map[string]string {
+	n := map[string]string{}
+	for k, v := range m {
+		n[k] = v
+	}
+	return n
+}
+
+func copyStringSlice(s []string) []string {
+	t := make([]string, len(s))
+	copy(t, s)
+	return t
+}


### PR DESCRIPTION
Previously, build-using-dockerfile wasn't taking sufficient care to communicate a source image's configuration to the imagebuilder object, nor to extract updated settings from it when committing the image.  This PR makes an effort to avoid discarding configuration information from source images, uses as much of that information as we keep to initialize the imagebuilder object, and reads those settings back out when a build is complete.