### PR TITLE
Use Hostname settings, avoid mounting tmpfs over volumes with mounts

### DIFF
--- a/run.go
+++ b/run.go
@@ -109,6 +109,8 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	}
 	if options.Hostname != "" {
 		g.SetHostname(options.Hostname)
+	} else if b.Hostname() != "" {
+		g.SetHostname(b.Hostname())
 	}
 	for _, volume := range b.Volumes() {
 		g.AddTmpfsMount(volume, nil)


### PR DESCRIPTION
Go ahead and default to a hostname from the source image if it included one, and avoid mounting a tmpfs at a volume location if the list of mounts already includes an entry that mounts something else there.