### PR TITLE
Handle "run" without an explicit command correctly

### DIFF
--- a/run.go
+++ b/run.go
@@ -145,14 +145,16 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	}
 	if len(command) > 0 {
 		g.SetProcessArgs(command)
-	} else if len(options.Cmd) != 0 {
-		g.SetProcessArgs(options.Cmd)
-	} else if len(b.Cmd()) != 0 {
-		g.SetProcessArgs(b.Cmd())
-	} else if len(options.Entrypoint) != 0 {
-		g.SetProcessArgs(options.Entrypoint)
-	} else if len(b.Entrypoint()) != 0 {
-		g.SetProcessArgs(b.Entrypoint())
+	} else {
+		cmd := b.Cmd()
+		if len(options.Cmd) > 0 {
+			cmd = options.Cmd
+		}
+		ep := b.Entrypoint()
+		if len(options.Entrypoint) > 0 {
+			ep = options.Entrypoint
+		}
+		g.SetProcessArgs(append(ep, cmd...))
 	}
 	if options.WorkingDir != "" {
 		g.SetProcessCwd(options.WorkingDir)

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -23,6 +23,41 @@ load helpers
 	buildah rm $cid
 }
 
+@test "run-cmd" {
+	if ! which runc ; then
+		skip
+	fi
+	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	buildah config $cid --workingdir /tmp
+
+	buildah config $cid --entrypoint ""
+	buildah config $cid --cmd pwd
+	run buildah --debug=false run $cid
+	[ "$output" = /tmp ]
+
+	buildah config $cid --entrypoint echo
+	run buildah --debug=false run $cid
+	[ "$output" = pwd ]
+
+	buildah config $cid --cmd ""
+	run buildah --debug=false run $cid
+	[ "$output" = "" ]
+
+	buildah config $cid --entrypoint ""
+	run buildah --debug=false run $cid echo that-other-thing
+	[ "$output" = that-other-thing ]
+
+	buildah config $cid --cmd echo
+	run buildah --debug=false run $cid echo that-other-thing
+	[ "$output" = that-other-thing ]
+
+	buildah config $cid --entrypoint echo
+	run buildah --debug=false run $cid echo that-other-thing
+	[ "$output" = that-other-thing ]
+
+	buildah rm $cid
+}
+
 @test "run-user" {
 	if ! which runc ; then
 		skip


### PR DESCRIPTION
When "run" isn't explicitly given a command, mix the command and entrypoint options and configured values together correctly.