### PR TITLE
Increase the timeout for metalinter from 2m to 4m

### DIFF
--- a/tests/validate/gometalinter.sh
+++ b/tests/validate/gometalinter.sh
@@ -16,5 +16,5 @@ exec gometalinter.v1 \
 	--disable=gas \
 	--disable=aligncheck \
 	--cyclo-over=40 \
-	--deadline=120s \
+	--deadline=240s \
 	--tests "$@"


### PR DESCRIPTION
Increase the timeout that we set for running the metalinter from 2 minutes to 4 minutes, for cases where the calling environment is more heavily loaded than we expected.

As of this writing, this appears to be what's causing CI to reject #117.