### PR TITLE
Finish wiring --format into build-using-dockerfile

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -114,6 +114,7 @@ type Executor struct {
 	transientMounts                []Mount
 	compression                    archive.Compression
 	output                         string
+	outputFormat                   string
 	additionalTags                 []string
 	log                            func(format string, args ...interface{})
 	out                            io.Writer
@@ -391,6 +392,7 @@ func NewExecutor(store storage.Store, options BuildOptions) (*Executor, error) {
 		transientMounts:     options.TransientMounts,
 		compression:         options.Compression,
 		output:              options.Output,
+		outputFormat:        options.OutputFormat,
 		additionalTags:      options.AdditionalTags,
 		signaturePolicyPath: options.SignaturePolicyPath,
 		systemContext:       makeSystemContext(options.SignaturePolicyPath),
@@ -588,10 +590,11 @@ func (b *Executor) Commit(ib *imagebuilder.Builder) (err error) {
 		}
 	}
 	options := buildah.CommitOptions{
-		Compression:         b.compression,
-		SignaturePolicyPath: b.signaturePolicyPath,
-		AdditionalTags:      b.additionalTags,
-		ReportWriter:        b.reportWriter,
+		Compression:           b.compression,
+		SignaturePolicyPath:   b.signaturePolicyPath,
+		AdditionalTags:        b.additionalTags,
+		ReportWriter:          b.reportWriter,
+		PreferredManifestType: b.outputFormat,
 	}
 	return b.builder.Commit(imageRef, options)
 }

--- a/tests/formats.bats
+++ b/tests/formats.bats
@@ -18,3 +18,19 @@ load helpers
   run imgtype -expected-manifest-type application/vnd.oci.image.manifest.v1+json scratch-image-docker
   [ "$status" -ne 0 ]
 }
+
+@test "bud-formats" {
+  buildimgtype
+  buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json -t scratch-image-default -f bud/from-scratch/Dockerfile
+  buildah build-using-dockerfile --format dockerv2 --signature-policy ${TESTSDIR}/policy.json -t scratch-image-docker -f bud/from-scratch/Dockerfile
+  buildah build-using-dockerfile --format ociv1 --signature-policy ${TESTSDIR}/policy.json -t scratch-image-oci -f bud/from-scratch/Dockerfile
+  imgtype -expected-manifest-type application/vnd.oci.image.manifest.v1+json scratch-image-default
+  imgtype -expected-manifest-type application/vnd.oci.image.manifest.v1+json scratch-image-oci
+  imgtype -expected-manifest-type application/vnd.docker.distribution.manifest.v2+json scratch-image-docker
+  run imgtype -expected-manifest-type application/vnd.docker.distribution.manifest.v2+json scratch-image-default
+  [ "$status" -ne 0 ]
+  run imgtype -expected-manifest-type application/vnd.docker.distribution.manifest.v2+json scratch-image-oci
+  [ "$status" -ne 0 ]
+  run imgtype -expected-manifest-type application/vnd.oci.image.manifest.v1+json scratch-image-docker
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
We weren't properly passing the preferred output format to the Commit() method when committing images that we were building using build-with-dockerfile.  This fixes that and adds a test for it.