### PR TITLE
buildah mount command should list mounts when no arguments are given.

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -68,9 +68,6 @@ type Builder struct {
 	// MountPoint is the last location where the container's root
 	// filesystem was mounted.  It should not be modified.
 	MountPoint string `json:"mountpoint,omitempty"`
-	// Mounts is a list of places where the container's root filesystem has
-	// been mounted.  It should not be modified.
-	Mounts []string `json:"mounts,omitempty"`
 
 	// ImageAnnotations is a set of key-value pairs which is stored in the
 	// image's manifest.
@@ -192,15 +189,7 @@ func OpenBuilderByPath(store storage.Store, path string) (*Builder, error) {
 		return nil, err
 	}
 	builderMatchesPath := func(b *Builder, path string) bool {
-		if b.MountPoint == path {
-			return true
-		}
-		for _, m := range b.Mounts {
-			if m == path {
-				return true
-			}
-		}
-		return false
+		return (b.MountPoint == path)
 	}
 	for _, container := range containers {
 		cdir, err := store.ContainerDirectory(container.ID)

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -8,41 +8,65 @@ import (
 
 var (
 	mountDescription = "Mounts a working container's root filesystem for manipulation"
-	mountCommand     = cli.Command{
+	mountFlags       = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "notruncate",
+			Usage: "do not truncate output",
+		},
+	}
+	mountCommand = cli.Command{
 		Name:        "mount",
 		Usage:       "Mount a working container's root filesystem",
 		Description: mountDescription,
 		Action:      mountCmd,
 		ArgsUsage:   "CONTAINER-NAME-OR-ID",
+		Flags:       mountFlags,
 	}
 )
 
 func mountCmd(c *cli.Context) error {
+	var name string
 	args := c.Args()
-	if len(args) == 0 {
-		return fmt.Errorf("container ID must be specified")
-	}
 	if len(args) > 1 {
 		return fmt.Errorf("too many arguments specified")
 	}
-	name := args[0]
 
 	store, err := getStore(c)
 	if err != nil {
 		return err
 	}
-
-	builder, err := openBuilder(store, name)
-	if err != nil {
-		return fmt.Errorf("error reading build container %q: %v", name, err)
+	truncate := true
+	if c.IsSet("notruncate") {
+		truncate = !c.Bool("notruncate")
 	}
 
-	mountPoint, err := builder.Mount("")
-	if err != nil {
-		return fmt.Errorf("error mounting container %q: %v", builder.Container, err)
+	if len(args) == 1 {
+		name = args[0]
+
+		builder, err := openBuilder(store, name)
+		if err != nil {
+			return fmt.Errorf("error reading build container %q: %v", name, err)
+		}
+		mountPoint, err := builder.Mount("")
+		if err != nil {
+			return fmt.Errorf("error mounting container %q: %v", builder.Container, err)
+		}
+		fmt.Printf("%s\n", mountPoint)
+	} else {
+		builders, err := openBuilders(store)
+		if err != nil {
+			return fmt.Errorf("error reading build containers: %v", err)
+		}
+		for _, builder := range builders {
+			if builder.MountPoint == "" {
+				continue
+			}
+			if truncate {
+				fmt.Printf("%-12.12s %s\n", builder.ContainerID, builder.MountPoint)
+			} else {
+				fmt.Printf("%-64s %s\n", builder.ContainerID, builder.MountPoint)
+			}
+		}
 	}
-
-	fmt.Printf("%s\n", mountPoint)
-
 	return nil
 }

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -463,6 +463,7 @@ return 1
      local boolean_options="
      --help
      -h
+     --notruncate
   "
 
      local options_with_args="

--- a/docs/buildah-mount.md
+++ b/docs/buildah-mount.md
@@ -4,19 +4,37 @@
 buildah mount - Mount a working container's root filesystem.
 
 ## SYNOPSIS
+**buildah** **mount**
+
 **buildah** **mount** **containerID**
 
 ## DESCRIPTION
 Mounts the specified container's root file system in a location which can be
 accessed from the host, and returns its location.
 
+If you execute the command without any arguments, the tool will list all of the
+currently mounted containers.
+
 ## RETURN VALUE
 The location of the mounted file system.  On error an empty string and errno is
 returned.
 
+## OPTIONS
+
+**--notruncate**
+
+Do not truncate IDs in output.
+
 ## EXAMPLE
 
-buildah mount containerID
+buildah mount c831414b10a3
+
+/var/lib/containers/storage/overlay2/f3ac502d97b5681989dff84dfedc8354239bcecbdc2692f9a639f4e080a02364/merged
+
+buildah mount
+
+c831414b10a3 /var/lib/containers/storage/overlay2/f3ac502d97b5681989dff84dfedc8354239bcecbdc2692f9a639f4e080a02364/merged
+a7060253093b /var/lib/containers/storage/overlay2/0ff7d7ca68bed1ace424f9df154d2dd7b5a125c19d887f17653cbcd5b6e30ba1/merged
 
 ## SEE ALSO
 buildah(1)

--- a/import.go
+++ b/import.go
@@ -47,7 +47,6 @@ func importBuilderDataFromImage(store storage.Store, systemContext *types.System
 		Manifest:         manifest,
 		Container:        containerName,
 		ContainerID:      containerID,
-		Mounts:           []string{},
 		ImageAnnotations: map[string]string{},
 		ImageCreatedBy:   "",
 	}

--- a/mount.go
+++ b/mount.go
@@ -9,17 +9,6 @@ func (b *Builder) Mount(label string) (string, error) {
 	}
 	b.MountPoint = mountpoint
 
-	present := false
-	for _, m := range b.Mounts {
-		if m == mountpoint {
-			present = true
-			break
-		}
-	}
-	if !present {
-		b.Mounts = append(b.Mounts, mountpoint)
-	}
-
 	err = b.Save()
 	if err != nil {
 		return "", err

--- a/new.go
+++ b/new.go
@@ -131,7 +131,6 @@ func newBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
 		Manifest:         manifest,
 		Container:        name,
 		ContainerID:      container.ID,
-		Mounts:           []string{},
 		ImageAnnotations: map[string]string{},
 		ImageCreatedBy:   "",
 	}

--- a/unmount.go
+++ b/unmount.go
@@ -4,6 +4,7 @@ package buildah
 func (b *Builder) Unmount() error {
 	err := b.store.Unmount(b.ContainerID)
 	if err == nil {
+		b.MountPoint = ""
 		err = b.Save()
 	}
 	return err


### PR DESCRIPTION
buildah mount should work like the mount command and list all mount points
when no options are specified.

Need buildah umount to remove mount point from the database when a mount point
is umounted.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>