### PR TITLE
Add a --volume flag to "buildah run"

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -381,6 +381,8 @@ return 1
      local options_with_args="
      --runtime
      --runtime-flag
+     --volume
+     -v
   "
 
      local all_options="$options_with_args $boolean_options"

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -22,6 +22,10 @@ The *path* to an alternate OCI-compatible runtime.
 
 Adds global flags for the container rutime.
 
+**--volume, -v** *source*:*destination*:*flags*
+
+Bind mount a location from the host into the container for its lifetime.
+
 ## EXAMPLE
 
 buildah run containerID 'ps -auxw'

--- a/run.go
+++ b/run.go
@@ -64,7 +64,7 @@ type RunOptions struct {
 	Terminal int
 }
 
-func setupMounts(spec *specs.Spec, optionMounts []specs.Mount, bindFiles []string, volumes []string) error {
+func setupMounts(spec *specs.Spec, optionMounts []specs.Mount, bindFiles, volumes []string) error {
 	// The passed-in mounts matter the most to us.
 	mounts := make([]specs.Mount, len(optionMounts))
 	copy(mounts, optionMounts)


### PR DESCRIPTION
Add a `--volume`/`-v` flag to `buildah run` to allow volume bind mounts to be specified on the command line.