### PR TITLE
Fix a copy/paste error in a man page

### DIFF
--- a/docs/buildah-inspect.md
+++ b/docs/buildah-inspect.md
@@ -1,4 +1,4 @@
-## buildah-mount "1" "May 2017" "buildah"
+## buildah-inspect "1" "May 2017" "buildah"
 
 ## NAME
 buildah inspect - Display information about a working container.


### PR DESCRIPTION
Well, I think we can all tell what I used as a template when writing the "inspect" man page.