### PR TITLE
Update README.md to show Dockerfile functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-buildah - a tool for building OCI images
-========================================
+buildah - a tool which facilites building OCI container images
+==============================================================
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/projectatomic/buildah)](https://goreportcard.com/report/github.com/projectatomic/buildah)
 [![Travis](https://travis-ci.org/projectatomic/buildah.svg?branch=master)](https://travis-ci.org/projectatomic/buildah)
@@ -8,6 +8,8 @@ Note: this package is in alpha.
 
 The buildah package provides a command line tool which can be used to
 * create a working container, either from scratch or using an image as a starting point
+* create an image, either from a working container or via the instructions in a Dockerfile
+* images can be built in either the OCI image format or the traditional upstream docker image format
 * mount a working container's root filesystem for manipulation
 * unmount a working container's root filesystem
 * use the updated contents of a container's root filesystem as a filesystem layer to create a new image


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweney@redhat.com>

A few touch ups to the README.md.  In specific listing that buildah works on both images and containers in the intro line, then added notes about the use of Dockerfiles and image formats.