### PR TITLE
Update the version number we identify as to 0.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ buildah - a tool which facilitates building OCI container images
 [![Go Report Card](https://goreportcard.com/badge/github.com/projectatomic/buildah)](https://goreportcard.com/report/github.com/projectatomic/buildah)
 [![Travis](https://travis-ci.org/projectatomic/buildah.svg?branch=master)](https://travis-ci.org/projectatomic/buildah)
 
-Note: this package is in alpha.
+Note: this package is in alpha, but is close to being feature-complete.
 
 The buildah package provides a command line tool which can be used to
 * create a working container, either from scratch or using an image as a starting point

--- a/buildah.go
+++ b/buildah.go
@@ -19,7 +19,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package
-	Version       = "0.0.1"
+	Version       = "0.1"
 	containerType = Package + " 0.0.1"
 	stateFile     = Package + ".json"
 )

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -86,8 +86,8 @@ func main() {
 		rmCommand,
 		rmiCommand,
 		runCommand,
-		umountCommand,
 		tagCommand,
+		umountCommand,
 	}
 	err := app.Run(os.Args)
 	if err != nil {

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -25,7 +25,7 @@
 %global shortcommit    %(c=%{commit}; echo ${c:0:7})
 
 Name:           buildah
-Version:        0.0.1
+Version:        0.1
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -68,7 +68,6 @@ mv vendor src
 
 export GOPATH=$(pwd)/_build:$(pwd):%{gopath}
 make all
-
 
 %install
 export GOPATH=$(pwd)/_build:$(pwd):%{gopath}


### PR DESCRIPTION
Adjust the order in which `--help` output lists commands to keep them sorted, and change our claimed version number to 0.1.