### PR TITLE
Add a -a/--all option to "buildah containers"

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -534,6 +534,8 @@ return 1
      --noheading
      -n
      --notruncate
+     -a
+     --all
   "
 
      local options_with_args="

--- a/docs/buildah-containers.md
+++ b/docs/buildah-containers.md
@@ -24,6 +24,11 @@ Do not truncate IDs in output.
 
 Displays only the container IDs.
 
+**--all, -a**
+
+List information about all containers, including those which were not created
+by and are not being used by buildah.
+
 ## EXAMPLE
 
 buildah containers


### PR DESCRIPTION
Add a --all option to "buildah containers" that causes it to go through the full list of containers, providing information about the ones that aren't buildah containers in addition to the ones that are.