### PR TITLE
Support writing image manifests and configurations in both oci and docker formats

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -79,8 +79,8 @@ type Builder struct {
 	ImageCreatedBy string `json:"created-by,omitempty"`
 
 	// Image metadata and runtime settings, in multiple formats.
-	OCIv1  v1.Image     `json:"ociv1,omitempty"`
-	Docker docker.Image `json:"docker,omitempty"`
+	OCIv1  v1.Image       `json:"ociv1,omitempty"`
+	Docker docker.V2Image `json:"docker,omitempty"`
 }
 
 // BuilderOptions are used to initialize a new Builder.

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -47,6 +47,10 @@ var (
 			Name:  "runtime-flag",
 			Usage: "add global flags for the container runtime",
 		},
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "`format` of the built image's manifest and metadata",
+		},
 		cli.StringSliceFlag{
 			Name:  "tag, t",
 			Usage: "`tag` to apply to the built image",
@@ -130,6 +134,17 @@ func budCmd(c *cli.Context) error {
 	if c.IsSet("file") || c.IsSet("f") {
 		dockerfiles = c.StringSlice("file")
 	}
+	format := "oci"
+	if c.IsSet("format") {
+		format = strings.ToLower(c.String("format"))
+	}
+	if strings.HasPrefix(format, "oci") {
+		format = imagebuildah.OCIv1ImageFormat
+	} else if strings.HasPrefix(format, "docker") {
+		format = imagebuildah.Dockerv2ImageFormat
+	} else {
+		return fmt.Errorf("unrecognized image type %q", format)
+	}
 	contextDir := ""
 	cliArgs := c.Args()
 	if len(cliArgs) > 0 {
@@ -202,6 +217,7 @@ func budCmd(c *cli.Context) error {
 		AdditionalTags:      tags,
 		Runtime:             runtime,
 		RuntimeArgs:         runtimeFlags,
+		OutputFormat:        format,
 	}
 	if !quiet {
 		options.ReportWriter = os.Stderr

--- a/commit.go
+++ b/commit.go
@@ -16,6 +16,9 @@ import (
 
 // CommitOptions can be used to alter how an image is committed.
 type CommitOptions struct {
+	// PreferredManifestType is the preferred type of image manifest.  The
+	// image configuration format will be of a compatible type.
+	PreferredManifestType string
 	// Compression specifies the type of compression which is applied to
 	// layer blobs.  The default is to not use compression, but
 	// archive.Gzip is recommended.
@@ -47,7 +50,7 @@ func (b *Builder) Commit(dest types.ImageReference, options CommitOptions) error
 	if err != nil {
 		return err
 	}
-	src, err := b.makeContainerImageRef(options.Compression)
+	src, err := b.makeContainerImageRef(options.PreferredManifestType, options.Compression)
 	if err != nil {
 		return fmt.Errorf("error recomputing layer digests and building metadata: %v", err)
 	}

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -293,6 +293,8 @@ return 1
 
      local options_with_args="
           --signature-policy
+          --format
+          -f
   "
 
      local all_options="$options_with_args $boolean_options"
@@ -345,6 +347,7 @@ return 1
      --file
      -f
      --build-arg
+     --format
   "
 
      local all_options="$options_with_args $boolean_options"

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -67,6 +67,12 @@ Adds global flags for the container rutime.
 Specifies the name which will be assigned to the resulting image if the build
 process completes successfully.
 
+**--format**
+
+Control the format for the built image's manifest and configuration data.
+Recognized formats include *oci* (OCI image-spec v1.0, the default) and
+*docker* (version 2, using schema format 2 for the manifest).
+
 **--quiet**
 
 Suppress output messages which indicate which instruction is being processed,

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -27,6 +27,12 @@ option be used, as the default behavior of using the system-wide default policy
 
 When writing the output image, suppress progress output.
 
+**--format**
+
+Control the format for the image manifest and configuration data.  Recognized
+formats include *oci* (OCI image-spec v1.0, the default) and *docker* (version
+2, using schema format 2 for the manifest).
+
 ## EXAMPLE
 
 buildah commit containerID

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -24,10 +24,12 @@ import (
 )
 
 const (
-	PullIfMissing  = buildah.PullIfMissing
-	PullAlways     = buildah.PullAlways
-	PullNever      = buildah.PullNever
-	DefaultRuntime = buildah.DefaultRuntime
+	PullIfMissing       = buildah.PullIfMissing
+	PullAlways          = buildah.PullAlways
+	PullNever           = buildah.PullNever
+	DefaultRuntime      = buildah.DefaultRuntime
+	OCIv1ImageFormat    = buildah.OCIv1ImageManifest
+	Dockerv2ImageFormat = buildah.Dockerv2ImageManifest
 
 	Gzip         = archive.Gzip
 	Bzip2        = archive.Bzip2
@@ -91,6 +93,10 @@ type BuildOptions struct {
 	// progress of the (possible) pulling of the source image and the
 	// writing of the new image.
 	ReportWriter io.Writer
+	// OutputFormat is the format of the output image's manifest and
+	// configuration data.
+	// Accepted values are OCIv1ImageFormat and Dockerv2ImageFormat.
+	OutputFormat string
 }
 
 // Executor is a buildah-based implementation of the imagebuilder.Executor

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "config" {
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah config \
+   --author TESTAUTHOR \
+   --created-by COINCIDENCE \
+   --arch SOMEARCH \
+   --os SOMEOS \
+   --user likes:things \
+   --port 12345 \
+   --env VARIABLE=VALUE \
+   --entrypoint /ENTRYPOINT \
+   --cmd COMMAND-OR-ARGS \
+   --volume /VOLUME \
+   --workingdir /tmp \
+   --label LABEL=VALUE \
+   --annotation ANNOTATION=VALUE \
+  $cid
+
+  buildah commit --format dockerv2 --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  buildah commit --format ociv1 --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+
+  buildah --debug=false inspect --type=image --format '{{.Docker.Author}}' scratch-image-docker | grep TESTAUTHOR
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Author}}' scratch-image-docker | grep TESTAUTHOR
+  buildah --debug=false inspect --type=image --format '{{.Docker.Author}}' scratch-image-oci | grep TESTAUTHOR
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Author}}' scratch-image-oci | grep TESTAUTHOR
+
+  buildah --debug=false inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
+
+  buildah --debug=false inspect --type=image --format '{{.Docker.Architecture}}' scratch-image-docker | grep SOMEARCH
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Architecture}}' scratch-image-docker | grep SOMEARCH
+  buildah --debug=false inspect --type=image --format '{{.Docker.Architecture}}' scratch-image-oci | grep SOMEARCH
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Architecture}}' scratch-image-oci | grep SOMEARCH
+
+  buildah --debug=false inspect --type=image --format '{{.Docker.OS}}' scratch-image-docker | grep SOMEOS
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.OS}}' scratch-image-docker | grep SOMEOS
+  buildah --debug=false inspect --type=image --format '{{.Docker.OS}}' scratch-image-oci | grep SOMEOS
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.OS}}' scratch-image-oci | grep SOMEOS
+
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.User}}' scratch-image-docker | grep likes:things
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.User}}' scratch-image-docker | grep likes:things
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.User}}' scratch-image-oci | grep likes:things
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.User}}' scratch-image-oci | grep likes:things
+
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Env}}' scratch-image-docker | grep VARIABLE=VALUE
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Env}}' scratch-image-docker | grep VARIABLE=VALUE
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Env}}' scratch-image-oci | grep VARIABLE=VALUE
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Env}}' scratch-image-oci | grep VARIABLE=VALUE
+
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Entrypoint}}' scratch-image-docker | grep /ENTRYPOINT
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Entrypoint}}' scratch-image-docker | grep /ENTRYPOINT
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Entrypoint}}' scratch-image-oci | grep /ENTRYPOINT
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Entrypoint}}' scratch-image-oci | grep /ENTRYPOINT
+
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Cmd}}' scratch-image-docker | grep COMMAND-OR-ARGS
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Cmd}}' scratch-image-docker | grep COMMAND-OR-ARGS
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Cmd}}' scratch-image-oci | grep COMMAND-OR-ARGS
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Cmd}}' scratch-image-oci | grep COMMAND-OR-ARGS
+
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Volumes}}' scratch-image-docker | grep /VOLUME
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Volumes}}' scratch-image-docker | grep /VOLUME
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Volumes}}' scratch-image-oci | grep /VOLUME
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Volumes}}' scratch-image-oci | grep /VOLUME
+
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.WorkingDir}}' scratch-image-docker | grep /tmp
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.WorkingDir}}' scratch-image-docker | grep /tmp
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.WorkingDir}}' scratch-image-oci | grep /tmp
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.WorkingDir}}' scratch-image-oci | grep /tmp
+
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Labels}}' scratch-image-docker | grep LABEL:VALUE
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Labels}}' scratch-image-docker | grep LABEL:VALUE
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Labels}}' scratch-image-oci | grep LABEL:VALUE
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Labels}}' scratch-image-oci | grep LABEL:VALUE
+
+  # Annotations aren't part of the Docker v2 spec, so they're discarded when we save to Docker format.
+  buildah --debug=false inspect --type=image --format '{{.ImageAnnotations}}' scratch-image-oci | grep ANNOTATION:VALUE
+  buildah --debug=false inspect --type=image --format '{{.ImageAnnotations}}' scratch-image-oci | grep ANNOTATION:VALUE
+}

