### PR TITLE
Fix "unmount" bash completion

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -437,7 +437,7 @@ return 1
      esac
  }
 
- _buildah_umount() {
+ _buildah_unmount() {
      _buildah_umount $@
  }
 


### PR DESCRIPTION
Fix the infinitely self-recursing, but immediately replaced, version of the "umount" completion function with the missing "unmount" completion function.