### PR TITLE
Add an initial "inspect" command

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -127,6 +127,18 @@ type ImportOptions struct {
 	SignaturePolicyPath string
 }
 
+// ImportFromImageOptions are used to initialize a Builder from an image.
+type ImportFromImageOptions struct {
+	// Image is the name or ID of the image we'd like to examine.
+	Image string
+	// SignaturePolicyPath specifies an override location for the signature
+	// policy which should be used for verifying the new image as it is
+	// being written.  Except in specific circumstances, no value should be
+	// specified, indicating that the shared, system-wide default policy
+	// should be used.
+	SignaturePolicyPath string
+}
+
 // NewBuilder creates a new build container.
 func NewBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
 	return newBuilder(store, options)
@@ -136,6 +148,13 @@ func NewBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
 // container.
 func ImportBuilder(store storage.Store, options ImportOptions) (*Builder, error) {
 	return importBuilder(store, options)
+}
+
+// ImportBuilderFromImage creates a new builder configuration using an image.
+// The returned object can be modified and examined, but it can not be saved
+// or committed because it is not associated with a working container.
+func ImportBuilderFromImage(store storage.Store, options ImportFromImageOptions) (*Builder, error) {
+	return importBuilderFromImage(store, options)
 }
 
 // OpenBuilder loads information about a build container given its name or ID.

--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -57,3 +57,17 @@ func openBuilder(store storage.Store, name string) (builder *buildah.Builder, er
 func openBuilders(store storage.Store) (builders []*buildah.Builder, err error) {
 	return buildah.OpenAllBuilders(store)
 }
+
+func openImage(store storage.Store, name string) (builder *buildah.Builder, err error) {
+	options := buildah.ImportFromImageOptions{
+		Image: name,
+	}
+	builder, err = buildah.ImportBuilderFromImage(store, options)
+	if err != nil {
+		return nil, fmt.Errorf("error reading image: %v", err)
+	}
+	if builder == nil {
+		return nil, fmt.Errorf("error mocking up build configuration")
+	}
+	return builder, nil
+}

--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/template"
+
+	"github.com/projectatomic/buildah"
+	"github.com/urfave/cli"
+)
+
+const (
+	defaultFormat = `Container: {{.Container}}
+ID: {{.ContainerID}}
+`
+	inspectTypeContainer = "container"
+	inspectTypeImage     = "image"
+)
+
+var (
+	inspectFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "type, t",
+			Usage: "look at the item of the specified `type` (container or image) and name",
+		},
+		cli.StringFlag{
+			Name:  "format, f",
+			Usage: "use `format` as a Go template to format the output",
+		},
+	}
+	inspectDescription = "Inspects a build container's or built image's configuration."
+	inspectCommand     = cli.Command{
+		Name:        "inspect",
+		Usage:       "Inspects the configuration of a container or image",
+		Description: inspectDescription,
+		Flags:       inspectFlags,
+		Action:      inspectCmd,
+		ArgsUsage:   "CONTAINER-OR-IMAGE",
+	}
+)
+
+func inspectCmd(c *cli.Context) error {
+	var builder *buildah.Builder
+
+	args := c.Args()
+	if len(args) == 0 {
+		return fmt.Errorf("container or image name must be specified")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments specified")
+	}
+
+	itemType := inspectTypeContainer
+	if c.IsSet("type") {
+		itemType = c.String("type")
+	}
+	switch itemType {
+	case inspectTypeContainer:
+	case inspectTypeImage:
+	default:
+		return fmt.Errorf("the only recognized types are %q and %q", inspectTypeContainer, inspectTypeImage)
+	}
+
+	format := defaultFormat
+	if c.IsSet("format") {
+		if c.String("format") != "" {
+			format = c.String("format")
+		}
+	}
+	t := template.Must(template.New("format").Parse(format))
+
+	name := args[0]
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	switch itemType {
+	case inspectTypeContainer:
+		builder, err = openBuilder(store, name)
+		if err != nil {
+			return fmt.Errorf("error reading build container %q: %v", name, err)
+		}
+	case inspectTypeImage:
+		builder, err = openImage(store, name)
+		if err != nil {
+			return fmt.Errorf("error reading image %q: %v", name, err)
+		}
+	}
+
+	if c.IsSet("format") {
+		return t.Execute(os.Stdout, builder)
+	}
+
+	b, err := json.MarshalIndent(builder, "", "    ")
+	if err != nil {
+		return fmt.Errorf("error encoding build container as json: %v", err)
+	}
+	_, err = fmt.Println(string(b))
+	return err
+}

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -82,6 +82,7 @@ func main() {
 		imagesCommand,
 		rmiCommand,
 		budCommand,
+		inspectCommand,
 	}
 	err := app.Run(os.Args)
 	if err != nil {

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -520,6 +520,23 @@ return 1
      esac
  }
 
