### PR TITLE
Update the example commit target to skip transport

### DIFF
--- a/examples/all-the-things.sh
+++ b/examples/all-the-things.sh
@@ -24,7 +24,7 @@ echo yay > $mountpoint1/file-in-root
 read
 : "[1m Produce an image from the container [0m"
 read
-buildah commit "$container1" containers-storage:${2:-first-new-image}
+buildah commit "$container1" ${2:-first-new-image}
 read
 : "[1m Verify that our new image is there [0m"
 read


### PR DESCRIPTION
Update the target name that we use when committing an image in the example script to not mention the local storage transport, since the default is to use it anyway, and if we ever rename it, it's one fewer edit to make.