### PR TITLE
Split copying to external locations ("pushing") from "commit"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILDFLAGS := -tags "$(AUTOTAGS) $(TAGS)"
 
 all: buildah docs
 
-buildah: *.go imagebuildah/*.go cmd/buildah/*.go docker/*.go
+buildah: *.go imagebuildah/*.go cmd/buildah/*.go docker/*.go util/*.go
 	go build -o buildah $(BUILDFLAGS) ./cmd/buildah
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ encounters a `RUN` instruction, so you'll also need to build and install a compa
 | buildah-images(1)     | List images in local storage. |
 | buildah-inspect(1)    | Inspects the configuration of a container or image. |
 | buildah-mount(1)      | Mount the working container's root filesystem. |
+| buildah-push(1)       | Copies an image from local storage. |
 | buildah-rm(1)         | Removes one or more working containers. |
 | buildah-rmi(1)        | Removes one or more images. |
 | buildah-run(1)        | Run a command inside of the container. |

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -82,6 +82,7 @@ func main() {
 		imagesCommand,
 		inspectCommand,
 		mountCommand,
+		pushCommand,
 		rmCommand,
 		rmiCommand,
 		runCommand,

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+
+	"github.com/containers/image/transports/alltransports"
+	"github.com/containers/storage/pkg/archive"
+	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah"
+	"github.com/urfave/cli"
+)
+
+var (
+	pushFlags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "disable-compression, D",
+			Usage: "don't compress layers",
+		},
+		cli.StringFlag{
+			Name:  "signature-policy",
+			Usage: "`pathname` of signature policy file (not usually used)",
+		},
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "don't output progress information when pushing images",
+		},
+	}
+	pushDescription = "Pushes an image to a specified location."
+	pushCommand     = cli.Command{
+		Name:        "push",
+		Usage:       "Push an image to a specified location",
+		Description: pushDescription,
+		Flags:       pushFlags,
+		Action:      pushCmd,
+		ArgsUsage:   "IMAGE [TRANSPORT:]IMAGE",
+	}
+)
+
+func pushCmd(c *cli.Context) error {
+	args := c.Args()
+	if len(args) < 2 {
+		return errors.New("source and destination image IDs must be specified")
+	}
+	src := args[0]
+	destSpec := args[1]
+
+	signaturePolicy := ""
+	if c.IsSet("signature-policy") {
+		signaturePolicy = c.String("signature-policy")
+	}
+	compress := archive.Uncompressed
+	if !c.IsSet("disable-compression") || !c.Bool("disable-compression") {
+		compress = archive.Gzip
+	}
+	quiet := false
+	if c.IsSet("quiet") {
+		quiet = c.Bool("quiet")
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+	dest, err := alltransports.ParseImageName(destSpec)
+	if err != nil {
+		return err
+	}
+
+	options := buildah.PushOptions{
+		Compression:         compress,
+		SignaturePolicyPath: signaturePolicy,
+		Store:               store,
+	}
+	if !quiet {
+		options.ReportWriter = os.Stderr
+	}
+
+	err = buildah.Push(src, dest, options)
+	if err != nil {
+		return errors.Wrapf(err, "error pushing image %q to %q", src, destSpec)
+	}
+
+	return nil
+}

--- a/commit.go
+++ b/commit.go
@@ -3,6 +3,7 @@ package buildah
 import (
 	"bytes"
 	"io"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	cp "github.com/containers/image/copy"
@@ -50,6 +51,9 @@ type CommitOptions struct {
 	// ReportWriter is an io.Writer which will be used to log the writing
 	// of the new image.
 	ReportWriter io.Writer
+	// HistoryTimestamp is the timestamp used when creating new items in the
+	// image's history.  If unset, the current time will be used.
+	HistoryTimestamp *time.Time
 }
 
 // shallowCopy copies the most recent layer, the configuration, and the manifest from one image to another.
@@ -220,7 +224,7 @@ func (b *Builder) Commit(dest types.ImageReference, options CommitOptions) error
 	// Check if we're keeping everything in local storage.  If so, we can take certain shortcuts.
 	_, destIsStorage := dest.Transport().(storage.StoreTransport)
 	exporting := !destIsStorage
-	src, err := b.makeContainerImageRef(options.PreferredManifestType, exporting, options.Compression)
+	src, err := b.makeContainerImageRef(options.PreferredManifestType, exporting, options.Compression, options.HistoryTimestamp)
 	if err != nil {
 		return errors.Wrapf(err, "error recomputing layer digests and building metadata")
 	}

--- a/commit.go
+++ b/commit.go
@@ -1,6 +1,7 @@
 package buildah
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/Sirupsen/logrus"
@@ -10,8 +11,21 @@ import (
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/stringid"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah/util"
+)
+
+var (
+	// gzippedEmptyLayer is a gzip-compressed version of an empty tar file (just 1024 zero bytes).  This
+	// comes from github.com/docker/distribution/manifest/schema1/config_builder.go by way of
+	// github.com/containers/image/image/docker_schema2.go; there is a non-zero embedded timestamp; we could
+	// zero that, but that would just waste storage space in registries, so let’s use the same values.
+	gzippedEmptyLayer = []byte{
+		31, 139, 8, 0, 0, 9, 110, 136, 0, 255, 98, 24, 5, 163, 96, 20, 140, 88,
+		0, 8, 0, 0, 255, 255, 46, 175, 181, 239, 0, 4, 0, 0,
+	}
 )
 
 // CommitOptions can be used to alter how an image is committed.
@@ -38,6 +52,159 @@ type CommitOptions struct {
 	ReportWriter io.Writer
 }
 
+// shallowCopy copies the most recent layer, the configuration, and the manifest from one image to another.
+// For local storage, which doesn't care about histories and the manifest's contents, that's sufficient, but
+// almost any other destination has higher expectations.
+// We assume that "dest" is a reference to a local image (specifically, a containers/image/storage.storageReference),
+// and will fail if it isn't.
+func (b *Builder) shallowCopy(dest types.ImageReference, src types.ImageReference, systemContext *types.SystemContext) error {
+	// Read the target image name.
+	if dest.DockerReference() == nil {
+		return errors.New("can't write to an unnamed image")
+	}
+	names, err := util.ExpandTags([]string{dest.DockerReference().String()})
+	if err != nil {
+		return err
+	}
+	// Make a temporary image reference.
+	tmpName := stringid.GenerateRandomID() + "-tmp-" + Package + "-commit"
+	tmpRef, err := storage.Transport.ParseStoreReference(b.store, tmpName)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err2 := tmpRef.DeleteImage(systemContext); err2 != nil {
+			logrus.Debugf("error deleting temporary image %q: %v", tmpName, err2)
+		}
+	}()
+	// Open the source for reading and a temporary image for writing.
+	srcImage, err := src.NewImage(systemContext)
+	if err != nil {
+		return errors.Wrapf(err, "error reading configuration to write to image %q", transports.ImageName(dest))
+	}
+	defer srcImage.Close()
+	tmpImage, err := tmpRef.NewImageDestination(systemContext)
+	if err != nil {
+		return errors.Wrapf(err, "error opening temporary copy of image %q for writing", transports.ImageName(dest))
+	}
+	defer tmpImage.Close()
+	// Write an empty filesystem layer, because the image layer requires at least one.
+	_, err = tmpImage.PutBlob(bytes.NewReader(gzippedEmptyLayer), types.BlobInfo{Size: int64(len(gzippedEmptyLayer))})
+	if err != nil {
+		return errors.Wrapf(err, "error writing dummy layer for image %q", transports.ImageName(dest))
+	}
+	// Read the newly-generated configuration blob.
+	config, err := srcImage.ConfigBlob()
+	if err != nil {
+		return errors.Wrapf(err, "error reading new configuration for image %q", transports.ImageName(dest))
+	}
+	if len(config) == 0 {
+		return errors.Errorf("error reading new configuration for image %q: it's empty", transports.ImageName(dest))
+	}
+	logrus.Debugf("read configuration blob %q", string(config))
+	// Write the configuration to the temporary image.
+	configBlobInfo := types.BlobInfo{
+		Digest: digest.Canonical.FromBytes(config),
+		Size:   int64(len(config)),
+	}
+	_, err = tmpImage.PutBlob(bytes.NewReader(config), configBlobInfo)
+	if err != nil && len(config) > 0 {
+		return errors.Wrapf(err, "error writing image configuration for temporary copy of %q", transports.ImageName(dest))
+	}
+	// Read the newly-generated, mostly fake, manifest.
+	manifest, _, err := srcImage.Manifest()
+	if err != nil {
+		return errors.Wrapf(err, "error reading new manifest for image %q", transports.ImageName(dest))
+	}
+	// Write the manifest to the temporary image.
+	err = tmpImage.PutManifest(manifest)
+	if err != nil {
+		return errors.Wrapf(err, "error writing new manifest to temporary copy of image %q", transports.ImageName(dest))
+	}
+	// Save the temporary image.
+	err = tmpImage.Commit()
+	if err != nil {
+		return errors.Wrapf(err, "error committing new image %q", transports.ImageName(dest))
+	}
+	// Locate the temporary image in the lower-level API.  Read its item names.
+	tmpImg, err := storage.Transport.GetStoreImage(b.store, tmpRef)
+	if err != nil {
+		return errors.Wrapf(err, "error locating temporary image %q", transports.ImageName(dest))
+	}
+	items, err := b.store.ListImageBigData(tmpImg.ID)
+	if err != nil {
+		return errors.Wrapf(err, "error reading list of named data for image %q", tmpImg.ID)
+	}
+	// Look up the container's read-write layer.
+	container, err := b.store.Container(b.ContainerID)
+	if err != nil {
+		return errors.Wrapf(err, "error reading information about working container %q", b.ContainerID)
+	}
+	parentLayer := ""
+	// Look up the container's source image's layer, if there is a source image.
+	if container.ImageID != "" {
+		img, err2 := b.store.Image(container.ImageID)
+		if err2 != nil {
+			return errors.Wrapf(err2, "error reading information about working container %q's source image", b.ContainerID)
+		}
+		parentLayer = img.TopLayer
+	}
+	// Extract the read-write layer's contents.
+	layerDiff, err := b.store.Diff(parentLayer, container.LayerID)
+	if err != nil {
+		return errors.Wrapf(err, "error reading layer from source image %q", transports.ImageName(src))
+	}
+	defer layerDiff.Close()
+	// Write a copy of the layer for the new image to reference.
+	layer, _, err := b.store.PutLayer("", parentLayer, []string{}, "", false, layerDiff)
+	if err != nil {
+		return errors.Wrapf(err, "error creating new read-only layer from container %q", b.ContainerID)
+	}
+	// Create a low-level image record that uses the new layer.
+	image, err := b.store.CreateImage("", []string{}, layer.ID, "", nil)
+	if err != nil {
+		err2 := b.store.DeleteLayer(layer.ID)
+		if err2 != nil {
+			logrus.Debugf("error removing layer %q: %v", layer, err2)
+		}
+		return errors.Wrapf(err, "error creating new low-level image %q", transports.ImageName(dest))
+	}
+	logrus.Debugf("created image ID %q", image.ID)
+	defer func() {
+		if err != nil {
+			_, err2 := b.store.DeleteImage(image.ID, true)
+			if err2 != nil {
+				logrus.Debugf("error removing image %q: %v", image.ID, err2)
+			}
+		}
+	}()
+	// Copy the configuration and manifest, which are big data items, along with whatever else is there.
+	for _, item := range items {
+		var data []byte
+		data, err = b.store.ImageBigData(tmpImg.ID, item)
+		if err != nil {
+			return errors.Wrapf(err, "error copying data item %q", item)
+		}
+		err = b.store.SetImageBigData(image.ID, item, data)
+		if err != nil {
+			return errors.Wrapf(err, "error copying data item %q", item)
+		}
+		logrus.Debugf("copied data item %q to %q", item, image.ID)
+	}
+	// Set low-level metadata in the new image so that the image library will accept it as a real image.
+	err = b.store.SetMetadata(image.ID, "{}")
+	if err != nil {
+		return errors.Wrapf(err, "error assigning metadata to new image %q", transports.ImageName(dest))
+	}
+	// Move the target name(s) from the temporary image to the new image.
+	err = util.AddImageNames(b.store, image, names)
+	if err != nil {
+		return errors.Wrapf(err, "error assigning names %v to new image", names)
+	}
+	logrus.Debugf("assigned names %v to image %q", names, image.ID)
+	return nil
+}
+
 // Commit writes the contents of the container, along with its updated
 // configuration, to a new image in the specified location, and if we know how,
 // add any additional tags that were specified.
@@ -50,13 +217,25 @@ func (b *Builder) Commit(dest types.ImageReference, options CommitOptions) error
 	if err != nil {
 		return err
 	}
-	src, err := b.makeContainerImageRef(options.PreferredManifestType, options.Compression)
+	// Check if we're keeping everything in local storage.  If so, we can take certain shortcuts.
+	_, destIsStorage := dest.Transport().(storage.StoreTransport)
+	exporting := !destIsStorage
+	src, err := b.makeContainerImageRef(options.PreferredManifestType, exporting, options.Compression)
 	if err != nil {
 		return errors.Wrapf(err, "error recomputing layer digests and building metadata")
 	}
-	err = cp.Image(policyContext, dest, src, getCopyOptions(options.ReportWriter))
-	if err != nil {
-		return errors.Wrapf(err, "error copying layers and metadata")
+	if exporting {
+		// Copy everything.
+		err = cp.Image(policyContext, dest, src, getCopyOptions(options.ReportWriter))
+		if err != nil {
+			return errors.Wrapf(err, "error copying layers and metadata")
+		}
+	} else {
+		// Copy only the most recent layer, the configuration, and the manifest.
+		err = b.shallowCopy(dest, src, getSystemContext(options.SignaturePolicyPath))
+		if err != nil {
+			return errors.Wrapf(err, "error copying layer and metadata")
+		}
 	}
 	if len(options.AdditionalTags) > 0 {
 		switch dest.Transport().Name() {
@@ -69,6 +248,7 @@ func (b *Builder) Commit(dest types.ImageReference, options CommitOptions) error
 			if err != nil {
 				return errors.Wrapf(err, "error setting image names to %v", append(img.Names, options.AdditionalTags...))
 			}
+			logrus.Debugf("assigned names %v to image %q", img.Names, img.ID)
 		default:
 			logrus.Warnf("don't know how to add tags to images stored in %q transport", dest.Transport().Name())
 		}

--- a/config.go
+++ b/config.go
@@ -227,8 +227,15 @@ func (b *Builder) fixupConfig() {
 			b.Docker.Parent = docker.ID(digest.NewDigestFromHex(digest.Canonical.String(), b.FromImageID))
 		}
 	}
+	now := time.Now().UTC()
+	if b.Docker.Created.IsZero() {
+		b.Docker.Created = now
+	}
 	if b.FromImage != "" {
 		b.Docker.Config.Image = b.FromImage
+	}
+	if b.OCIv1.Created.IsZero() {
+		b.OCIv1.Created = now
 	}
 	if b.OS() == "" {
 		b.SetOS(runtime.GOOS)

--- a/config.go
+++ b/config.go
@@ -220,19 +220,9 @@ func (b *Builder) fixupConfig() {
 	}
 	b.Docker.Config = &b.Docker.ContainerConfig
 	b.Docker.DockerVersion = ""
-	if b.FromImageID != "" {
-		if d, err := digest.Parse(b.FromImageID); err == nil {
-			b.Docker.Parent = docker.ID(d)
-		} else {
-			b.Docker.Parent = docker.ID(digest.NewDigestFromHex(digest.Canonical.String(), b.FromImageID))
-		}
-	}
 	now := time.Now().UTC()
 	if b.Docker.Created.IsZero() {
 		b.Docker.Created = now
-	}
-	if b.FromImage != "" {
-		b.Docker.Config.Image = b.FromImage
 	}
 	if b.OCIv1.Created.IsZero() {
 		b.OCIv1.Created = now

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -295,6 +295,7 @@ return 1
           --signature-policy
           --format
           -f
+	  --reference-time
   "
 
      local all_options="$options_with_args $boolean_options"

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -287,6 +287,7 @@ return 1
           --help
           -h
           --disable-compression
+          -D
           --quiet
           -q
   "
@@ -295,7 +296,6 @@ return 1
           --signature-policy
           --format
           -f
-	  --reference-time
   "
 
      local all_options="$options_with_args $boolean_options"
@@ -460,6 +460,50 @@ return 1
      esac
  }
 
+ _buildah_push() {
+     local boolean_options="
+          --help
+          -h
+          --disable-compression
+          -D
+          --quiet
+          -q
+  "
+
+     local options_with_args="
+          --signature-policy
+  "
+
+     local all_options="$options_with_args $boolean_options"
+
+     case "$prev" in
+         --signature-policy)
+             case "$cur" in
+                 *:*) ;; # TODO somehow do _filedir for stuff inside the image, if it's already specified (which is also somewhat difficult to determine)
+                 '')
+                     COMPREPLY=($(compgen -W '/' -- "$cur"))
+                     __buildah_nospace
+                     ;;
+                 *)
+                     _filedir
+                     __buildah_nospace
+                     ;;
+             esac
+             return
+             ;;
+
+         $(__buildah_to_extglob "$options_with_args"))
+ return
+ ;;
+ esac
+
+     case "$cur" in
+         -*)
+             COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
+             ;;
+     esac
+ }
+
  _buildah_mount() {
      local boolean_options="
      --help
@@ -598,6 +642,7 @@ return 1
        images
        inspect
        mount
+       push
        rm
        rmi
        run
@@ -607,7 +652,6 @@ return 1
    )
 
    # These options are valid as global options for all client commands
-   # and valid as command options for `buildah daemon`
    local global_boolean_options="
          --debug
    "

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -13,7 +13,7 @@ specified, an ID is assigned, but no name is assigned to the image.
 
 ## OPTIONS
 
-**--disable-compression**
+**--disable-compression, -D**
 
 Don't compress filesystem layers when building the image.
 
@@ -32,11 +32,6 @@ When writing the output image, suppress progress output.
 Control the format for the image manifest and configuration data.  Recognized
 formats include *oci* (OCI image-spec v1.0, the default) and *docker* (version
 2, using schema format 2 for the manifest).
-
-**--reference-time**
-
-Sets the creation date in the image to match the last-modified time of the
-specified file.  This option is mainly present for use in buildah's self-tests.
 
 ## EXAMPLE
 

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -33,6 +33,11 @@ Control the format for the image manifest and configuration data.  Recognized
 formats include *oci* (OCI image-spec v1.0, the default) and *docker* (version
 2, using schema format 2 for the manifest).
 
+**--reference-time**
+
+Sets the creation date in the image to match the last-modified time of the
+specified file.  This option is mainly present for use in buildah's self-tests.
+
 ## EXAMPLE
 
 buildah commit containerID

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -1,0 +1,38 @@
+## buildah-push"1" "June 2017" "buildah"
+
+## NAME
+buildah push - Push an image from local storage to elsewhere.
+
+## SYNOPSIS
+**buildah** **push** [*options* [...]] **imageID** [**destination**]
+
+## DESCRIPTION
+Pushes an image from local storage to a specified destination, decompressing
+and recompessing layers as needed.
+
+## OPTIONS
+
+**--disable-compression, -D**
+
+Don't compress copies of filesystem layers which will be pushed.
+
+**--signature-policy**
+
+Pathname of a signature policy file to use.  It is not recommended that this
+option be used, as the default behavior of using the system-wide default policy
+(frequently */etc/containers/policy.json*) is most often preferred.
+
+**--quiet**
+
+When writing the output image, suppress progress output.
+
+## EXAMPLE
+
+buildah push imageID dir:/path/to/image
+
+buildah push imageID oci-layout:/path/to/layout
+
+buildah push imageID docker://registry/repository:tag
+
+## SEE ALSO
+buildah(1)

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "push" {
+  touch ${TESTDIR}/reference-time-file
+  for source in scratch scratch-image; do
+    cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json ${source})
+    for format in "" docker oci ; do
+      mkdir -p ${TESTDIR}/committed${format:+.${format}}
+      buildah commit ${format:+--format ${format}} --reference-time ${TESTDIR}/reference-time-file --signature-policy ${TESTSDIR}/policy.json "$cid" scratch-image${format:+-${format}}
+      buildah commit ${format:+--format ${format}} --reference-time ${TESTDIR}/reference-time-file --signature-policy ${TESTSDIR}/policy.json "$cid" dir:${TESTDIR}/committed${format:+.${format}}
+      mkdir -p ${TESTDIR}/pushed${format:+.${format}}
+      buildah push --signature-policy ${TESTSDIR}/policy.json scratch-image${format:+-${format}} dir:${TESTDIR}/pushed${format:+.${format}}
+      diff -u ${TESTDIR}/committed${format:+.${format}}/manifest.json ${TESTDIR}/pushed${format:+.${format}}/manifest.json
+      [ "$output" = "" ]
+    done
+    buildah rm "$cid"
+  done
+}


### PR DESCRIPTION
This patch set modifies `Commit()` to take shortcuts when it notices that the location to which we're committing the new image is local storage: the manifest blob sums are not recalculated, and a bit of lower-level trickery is used to copy only the container's most recent layer to a read-only layer that becomes the top level for the new image.  A separate "push" path that never takes those shortcuts is added so that when we want to export things, we actually do the necessary digesting and copying.