### PR TITLE
Make README dnf command copy-pastable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ Prior to installing buildah, install the following packages on your linux distro
 In Fedora, you can use this command:
 
 ```
- dnf -y install \ 
-    make \ 
-    golang \ 
-    bats \ 
-    btrfs-progs-devel \ 
-    device-mapper-devel \ 
-    gpgme-devel \ 
-    libassuan-devel \ 
-    git \ 
+ dnf -y install \
+    make \
+    golang \
+    bats \
+    btrfs-progs-devel \
+    device-mapper-devel \
+    gpgme-devel \
+    libassuan-devel \
+    git \
     bzip2 \
     go-md2man \
     skopeo-containers


### PR DESCRIPTION
There are EOL spaces in the README preventing the `dnf install` command from being used in copy-pasta.