### PR TITLE
Help people figure out runc compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Then to install buildah follow the steps in this example:
   buildah --help
 ```
 
+buildah uses `runc` to run commands when `buildah run` is used, or when `buildah build-using-dockerfile`
+encounters a `RUN` instruction, so you'll also need to build and install a compatible version of
+[runc](https://github.com/opencontainers/runc) for buildah to call for those cases.
+
 ## Commands
 | Command               | Description |
 | --------------------- | --------------------------------------------------- |

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/storage"
+	ispecs "github.com/opencontainers/image-spec/specs-go"
+	rspecs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/projectatomic/buildah"
 	"github.com/urfave/cli"
 )
@@ -17,7 +20,7 @@ func main() {
 
 	app := cli.NewApp()
 	app.Name = buildah.Package
-	app.Version = buildah.Version
+	app.Version = fmt.Sprintf("%s (image-spec %s, runtime-spec %s)", buildah.Version, ispecs.Version, rspecs.Version)
 	app.Usage = "an image builder"
 	if len(storage.DefaultStoreOptions.GraphDriverOptions) > 0 {
 		var optionSlice cli.StringSlice = storage.DefaultStoreOptions.GraphDriverOptions[:]


### PR DESCRIPTION
Output the versions of the image-spec and runtime-spec that we were built with as part of our version information, produced when we are invoked with the `--help` or `--version` flags, and note that we need a compatible version of `runc` in our README.