--- a/tests/formats.bats
+++ b/tests/formats.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "write-formats" {
+  buildimgtype
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-default
+  buildah commit --format dockerv2 --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  buildah commit --format ociv1 --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  imgtype -expected-manifest-type application/vnd.oci.image.manifest.v1+json scratch-image-default
+  imgtype -expected-manifest-type application/vnd.oci.image.manifest.v1+json scratch-image-oci
+  imgtype -expected-manifest-type application/vnd.docker.distribution.manifest.v2+json scratch-image-docker
+  run imgtype -expected-manifest-type application/vnd.docker.distribution.manifest.v2+json scratch-image-default
+  [ "$status" -ne 0 ]
+  run imgtype -expected-manifest-type application/vnd.docker.distribution.manifest.v2+json scratch-image-oci
+  [ "$status" -ne 0 ]
+  run imgtype -expected-manifest-type application/vnd.oci.image.manifest.v1+json scratch-image-docker
+  [ "$status" -ne 0 ]
+}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -11,6 +11,10 @@ function setup() {
 	REPO=${TESTDIR}/root
 }
 
+function buildimgtype() {
+	go build -tags "$(${TESTSDIR}/../btrfs_tag.sh; ${TESTSDIR}/../libdm_tag.sh)" -o imgtype ${TESTSDIR}/imgtype.go
+}
+
 function starthttpd() {
 	pushd ${2:-${TESTDIR}} > /dev/null
 	cp ${TESTSDIR}/serve.go .
@@ -41,4 +45,8 @@ function createrandom() {
 
 function buildah() {
 	${BUILDAH_BINARY} --debug --root ${TESTDIR}/root --runroot ${TESTDIR}/runroot --storage-driver vfs "$@"
+}
+
+function imgtype() {
+        ./imgtype -root ${TESTDIR}/root -runroot ${TESTDIR}/runroot -storage-driver vfs "$@"
 }

--- a/tests/imgtype.go
+++ b/tests/imgtype.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	is "github.com/containers/image/storage"
+	"github.com/containers/image/types"
+	"github.com/containers/storage"
+	"github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/projectatomic/buildah"
+	"github.com/projectatomic/buildah/docker"
+)
+
+func main() {
+	expectedManifestType := ""
+	expectedConfigType := ""
+
+	storeOptions := storage.DefaultStoreOptions
+	root := flag.String("root", storeOptions.GraphRoot, "storage root directory")
+	runroot := flag.String("runroot", storeOptions.RunRoot, "storage runtime directory")
+	driver := flag.String("storage-driver", storeOptions.GraphDriverName, "storage driver")
+	opts := flag.String("storage-opts", "", "storage option list (comma separated)")
+	policy := flag.String("signature-policy", "", "signature policy file")
+	mtype := flag.String("expected-manifest-type", buildah.OCIv1ImageManifest, "expected manifest type")
+	showm := flag.Bool("show-manifest", false, "output the manifest JSON")
+	showc := flag.Bool("show-config", false, "output the configuration JSON")
+	flag.Parse()
+	switch *mtype {
+	case buildah.OCIv1ImageManifest:
+		expectedManifestType = *mtype
+		expectedConfigType = v1.MediaTypeImageConfig
+	case buildah.Dockerv2ImageManifest:
+		expectedManifestType = *mtype
+		expectedConfigType = docker.V2S2MediaTypeImageConfig
+	case "*":
+		expectedManifestType = ""
+		expectedConfigType = ""
+	default:
+		logrus.Fatalf("unknown -expected-manifest-type value, expected either %q or %q or %q",
+			buildah.OCIv1ImageManifest, buildah.Dockerv2ImageManifest, "*")
+	}
+	if root != nil {
+		storeOptions.GraphRoot = *root
+	}
+	if runroot != nil {
+		storeOptions.RunRoot = *runroot
+	}
+	if driver != nil {
+		storeOptions.GraphDriverName = *driver
+	}
+	if opts != nil && *opts != "" {
+		storeOptions.GraphDriverOptions = strings.Split(*opts, ",")
+	}
+	systemContext := &types.SystemContext{
+		SignaturePolicyPath: *policy,
+	}
+	args := flag.Args()
+	if len(args) == 0 {
+		flag.Usage()
+		return
+	}
+	store, err := storage.GetStore(storeOptions)
+	if err != nil {
+		logrus.Fatalf("error opening storage: %v", err)
+	}
+	defer store.Shutdown(false)
+
+	for _, image := range args {
+		oImage := v1.Image{}
+		dImage := docker.V2Image{}
+		oManifest := v1.Manifest{}
+		dManifest := docker.V2S2Manifest{}
+		manifestType := ""
+		configType := ""
+
+		ref, err := is.Transport.ParseStoreReference(store, image)
+		if err != nil {
+			logrus.Fatalf("error parsing reference %q: %v", image, err)
+		}
+
+		src, err := ref.NewImageSource(systemContext, []string{expectedManifestType})
+		if err != nil {
+			logrus.Fatalf("error opening source image %q: %v", image, err)
+		}
+		defer src.Close()
+
+		manifest, manifestType, err := src.GetManifest()
+		if err != nil {
+			logrus.Fatalf("error reading manifest from %q: %v", image, err)
+		}
+
+		img, err := ref.NewImage(systemContext)
+		if err != nil {
+			logrus.Fatalf("error opening image %q: %v", image, err)
+		}
+		defer img.Close()
+
+		config, err := img.ConfigBlob()
+		if err != nil {
+			logrus.Fatalf("error reading configuration from %q: %v", image, err)
+		}
+
+		switch expectedManifestType {
+		case buildah.OCIv1ImageManifest:
+			err = json.Unmarshal(manifest, &oManifest)
+			if err != nil {
+				logrus.Fatalf("error parsing manifest from %q: %v", image, err)
+			}
+			err = json.Unmarshal(config, &oImage)
+			if err != nil {
+				logrus.Fatalf("error parsing config from %q: %v", image, err)
+			}
+			manifestType = v1.MediaTypeImageManifest
+			configType = oManifest.Config.MediaType
+		case buildah.Dockerv2ImageManifest:
+			err = json.Unmarshal(manifest, &dManifest)
+			if err != nil {
+				logrus.Fatalf("error parsing manifest from %q: %v", image, err)
+			}
+			err = json.Unmarshal(config, &dImage)
+			if err != nil {
+				logrus.Fatalf("error parsing config from %q: %v", image, err)
+			}
+			manifestType = dManifest.MediaType
+			configType = dManifest.Config.MediaType
+		}
+		if expectedManifestType != "" && manifestType != expectedManifestType {
+			logrus.Fatalf("expected manifest type %q in %q, got %q", expectedManifestType, image, manifestType)
+		}
+		if expectedConfigType != "" && configType != expectedConfigType {
+			logrus.Fatalf("expected config type %q in %q, got %q", expectedConfigType, image, configType)
+		}
+		if showm != nil && *showm {
+			fmt.Println(string(manifest))
+		}
+		if showc != nil && *showc {
+			fmt.Println(string(config))
+		}
+	}
+}


### PR DESCRIPTION
This patch set adds `--format` options to the `commit` and `build-using-dockerfile` commands (also `-f` for `commit`) to allow selecting either docker v2s2 or oci v1 as output formats for the manifest and configuration blobs that we write to images.  It also adds initial support for importing settings from docker v2s1 images, though that's not as well tested since we don't produce that format.

This also helps us properly test the `config` command and the logic that imports settings from images in the two formats.