### PR TITLE
Change all calls that use fmt.Errorf and an err, to errors.Wrapf

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -50,12 +51,12 @@ func addAndCopyCmd(c *cli.Context, extractLocalArchives bool) error {
 
 	builder, err := openBuilder(store, name)
 	if err != nil {
-		return fmt.Errorf("error reading build container %q: %v", name, err)
+		return errors.Wrapf(err, "error reading build container %q", name)
 	}
 
 	err = builder.Add(dest, extractLocalArchives, args...)
 	if err != nil {
-		return fmt.Errorf("error adding content to container %q: %v", builder.Container, err)
+		return errors.Wrapf(err, "error adding content to container %q", builder.Container)
 	}
 
 	return nil

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah/imagebuildah"
 	"github.com/urfave/cli"
 )
@@ -151,7 +152,7 @@ func budCmd(c *cli.Context) error {
 		// The context directory could be a URL.  Try to handle that.
 		tempDir, subDir, err := imagebuildah.TempDirForURL("", "buildah", cliArgs[0])
 		if err != nil {
-			return fmt.Errorf("error prepping temporary context directory: %v", err)
+			return errors.Wrapf(err, "error prepping temporary context directory")
 		}
 		if tempDir != "" {
 			// We had to download it to a temporary directory.
@@ -166,7 +167,7 @@ func budCmd(c *cli.Context) error {
 			// Nope, it was local.  Use it as is.
 			absDir, err := filepath.Abs(cliArgs[0])
 			if err != nil {
-				return fmt.Errorf("error determining path to directory %q: %v", cliArgs[0], err)
+				return errors.Wrapf(err, "error determining path to directory %q", cliArgs[0])
 			}
 			contextDir = absDir
 		}
@@ -183,12 +184,12 @@ func budCmd(c *cli.Context) error {
 			}
 			absFile, err := filepath.Abs(dockerfiles[i])
 			if err != nil {
-				return fmt.Errorf("error determining path to file %q: %v", dockerfiles[i], err)
+				return errors.Wrapf(err, "error determining path to file %q", dockerfiles[i])
 			}
 			contextDir = filepath.Dir(absFile)
 			dockerfiles[i], err = filepath.Rel(contextDir, absFile)
 			if err != nil {
-				return fmt.Errorf("error determining path to file %q: %v", dockerfiles[i], err)
+				return errors.Wrapf(err, "error determining path to file %q", dockerfiles[i])
 			}
 			break
 		}

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/image/storage"
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/storage/pkg/archive"
+	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
 	"github.com/urfave/cli"
 )
