### PR TITLE
Makefile: add source deps for the CLI tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILDFLAGS := -tags "$(AUTOTAGS) $(TAGS)"
 
 all: buildah docs
 
-buildah: *.go imagebuildah/*.go cmd/buildah/*.go
+buildah: *.go imagebuildah/*.go cmd/buildah/*.go docker/*.go
 	go build -o buildah $(BUILDFLAGS) ./cmd/buildah
 
 .PHONY: clean


### PR DESCRIPTION
The CLI tool also incorporates types from the 'docker' subdirectory, so add it as a build-time dependency to check.