+ _buildah_inspect() {
+     local options_with_args="
+       --format
+       -f
+       --type
+       -t
+     "
+
+     local all_options="$options_with_args"
+
+     case "$cur" in
+         -*)
+             COMPREPLY=($(compgen -W "$options_with_args" -- "$cur"))
+             ;;
+     esac
+ }
+
  _buildah_from() {
      local boolean_options="
      --help
@@ -561,6 +578,7 @@ return 1
        copy
        from
        images
+       inspect
        mount
        rm
        rmi

--- a/docs/buildah-inspect.md
+++ b/docs/buildah-inspect.md
@@ -1,0 +1,34 @@
+## buildah-mount "1" "May 2017" "buildah"
+
+## NAME
+buildah inspect - Display information about a working container.
+
+## SYNOPSIS
+**buildah** **inspect** [*options* [...] --] **ID**
+
+## DESCRIPTION
+Prints information about a working container's configuration, or the initial
+configuration for a container which would be created for an image.
+
+## OPTIONS
+
+**--format** *template*
+
+Use *template* as a Go template when formatting the output.
+
+Users of this option should be familiar with the [*text/template*
+package](https://golang.org/pkg/text/template/) in the Go standard library, and
+of internals of buildah's implementation.
+
+**--type** *container* | *image*
+
+Specify whether the ID is that of a container or an image.
+
+## EXAMPLE
+
+buildah inspect containerID
+buildah inspect --type container containerID
+buildah inspect --type image imageID
+
+## SEE ALSO
+buildah(1)

--- a/import.go
+++ b/import.go
@@ -4,15 +4,60 @@ import (
 	"fmt"
 
 	is "github.com/containers/image/storage"
+	"github.com/containers/image/types"
 	"github.com/containers/storage"
 )
 
-func importBuilder(store storage.Store, options ImportOptions) (*Builder, error) {
+func importBuilderDataFromImage(store storage.Store, systemContext *types.SystemContext, imageID, containerName, containerID string) (*Builder, error) {
 	manifest := []byte{}
 	config := []byte{}
-	image := ""
 	imageName := ""
 
+	if imageID != "" {
+		ref, err := is.Transport.ParseStoreReference(store, "@"+imageID)
+		if err != nil {
+			return nil, fmt.Errorf("no such image %q: %v", "@"+imageID, err)
+		}
+		src, err2 := ref.NewImage(systemContext)
+		if err2 != nil {
+			return nil, fmt.Errorf("error instantiating image: %v", err2)
+		}
+		defer src.Close()
+		config, err = src.ConfigBlob()
+		if err != nil {
+			return nil, fmt.Errorf("error reading image configuration: %v", err)
+		}
+		manifest, _, err = src.Manifest()
+		if err != nil {
+			return nil, fmt.Errorf("error reading image manifest: %v", err)
+		}
+		if img, err3 := store.Image(imageID); err3 == nil {
+			if len(img.Names) > 0 {
+				imageName = img.Names[0]
+			}
+		}
+	}
+
+	builder := &Builder{
+		store:            store,
+		Type:             containerType,
+		FromImage:        imageName,
+		FromImageID:      imageID,
+		Config:           config,
+		Manifest:         manifest,
+		Container:        containerName,
+		ContainerID:      containerID,
+		Mounts:           []string{},
+		ImageAnnotations: map[string]string{},
+		ImageCreatedBy:   "",
+	}
+
+	builder.initConfig()
+
+	return builder, nil
+}
+
+func importBuilder(store storage.Store, options ImportOptions) (*Builder, error) {
 	if options.Container == "" {
 		return nil, fmt.Errorf("container name must be specified")
 	}
@@ -24,52 +69,38 @@ func importBuilder(store storage.Store, options ImportOptions) (*Builder, error)
 
 	systemContext := getSystemContext(options.SignaturePolicyPath)
 
-	if c.ImageID != "" {
-		ref, err2 := is.Transport.ParseStoreReference(store, "@"+c.ImageID)
-		if err2 != nil {
-			return nil, fmt.Errorf("no such image %q: %v", "@"+c.ImageID, err2)
-		}
-		src, err3 := ref.NewImage(systemContext)
-		if err3 != nil {
-			return nil, fmt.Errorf("error instantiating image: %v", err3)
-		}
-		defer src.Close()
-		config, err = src.ConfigBlob()
-		if err != nil {
-			return nil, fmt.Errorf("error reading image configuration: %v", err)
-		}
-		manifest, _, err = src.Manifest()
-		if err != nil {
-			return nil, fmt.Errorf("error reading image manifest: %v", err)
-		}
-		image = c.ImageID
-		if img, err4 := store.Image(image); err4 == nil {
-			if len(img.Names) > 0 {
-				imageName = img.Names[0]
-			}
-		}
+	builder, err := importBuilderDataFromImage(store, systemContext, c.ImageID, options.Container, c.ID)
+	if err != nil {
+		return nil, err
 	}
 
-	name := options.Container
-
-	builder := &Builder{
-		store:            store,
-		Type:             containerType,
-		FromImage:        imageName,
-		FromImageID:      image,
-		Config:           config,
-		Manifest:         manifest,
-		Container:        name,
-		ContainerID:      c.ID,
-		Mounts:           []string{},
-		ImageAnnotations: map[string]string{},
-		ImageCreatedBy:   "",
-	}
-
-	builder.initConfig()
 	err = builder.Save()
 	if err != nil {
 		return nil, fmt.Errorf("error saving builder state: %v", err)
+	}
+
+	return builder, nil
+}
+
+func importBuilderFromImage(store storage.Store, options ImportFromImageOptions) (*Builder, error) {
+	if options.Image == "" {
+		return nil, fmt.Errorf("image name must be specified")
+	}
+
+	ref, err := is.Transport.ParseStoreReference(store, options.Image)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing reference to image %q: %v", options.Image, err)
+	}
+	img, err := is.Transport.GetStoreImage(store, ref)
+	if err != nil {
+		return nil, fmt.Errorf("unable to locate image: %v", err)
+	}
+
+	systemContext := getSystemContext(options.SignaturePolicyPath)
+
+	builder, err := importBuilderDataFromImage(store, systemContext, img.ID, "", "")
+	if err != nil {
+		return nil, err
 	}
 
 	return builder, nil

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "inspect-json" {
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  run buildah --debug=false inspect "$cid"
+  [ "$status" -eq 0 ]
+  [ "$output" != "" ]
+}
+
+@test "inspect-format" {
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  run buildah --debug=false inspect --format '{{.}}' "$cid"
+  [ "$status" -eq 0 ]
+  [ "$output" != "" ]
+}
+
+@test "inspect-image" {
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid scratchy-image
+  run buildah --debug=false inspect --type image scratchy-image
+  [ "$status" -eq 0 ]
+  [ "$output" != "" ]
+  run buildah --debug=false inspect --type image scratchy-image:latest
+  [ "$status" -eq 0 ]
+  [ "$output" != "" ]
+}


### PR DESCRIPTION
Add an "inspect" command, which can be used to dump the contents of the Buildah object for a working container.  This'll make it easier to write integration tests that need to look at a container while we're working on it.