### PR TITLE
gccgo is giving errors about using copy

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -4,7 +4,7 @@ import (
 	"io"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/containers/image/copy"
+	cp "github.com/containers/image/copy"
 	"github.com/containers/image/signature"
 	"github.com/containers/image/storage"
 	"github.com/containers/image/transports"
@@ -54,7 +54,7 @@ func (b *Builder) Commit(dest types.ImageReference, options CommitOptions) error
 	if err != nil {
 		return errors.Wrapf(err, "error recomputing layer digests and building metadata")
 	}
-	err = copy.Image(policyContext, dest, src, getCopyOptions(options.ReportWriter))
+	err = cp.Image(policyContext, dest, src, getCopyOptions(options.ReportWriter))
 	if err != nil {
 		return errors.Wrapf(err, "error copying layers and metadata")
 	}

--- a/common.go
+++ b/common.go
@@ -3,12 +3,12 @@ package buildah
 import (
 	"io"
 
-	"github.com/containers/image/copy"
+	cp "github.com/containers/image/copy"
 	"github.com/containers/image/types"
 )
 
-func getCopyOptions(reportWriter io.Writer) *copy.Options {
-	return &copy.Options{
+func getCopyOptions(reportWriter io.Writer) *cp.Options {
+	return &cp.Options{
 		ReportWriter: reportWriter,
 	}
 }

--- a/pull.go
+++ b/pull.go
@@ -2,7 +2,7 @@ package buildah
 
 import (
 	"github.com/Sirupsen/logrus"
-	"github.com/containers/image/copy"
+	cp "github.com/containers/image/copy"
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/signature"
 	is "github.com/containers/image/storage"
@@ -53,6 +53,6 @@ func pullImage(store storage.Store, options BuilderOptions, sc *types.SystemCont
 
 	logrus.Debugf("copying %q to %q", spec, name)
 
-	err = copy.Image(policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter))
+	err = cp.Image(policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter))
 	return err
 }


### PR DESCRIPTION
golang-bin-1.8.1-1.fc26.x86_64
gcc-go-7.1.1-1.fc26.x86_64

Signed-off-by: Dan Walsh <dwalsh@redhat.com>