### PR TITLE
cmd/buildah/images.go: Add JSON output option

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -554,6 +554,7 @@ return 1
      local boolean_options="
      --help
      -h
+     --json
      --quiet
      -q
      --noheading

--- a/docs/buildah-images.md
+++ b/docs/buildah-images.md
@@ -11,6 +11,9 @@ Displays locally stored images, their names, and their IDs.
 
 ## OPTIONS
 
+**--json**
+Display the output in JSON format.
+
 **--noheading, -n**
 
 Omit the table headings from the listing of images.
@@ -26,6 +29,8 @@ Lists only the image IDs.
 ## EXAMPLE
 
 buildah images
+
+buildah images --json
 
 buildah images --quiet
 


### PR DESCRIPTION
The Atomic CLI will eventually need to be able to consume
structured output (in something like JSON).  This commit
adds a -j option to output to trigger JSON output of
images.

Example output:
```
[
    {
        "id": "aa66247d48aedfa3e9b74e4a41d2c9e5d2529122c8f0d43417012028a66f4f3b",
        "names": [
            "docker.io/library/busybox:latest"
        ]
    },
    {
        "id": "26db5ad6e82d85265d1609e6bffc04331537fdceb9740d36f576e7ee4e8d1be3",
        "names": [
            "docker.io/library/alpine:latest"
        ]
    }
]
```