### PR TITLE
Use errors.New() instead of Wrapf() for new errors

### DIFF
--- a/add.go
+++ b/add.go
@@ -1,7 +1,6 @@
 package buildah
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -48,7 +47,7 @@ func addURL(destination, srcurl string) error {
 		return errors.Wrapf(err, "error reading contents for %q", destination)
 	}
 	if resp.ContentLength >= 0 && n != resp.ContentLength {
-		return fmt.Errorf("error reading contents for %q: wrong length (%d != %d)", destination, n, resp.ContentLength)
+		return errors.Errorf("error reading contents for %q: wrong length (%d != %d)", destination, n, resp.ContentLength)
 	}
 	if err := f.Chmod(0600); err != nil {
 		return errors.Wrapf(err, "error setting permissions on %q", destination)
@@ -88,7 +87,7 @@ func (b *Builder) Add(destination string, extract bool, source ...string) error 
 	}
 	// Make sure the destination's parent directory is usable.
 	if destpfi, err2 := os.Stat(filepath.Dir(dest)); err2 == nil && !destpfi.IsDir() {
-		return fmt.Errorf("%q already exists, but is not a subdirectory)", filepath.Dir(dest))
+		return errors.Errorf("%q already exists, but is not a subdirectory)", filepath.Dir(dest))
 	}
 	// Now look at the destination itself.
 	destfi, err := os.Stat(dest)
