### PR TITLE
Code cleanup

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -21,8 +21,8 @@ func getStore(c *cli.Context) (storage.Store, error) {
 	if c.GlobalIsSet("storage-driver") {
 		options.GraphDriverName = c.GlobalString("storage-driver")
 	}
-	if c.GlobalIsSet("storage-options") {
-		opts := c.GlobalStringSlice("storage-options")
+	if c.GlobalIsSet("storage-opt") {
+		opts := c.GlobalStringSlice("storage-opt")
 		if len(opts) > 0 {
 			options.GraphDriverOptions = opts
 		}

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -40,7 +40,7 @@ func main() {
 			Value: storage.DefaultStoreOptions.GraphDriverName,
 		},
 		cli.StringSliceFlag{
-			Name:  "storage-option",
+			Name:  "storage-opt",
 			Usage: "storage driver option",
 			Value: defaultStoreDriverOptions,
 		},
@@ -70,19 +70,19 @@ func main() {
 	}
 	app.Commands = []cli.Command{
 		addCommand,
+		budCommand,
 		commitCommand,
 		configCommand,
-		copyCommand,
-		rmCommand,
-		fromCommand,
 		containersCommand,
+		copyCommand,
+		fromCommand,
+		imagesCommand,
+		inspectCommand,
 		mountCommand,
+		rmCommand,
+		rmiCommand,
 		runCommand,
 		umountCommand,
-		imagesCommand,
-		rmiCommand,
-		budCommand,
-		inspectCommand,
 		tagCommand,
 	}
 	err := app.Run(os.Args)

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -167,7 +167,7 @@ return 1
          --root
          --runroot
          --storage-driver
-         --storage-option
+         --storage-opt
          "
 
      case "$prev" in
@@ -611,7 +611,7 @@ return 1
          --root
          --runroot
          --storage-driver
-         --storage-option
+         --storage-opt
    "
 
    COMPREPLY=()

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -3,6 +3,10 @@
 ## NAME
 buildah - A command line tool to facilitate working with containers and using them to build images.
 
+## SYNOPSIS
+buildah [OPTIONS] COMMAND [ARG...]
+
+
 ## DESCRIPTION
 The buildah package provides a command line tool which can be used to:
 
@@ -12,19 +16,54 @@ The buildah package provides a command line tool which can be used to:
     * Use the updated contents of a container's root filesystem as a filesystem layer to create a new image.
     * Delete a working container or an image.
 
+## OPTIONS
+
+**--root** **value**
+
+Storage root dir (default: "/var/lib/containers/storage")
+
+**--runroot** **value**
+
+Storage state dir (default: "/var/run/containers/storage")
+
+**--storage-driver** **value**
+
+Storage driver
+
+**--storage-opt** **value**
+
+Storage driver option
+
+**--debug**
+
+Print debugging information
+
+**--help, -h**
+
+Show help
+
+**--version, -v**
+
+Print the version
+
+
 ## SEE ALSO
-| Command               | Description |
-| --------------------- | --------------------------------------------------- |
-| buildah-add(1)        | Add the contents of a file, URL, or a directory to the container. |
-| buildah-bud(1)        | Build an image using instructions from Dockerfiles. |
-| buildah-commit(1)     | Create an image from a working container. |
-| buildah-config(1)     | Update image configuration settings. |
-| buildah-containers(1) | List the working containers and their base images. |
-| buildah-copy(1)       | Copies the contents of a file, URL, or directory into a container's working directory. |
+
+| Command               | Description                                                                                          |
+| --------------------- | ---------------------------------------------------                                                  |
+|                       |                                                                                                      |
+| buildah-add(1)        | Add the contents of a file, URL, or a directory to the container.                                    |
+| buildah-bud(1)        | Build an image using instructions from Dockerfiles.                                                  |
+| buildah-commit(1)     | Create an image from a working container.                                                            |
+| buildah-config(1)     | Update image configuration settings.                                                                 |
+| buildah-containers(1) | List the working containers and their base images.                                                   |
+| buildah-copy(1)       | Copies the contents of a file, URL, or directory into a container's working directory.               |
 | buildah-from(1)       | Creates a new working container, either from scratch or using a specified image as a starting point. |
-| buildah-images(1)     | List images in local storage. |
-| buildah-mount(1)      | Mount the working container's root filesystem. |
-| buildah-rm(1)         | Removes one or more working containers. |
-| buildah-rmi(1)        | Removes one or more images. |
-| buildah-run(1)        | Run a command inside of the container. |
-| buildah-umount(1)     | Unmount a working container's root file system. |
+| buildah-images(1)     | List images in local storage.                                                                        |
+| buildah-inspect(1)    | Inspects the configuration of a container or image                                                   |
+| buildah-mount(1)      | Mount the working container's root filesystem.                                                       |
+| buildah-rm(1)         | Removes one or more working containers.                                                              |
+| buildah-rmi(1)        | Removes one or more images.                                                                          |
+| buildah-run(1)        | Run a command inside of the container.                                                               |
+| buildah-tag(1)        | Add an additional name to a local image.                                                             |
+| buildah-umount(1)     | Unmount a working container's root file system.                                                      |


### PR DESCRIPTION
Other tools use --storage-opt, buildah should be consistent

Cleanup buildah.1 man page

add options to buildah man page
add missing commands

Finally sort the commands in the buildah command.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>