@@ -87,14 +88,14 @@ func commitCmd(c *cli.Context) error {
 
 	builder, err := openBuilder(store, name)
 	if err != nil {
-		return fmt.Errorf("error reading build container %q: %v", name, err)
+		return errors.Wrapf(err, "error reading build container %q", name)
 	}
 
 	dest, err := alltransports.ParseImageName(image)
 	if err != nil {
 		dest2, err2 := storage.Transport.ParseStoreReference(store, image)
 		if err2 != nil {
-			return fmt.Errorf("error parsing target image name %q: %v", image, err)
+			return errors.Wrapf(err, "error parsing target image name %q", image)
 		}
 		dest = dest2
 	}
@@ -109,7 +110,7 @@ func commitCmd(c *cli.Context) error {
 	}
 	err = builder.Commit(dest, options)
 	if err != nil {
-		return fmt.Errorf("error committing container %q to %q: %v", builder.Container, image, err)
+		return errors.Wrapf(err, "error committing container %q to %q", builder.Container, image)
 	}
 
 	return nil

--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -6,6 +6,7 @@ import (
 
 	is "github.com/containers/image/storage"
 	"github.com/containers/storage"
+	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
 	"github.com/urfave/cli"
 )
@@ -46,7 +47,7 @@ func openBuilder(store storage.Store, name string) (builder *buildah.Builder, er
 		}
 	}
 	if err != nil {
-		return nil, fmt.Errorf("error reading build container: %v", err)
+		return nil, errors.Wrapf(err, "error reading build container")
 	}
 	if builder == nil {
 		return nil, fmt.Errorf("error finding build container")
@@ -64,7 +65,7 @@ func openImage(store storage.Store, name string) (builder *buildah.Builder, err 
 	}
 	builder, err = buildah.ImportBuilderFromImage(store, options)
 	if err != nil {
-		return nil, fmt.Errorf("error reading image: %v", err)
+		return nil, errors.Wrapf(err, "error reading image")
 	}
 	if builder == nil {
 		return nil, fmt.Errorf("error mocking up build configuration")

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/mattn/go-shellwords"
+	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
 	"github.com/urfave/cli"
 )
@@ -179,7 +180,7 @@ func configCmd(c *cli.Context) error {
 
 	builder, err := openBuilder(store, name)
 	if err != nil {
-		return fmt.Errorf("error reading build container %q: %v", name, err)
+		return errors.Wrapf(err, "error reading build container %q", name)
 	}
 
 	updateConfig(builder, c)

--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
 	"github.com/urfave/cli"
 )
@@ -54,7 +55,7 @@ func containersCmd(c *cli.Context) error {
 
 	builders, err := openBuilders(store)
 	if err != nil {
-		return fmt.Errorf("error reading build containers: %v", err)
+		return errors.Wrapf(err, "error reading build containers")
 	}
 	if len(builders) > 0 && !noheading && !quiet {
 		if truncate {

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -52,7 +53,7 @@ func imagesCmd(c *cli.Context) error {
 	}
 	images, err := store.Images()
 	if err != nil {
-		return fmt.Errorf("error reading images: %v", err)
+		return errors.Wrapf(err, "error reading images")
 	}
 
 	if len(images) > 0 && !noheading && !quiet {

--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"text/template"
 
+	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
 	"github.com/urfave/cli"
 )
@@ -81,12 +82,12 @@ func inspectCmd(c *cli.Context) error {
 	case inspectTypeContainer:
 		builder, err = openBuilder(store, name)
 		if err != nil {
-			return fmt.Errorf("error reading build container %q: %v", name, err)
+			return errors.Wrapf(err, "error reading build container %q", name)
 		}
 	case inspectTypeImage:
 		builder, err = openImage(store, name)
 		if err != nil {
-			return fmt.Errorf("error reading image %q: %v", name, err)
+			return errors.Wrapf(err, "error reading image %q", name)
 		}
 	}
 
@@ -96,7 +97,7 @@ func inspectCmd(c *cli.Context) error {
 
 	b, err := json.MarshalIndent(builder, "", "    ")
 	if err != nil {
-		return fmt.Errorf("error encoding build container as json: %v", err)
+		return errors.Wrapf(err, "error encoding build container as json")
 	}
 	_, err = fmt.Println(string(b))
 	return err

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -25,7 +26,6 @@ var (
 )
 
 func mountCmd(c *cli.Context) error {
-	var name string
 	args := c.Args()
 	if len(args) > 1 {
 		return fmt.Errorf("too many arguments specified")
@@ -41,21 +41,20 @@ func mountCmd(c *cli.Context) error {
 	}
 
 	if len(args) == 1 {
-		name = args[0]
-
+		name := args[0]
 		builder, err := openBuilder(store, name)
 		if err != nil {
-			return fmt.Errorf("error reading build container %q: %v", name, err)
+			return errors.Wrapf(err, "error reading build container %q", name)
 		}
 		mountPoint, err := builder.Mount("")
 		if err != nil {
-			return fmt.Errorf("error mounting container %q: %v", builder.Container, err)
+			return errors.Wrapf(err, "error mounting %q container %q", name, builder.Container)
 		}
 		fmt.Printf("%s\n", mountPoint)
 	} else {
 		builders, err := openBuilders(store)
 		if err != nil {
-			return fmt.Errorf("error reading build containers: %v", err)
+			return errors.Wrapf(err, "error reading build containers")
 		}
 		for _, builder := range builders {
 			if builder.MountPoint == "" {

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
 	"github.com/urfave/cli"
 )
@@ -61,7 +62,7 @@ func runCmd(c *cli.Context) error {
 
 	builder, err := openBuilder(store, name)
 	if err != nil {
-		return fmt.Errorf("error reading build container %q: %v", name, err)
+		return errors.Wrapf(err, "error reading build container %q", name)
 	}
 
 	hostname := ""

--- a/cmd/buildah/tag.go
+++ b/cmd/buildah/tag.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah/util"
 	"github.com/urfave/cli"
 )
@@ -29,11 +30,11 @@ func tagCmd(c *cli.Context) error {
 	}
 	img, err := util.FindImage(store, args[0])
 	if err != nil {
-		return fmt.Errorf("error finding local image %q: %v", args[0], err)
+		return errors.Wrapf(err, "error finding local image %q", args[0])
 	}
 	err = util.AddImageNames(store, img, args[1:])
 	if err != nil {
-		return fmt.Errorf("error adding names %v to image %q: %v", args[1:], args[0], err)
+		return errors.Wrapf(err, "error adding names %v to image %q", args[1:], args[0])
 	}
 	return nil
 }

--- a/cmd/buildah/umount.go
+++ b/cmd/buildah/umount.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -34,12 +35,12 @@ func umountCmd(c *cli.Context) error {
 
 	builder, err := openBuilder(store, name)
 	if err != nil {
-		return fmt.Errorf("error reading build container %q: %v", name, err)
+		return errors.Wrapf(err, "error reading build container %q", name)
 	}
 
 	err = builder.Unmount()
 	if err != nil {
-		return fmt.Errorf("error unmounting container %q: %v", builder.Container, err)
+		return errors.Wrapf(err, "error unmounting container %q", builder.Container)
 	}
 
 	return nil

--- a/delete.go
+++ b/delete.go
@@ -1,14 +1,14 @@
 package buildah
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 )
 
 // Delete removes the working container.  The buildah.Builder object should not
 // be used after this method is called.
 func (b *Builder) Delete() error {
 	if err := b.store.DeleteContainer(b.ContainerID); err != nil {
-		return fmt.Errorf("error deleting build container: %v", err)
+		return errors.Wrapf(err, "error deleting build container")
 	}
 	b.MountPoint = ""
 	b.Container = ""

--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/storage/pkg/chrootarchive"
+	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
 )
 
@@ -27,7 +28,7 @@ func downloadToDirectory(url, dir string) error {
 	logrus.Debugf("extracting %q to %q", url, dir)
 	resp, err := http.Get(url)
 	if err != nil {
-		return fmt.Errorf("error getting %q: %v", url, err)
+		return errors.Wrapf(err, "error getting %q", url)
 	}
 	defer resp.Body.Close()
 	if resp.ContentLength == 0 {
@@ -52,7 +53,7 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 	}
 	name, err = ioutil.TempDir(dir, prefix)
 	if err != nil {
-		return "", "", fmt.Errorf("error creating temporary directory for %q: %v", url, err)
+		return "", "", errors.Wrapf(err, "error creating temporary directory for %q", url)
 	}
 	if strings.HasPrefix(url, "git://") {
 		err = cloneToDirectory(url, name)

--- a/pull.go
+++ b/pull.go
@@ -1,8 +1,6 @@
 package buildah
 
 import (
-	"fmt"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/copy"
 	"github.com/containers/image/docker/reference"
@@ -11,6 +9,7 @@ import (
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
+	"github.com/pkg/errors"
 )
 
 func pullImage(store storage.Store, options BuilderOptions, sc *types.SystemContext) error {
@@ -25,7 +24,7 @@ func pullImage(store storage.Store, options BuilderOptions, sc *types.SystemCont
 	if err != nil {
 		srcRef2, err2 := alltransports.ParseImageName(spec)
 		if err2 != nil {
-			return fmt.Errorf("error parsing image name %q: %v", spec, err2)
+			return errors.Wrapf(err2, "error parsing image name %q", spec)
 		}
 		srcRef = srcRef2
 	}
@@ -39,7 +38,7 @@ func pullImage(store storage.Store, options BuilderOptions, sc *types.SystemCont
 
 	destRef, err := is.Transport.ParseStoreReference(store, name)
 	if err != nil {
-		return fmt.Errorf("error parsing full image name %q: %v", name, err)
+		return errors.Wrapf(err, "error parsing full image name %q", name)
 	}
 
 	policy, err := signature.DefaultPolicy(sc)

--- a/user.go
+++ b/user.go
@@ -1,12 +1,12 @@
 package buildah
 
 import (
-	"fmt"
 	"os/user"
 	"strconv"
 	"strings"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 func getUser(rootdir, userspec string) (specs.User, error) {
@@ -70,9 +70,9 @@ func getUser(rootdir, userspec string) (specs.User, error) {
 		return u, nil
 	}
 
-	err := fmt.Errorf("%v determining run uid", uerr)
+	err := errors.Wrapf(uerr, "error determining run uid")
 	if uerr == nil {
-		err = fmt.Errorf("%v determining run gid", gerr)
+		err = errors.Wrapf(gerr, "error determining run gid")
 	}
 	return specs.User{}, err
 }

--- a/user_basic.go
+++ b/user_basic.go
@@ -7,13 +7,13 @@ import (
 )
 
 func lookupUserInContainer(rootdir, username string) (uint64, uint64, error) {
-	return 0, 0, fmt.Errorf("user lookup not supported")
+	return 0, 0, errors.Wrapf("user lookup not supported")
 }
 
 func lookupGroupInContainer(rootdir, groupname string) (uint64, error) {
-	return 0, fmt.Errorf("group lookup not supported")
+	return 0, errors.Wrapf("group lookup not supported")
 }
 
 func lookupGroupForUIDInContainer(rootdir string, userid uint64) (string, uint64, error) {
-	return "", 0, fmt.Errorf("primary group lookup by uid not supported")
+	return "", 0, errors.Wrapf("primary group lookup by uid not supported")
 }

--- a/user_unix_cgo.go
+++ b/user_unix_cgo.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"syscall"
 	"unsafe"
+
+	"github.com/pkg/errors"
 )
 
 func fopenContainerFile(rootdir, filename string) (C.pFILE, error) {
@@ -31,13 +33,13 @@ func fopenContainerFile(rootdir, filename string) (C.pFILE, error) {
 	defer C.free(unsafe.Pointer(mode))
 	f, err := C.fopen(cctrfile, mode)
 	if f == nil || err != nil {
-		return nil, fmt.Errorf("error opening %q: %v", ctrfile, err)
+		return nil, errors.Wrapf(err, "error opening %q", ctrfile)
 	}
 	if err = syscall.Fstat(int(C.fileno(f)), &st); err != nil {
-		return nil, fmt.Errorf("fstat(%q): %v", ctrfile, err)
+		return nil, errors.Wrapf(err, "fstat(%q)", ctrfile)
 	}
 	if err = syscall.Lstat(ctrfile, &lst); err != nil {
-		return nil, fmt.Errorf("lstat(%q): %v", ctrfile, err)
+		return nil, errors.Wrapf(err, "lstat(%q)", ctrfile)
 	}
 	if st.Dev != lst.Dev || st.Ino != lst.Ino {
 		return nil, fmt.Errorf("%q is not a regular file", ctrfile)

--- a/util/util.go
+++ b/util/util.go
@@ -1,11 +1,10 @@
 package util
 
 import (
-	"fmt"
-
 	"github.com/containers/image/docker/reference"
 	is "github.com/containers/image/storage"
 	"github.com/containers/storage"
+	"github.com/pkg/errors"
 )
 
 // ExpandTags takes unqualified names, parses them as image names, and returns
@@ -15,7 +14,7 @@ func ExpandTags(tags []string) ([]string, error) {
 	for _, tag := range tags {
 		name, err := reference.ParseNormalizedNamed(tag)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing tag %q: %v", tag, err)
+			return nil, errors.Wrapf(err, "error parsing tag %q", tag)
 		}
 		name = reference.TagNameOnly(name)
 		tag = ""
@@ -31,11 +30,11 @@ func ExpandTags(tags []string) ([]string, error) {
 func FindImage(store storage.Store, image string) (*storage.Image, error) {
 	ref, err := is.Transport.ParseStoreReference(store, image)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing reference to image %q: %v", image, err)
+		return nil, errors.Wrapf(err, "error parsing reference to image %q", image)
 	}
 	img, err := is.Transport.GetStoreImage(store, ref)
 	if err != nil {
-		return nil, fmt.Errorf("unable to locate image: %v", err)
+		return nil, errors.Wrapf(err, "unable to locate image")
 	}
 	return img, nil
 }
@@ -48,7 +47,7 @@ func AddImageNames(store storage.Store, image *storage.Image, addNames []string)
 	}
 	err = store.SetNames(image.ID, append(image.Names, names...))
 	if err != nil {
-		return fmt.Errorf("error adding names (%v) to image %q: %v", names, image.ID, err)
+		return errors.Wrapf(err, "error adding names (%v) to image %q", names, image.ID)
 	}
 	return nil
 }


### PR DESCRIPTION
We want to wrap all err calls with Wrapf, to allow for easier debugging
and better error reporting.