@@ -99,7 +98,7 @@ func (b *Builder) Add(destination string, extract bool, source ...string) error 
 		destfi = nil
 	}
 	if len(source) > 1 && (destfi == nil || !destfi.IsDir()) {
-		return fmt.Errorf("destination %q is not a directory", dest)
+		return errors.Errorf("destination %q is not a directory", dest)
 	}
 	for _, src := range source {
 		if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {

--- a/buildah.go
+++ b/buildah.go
@@ -2,7 +2,6 @@ package buildah
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah/docker"
 )
 
@@ -170,7 +170,7 @@ func OpenBuilder(store storage.Store, container string) (*Builder, error) {
 		return nil, err
 	}
 	if b.Type != containerType {
-		return nil, fmt.Errorf("container is not a %s container", Package)
+		return nil, errors.Errorf("container is not a %s container", Package)
 	}
 	b.store = store
 	b.fixupConfig()

--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -31,7 +29,7 @@ var (
 func addAndCopyCmd(c *cli.Context, extractLocalArchives bool) error {
 	args := c.Args()
 	if len(args) == 0 {
-		return fmt.Errorf("container ID must be specified")
+		return errors.Errorf("container ID must be specified")
 	}
 	name := args[0]
 	args = args.Tail()

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -144,7 +143,7 @@ func budCmd(c *cli.Context) error {
 	} else if strings.HasPrefix(format, "docker") {
 		format = imagebuildah.Dockerv2ImageFormat
 	} else {
-		return fmt.Errorf("unrecognized image type %q", format)
+		return errors.Errorf("unrecognized image type %q", format)
 	}
 	contextDir := ""
 	cliArgs := c.Args()
@@ -195,7 +194,7 @@ func budCmd(c *cli.Context) error {
 		}
 	}
 	if contextDir == "" {
-		return fmt.Errorf("no context directory specified, and no dockerfile specified")
+		return errors.Errorf("no context directory specified, and no dockerfile specified")
 	}
 	if len(dockerfiles) == 0 {
 		dockerfiles = append(dockerfiles, filepath.Join(contextDir, "Dockerfile"))

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -46,15 +45,15 @@ var (
 func commitCmd(c *cli.Context) error {
 	args := c.Args()
 	if len(args) == 0 {
-		return fmt.Errorf("container ID must be specified")
+		return errors.Errorf("container ID must be specified")
 	}
 	name := args[0]
 	args = args.Tail()
 	if len(args) == 0 {
-		return fmt.Errorf("an image name must be specified")
+		return errors.Errorf("an image name must be specified")
 	}
 	if len(args) > 1 {
-		return fmt.Errorf("too many arguments specified")
+		return errors.Errorf("too many arguments specified")
 	}
 	image := args[0]
 
@@ -79,7 +78,7 @@ func commitCmd(c *cli.Context) error {
 	} else if strings.HasPrefix(strings.ToLower(format), "docker") {
 		format = buildah.Dockerv2ImageManifest
 	} else {
-		return fmt.Errorf("unrecognized image type %q", format)
+		return errors.Errorf("unrecognized image type %q", format)
 	}
 	store, err := getStore(c)
 	if err != nil {

--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	is "github.com/containers/image/storage"
@@ -50,7 +49,7 @@ func openBuilder(store storage.Store, name string) (builder *buildah.Builder, er
 		return nil, errors.Wrapf(err, "error reading build container")
 	}
 	if builder == nil {
-		return nil, fmt.Errorf("error finding build container")
+		return nil, errors.Errorf("error finding build container")
 	}
 	return builder, nil
 }
@@ -68,7 +67,7 @@ func openImage(store storage.Store, name string) (builder *buildah.Builder, err 
 		return nil, errors.Wrapf(err, "error reading image")
 	}
 	if builder == nil {
-		return nil, fmt.Errorf("error mocking up build configuration")
+		return nil, errors.Errorf("error mocking up build configuration")
 	}
 	return builder, nil
 }

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -166,10 +165,10 @@ func updateConfig(builder *buildah.Builder, c *cli.Context) {
 func configCmd(c *cli.Context) error {
 	args := c.Args()
 	if len(args) == 0 {
-		return fmt.Errorf("container ID must be specified")
+		return errors.Errorf("container ID must be specified")
 	}
 	if len(args) > 1 {
-		return fmt.Errorf("too many arguments specified")
+		return errors.Errorf("too many arguments specified")
 	}
 	name := args[0]
 

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
 	"github.com/urfave/cli"
 )
@@ -59,10 +60,10 @@ func fromCmd(c *cli.Context) error {
 
 	args := c.Args()
 	if len(args) == 0 {
-		return fmt.Errorf("an image name (or \"scratch\") must be specified")
+		return errors.Errorf("an image name (or \"scratch\") must be specified")
 	}
 	if len(args) > 1 {
-		return fmt.Errorf("too many arguments specified")
+		return errors.Errorf("too many arguments specified")
 	}
 	image := args[0]
 

--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -46,10 +46,10 @@ func inspectCmd(c *cli.Context) error {
 
 	args := c.Args()
 	if len(args) == 0 {
-		return fmt.Errorf("container or image name must be specified")
+		return errors.Errorf("container or image name must be specified")
 	}
 	if len(args) > 1 {
-		return fmt.Errorf("too many arguments specified")
+		return errors.Errorf("too many arguments specified")
 	}
 
 	itemType := inspectTypeContainer
@@ -60,7 +60,7 @@ func inspectCmd(c *cli.Context) error {
 	case inspectTypeContainer:
 	case inspectTypeImage:
 	default:
-		return fmt.Errorf("the only recognized types are %q and %q", inspectTypeContainer, inspectTypeImage)
+		return errors.Errorf("the only recognized types are %q and %q", inspectTypeContainer, inspectTypeImage)
 	}
 
 	format := defaultFormat

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -28,7 +28,7 @@ var (
 func mountCmd(c *cli.Context) error {
 	args := c.Args()
 	if len(args) > 1 {
-		return fmt.Errorf("too many arguments specified")
+		return errors.Errorf("too many arguments specified")
 	}
 
 	store, err := getStore(c)

--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -22,7 +23,7 @@ var (
 func rmCmd(c *cli.Context) error {
 	args := c.Args()
 	if len(args) == 0 {
-		return fmt.Errorf("container ID must be specified")
+		return errors.Errorf("container ID must be specified")
 	}
 	store, err := getStore(c)
 	if err != nil {

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/image/transports"
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/image/types"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -26,7 +27,7 @@ var (
 func rmiCmd(c *cli.Context) error {
 	args := c.Args()
 	if len(args) == 0 {
-		return fmt.Errorf("image name or ID must be specified")
+		return errors.Errorf("image name or ID must be specified")
 	}
 
 	store, err := getStore(c)

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -38,7 +37,7 @@ var (
 func runCmd(c *cli.Context) error {
 	args := c.Args()
 	if len(args) == 0 {
-		return fmt.Errorf("container ID must be specified")
+		return errors.Errorf("container ID must be specified")
 	}
 	name := args[0]
 	args = args.Tail()

--- a/cmd/buildah/tag.go
+++ b/cmd/buildah/tag.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah/util"
 	"github.com/urfave/cli"
@@ -22,7 +20,7 @@ var (
 func tagCmd(c *cli.Context) error {
 	args := c.Args()
 	if len(args) < 2 {
-		return fmt.Errorf("image name and at least one new name must be specified")
+		return errors.Errorf("image name and at least one new name must be specified")
 	}
 	store, err := getStore(c)
 	if err != nil {

--- a/cmd/buildah/umount.go
+++ b/cmd/buildah/umount.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -21,10 +19,10 @@ var (
 func umountCmd(c *cli.Context) error {
 	args := c.Args()
 	if len(args) == 0 {
-		return fmt.Errorf("container ID must be specified")
+		return errors.Errorf("container ID must be specified")
 	}
 	if len(args) > 1 {
-		return fmt.Errorf("too many arguments specified")
+		return errors.Errorf("too many arguments specified")
 	}
 	name := args[0]
 

--- a/config.go
+++ b/config.go
@@ -10,6 +10,7 @@ import (
 
 	digest "github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah/docker"
 )
 
@@ -124,7 +125,7 @@ func makeDockerV2S2Image(oimage *ociv1.Image) (docker.V2Image, error) {
 func makeDockerV2S1Image(manifest docker.V2S1Manifest) (docker.V2Image, error) {
 	// Treat the most recent (first) item in the history as a description of the image.
 	if len(manifest.History) == 0 {
-		return docker.V2Image{}, fmt.Errorf("error parsing image configuration from manifest")
+		return docker.V2Image{}, errors.Errorf("error parsing image configuration from manifest")
 	}
 	dimage := docker.V2Image{}
 	err := json.Unmarshal([]byte(manifest.History[0].V1Compatibility), &dimage)
@@ -132,7 +133,7 @@ func makeDockerV2S1Image(manifest docker.V2S1Manifest) (docker.V2Image, error) {
 		return docker.V2Image{}, err
 	}
 	if dimage.DockerVersion == "" {
-		return docker.V2Image{}, fmt.Errorf("error parsing image configuration from history")
+		return docker.V2Image{}, errors.Errorf("error parsing image configuration from history")
 	}
 	// The DiffID list is intended to contain the sums of _uncompressed_ blobs, and these are most
 	// likely compressed, so leave the list empty to avoid potential confusion later on.  We can

--- a/image.go
+++ b/image.go
@@ -3,7 +3,6 @@ package buildah
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -92,7 +91,7 @@ func (i *containerImageRef) NewImageSource(sc *types.SystemContext, manifestType
 	}
 	// If it's not a format we support, return an error.
 	if manifestType != v1.MediaTypeImageManifest && manifestType != docker.V2S2MediaTypeManifest {
-		return nil, fmt.Errorf("no supported manifest types (attempted to use %q, only know %q and %q)",
+		return nil, errors.Errorf("no supported manifest types (attempted to use %q, only know %q and %q)",
 			manifestType, v1.MediaTypeImageManifest, docker.V2S2MediaTypeManifest)
 	}
 	layers := []string{}
@@ -215,7 +214,7 @@ func (i *containerImageRef) NewImageSource(sc *types.SystemContext, manifestType
 		layerFile.Close()
 		if i.compression == archive.Uncompressed {
 			if size != counter.Count {
-				return nil, fmt.Errorf("error storing layer %q to file: inconsistent layer size (copied %d, wrote %d)", layerID, size, counter.Count)
+				return nil, errors.Errorf("error storing layer %q to file: inconsistent layer size (copied %d, wrote %d)", layerID, size, counter.Count)
 			}
 		} else {
 			size = counter.Count
@@ -317,7 +316,7 @@ func (i *containerImageRef) NewImageSource(sc *types.SystemContext, manifestType
 }
 
 func (i *containerImageRef) NewImageDestination(sc *types.SystemContext) (types.ImageDestination, error) {
-	return nil, fmt.Errorf("can't write to a container")
+	return nil, errors.Errorf("can't write to a container")
 }
 
 func (i *containerImageRef) DockerReference() reference.Named {
@@ -365,7 +364,7 @@ func (i *containerImageSource) GetSignatures() ([][]byte, error) {
 }
 
 func (i *containerImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
-	return []byte{}, "", fmt.Errorf("TODO")
+	return []byte{}, "", errors.Errorf("TODO")
 }
 
 func (i *containerImageSource) GetManifest() ([]byte, string, error) {

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -160,7 +160,7 @@ func (b *Executor) Preserve(path string) error {
 	b.preserved++
 	cacheDir, err := b.store.ContainerDirectory(b.builder.ContainerID)
 	if err != nil {
-		return fmt.Errorf("unable to locate temporary directory for container")
+		return errors.Errorf("unable to locate temporary directory for container")
 	}
 	cacheFile := filepath.Join(cacheDir, fmt.Sprintf("volume%d.tar", b.preserved))
 	// Save info about the top level of the location that we'll be archiving.
@@ -174,7 +174,7 @@ func (b *Executor) Preserve(path string) error {
 	if !b.volumes.Add(path) {
 		// This path is not a subdirectory of a volume path that we're
 		// already preserving, so adding it to the list should work.
-		return fmt.Errorf("error adding %q to the volume cache", path)
+		return errors.Errorf("error adding %q to the volume cache", path)
 	}
 	b.volumeCache[path] = cacheFile
 	// Now prune cache files for volumes that are now supplanted by this one.
@@ -337,7 +337,7 @@ func convertMounts(mounts []Mount) []specs.Mount {
 func (b *Executor) Run(run imagebuilder.Run, config docker.Config) error {
 	logrus.Debugf("RUN %#v, %#v", run, config)
 	if b.builder == nil {
-		return fmt.Errorf("no build container available")
+		return errors.Errorf("no build container available")
 	}
 	options := buildah.RunOptions{
 		Hostname:        config.Hostname,
@@ -376,7 +376,7 @@ func (b *Executor) UnrecognizedInstruction(step *imagebuilder.Step) error {
 		return nil
 	}
 	logrus.Errorf("+(UNIMPLEMENTED?) %#v", step)
-	return fmt.Errorf("Unrecognized instruction: %#v", step)
+	return errors.Errorf("Unrecognized instruction: %#v", step)
 }
 
 // NewExecutor creates a new instance of the imagebuilder.Executor interface.
@@ -661,7 +661,7 @@ func BuildReadClosers(store storage.Store, options BuildOptions, dockerfile ...i
 func BuildDockerfiles(store storage.Store, options BuildOptions, dockerfile ...string) error {
 	var dockerfiles []io.ReadCloser
 	if len(dockerfile) == 0 {
-		return fmt.Errorf("error building: no dockerfiles specified")
+		return errors.Errorf("error building: no dockerfiles specified")
 	}
 	for _, dfile := range dockerfile {
 		var rc io.ReadCloser
@@ -673,7 +673,7 @@ func BuildDockerfiles(store storage.Store, options BuildOptions, dockerfile ...s
 			}
 			if resp.ContentLength == 0 {
 				resp.Body.Close()
-				return fmt.Errorf("no contents in %q", dfile)
+				return errors.Errorf("no contents in %q", dfile)
 			}
 			rc = resp.Body
 		} else {

--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -32,7 +32,7 @@ func downloadToDirectory(url, dir string) error {
 	}
 	defer resp.Body.Close()
 	if resp.ContentLength == 0 {
-		return fmt.Errorf("no contents in %q", url)
+		return errors.Errorf("no contents in %q", url)
 	}
 	return chrootarchive.Untar(resp.Body, dir, nil)
 }
@@ -85,7 +85,7 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 	if err2 := os.Remove(name); err2 != nil {
 		logrus.Debugf("error removing temporary directory %q: %v", name, err2)
 	}
-	return "", "", fmt.Errorf("unreachable code reached")
+	return "", "", errors.Errorf("unreachable code reached")
 }
 
 // InitReexec is a wrapper for buildah.InitReexec().  It should be called at

--- a/import.go
+++ b/import.go
@@ -1,8 +1,6 @@
 package buildah
 
 import (
-	"fmt"
-
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
@@ -59,7 +57,7 @@ func importBuilderDataFromImage(store storage.Store, systemContext *types.System
 
 func importBuilder(store storage.Store, options ImportOptions) (*Builder, error) {
 	if options.Container == "" {
-		return nil, fmt.Errorf("container name must be specified")
+		return nil, errors.Errorf("container name must be specified")
 	}
 
 	c, err := store.Container(options.Container)
@@ -84,7 +82,7 @@ func importBuilder(store storage.Store, options ImportOptions) (*Builder, error)
 
 func importBuilderFromImage(store storage.Store, options ImportFromImageOptions) (*Builder, error) {
 	if options.Image == "" {
-		return nil, fmt.Errorf("image name must be specified")
+		return nil, errors.Errorf("image name must be specified")
 	}
 
 	ref, err := is.Transport.ParseStoreReference(store, options.Image)

--- a/user_basic.go
+++ b/user_basic.go
@@ -3,17 +3,17 @@
 package buildah
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 )
 
 func lookupUserInContainer(rootdir, username string) (uint64, uint64, error) {
-	return 0, 0, errors.Wrapf("user lookup not supported")
+	return 0, 0, errors.New("user lookup not supported")
 }
 
 func lookupGroupInContainer(rootdir, groupname string) (uint64, error) {
-	return 0, errors.Wrapf("group lookup not supported")
+	return 0, errors.New("group lookup not supported")
 }
 
 func lookupGroupForUIDInContainer(rootdir string, userid uint64) (string, uint64, error) {
-	return "", 0, errors.Wrapf("primary group lookup by uid not supported")
+	return "", 0, errors.New("primary group lookup by uid not supported")
 }

--- a/user_unix_cgo.go
+++ b/user_unix_cgo.go
@@ -42,7 +42,7 @@ func fopenContainerFile(rootdir, filename string) (C.pFILE, error) {
 		return nil, errors.Wrapf(err, "lstat(%q)", ctrfile)
 	}
 	if st.Dev != lst.Dev || st.Ino != lst.Ino {
-		return nil, fmt.Errorf("%q is not a regular file", ctrfile)
+		return nil, errors.Errorf("%q is not a regular file", ctrfile)
 	}
 	return f, nil
 }


### PR DESCRIPTION
Call `errors.New()` instead of calling `errors.Wrapf()` when there's no error to wrap.