### PR TITLE
cmd/buildah/containers.go: Add JSON output option

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -529,6 +529,7 @@ return 1
      local boolean_options="
      --help
      -h
+     --json
      --quiet
      -q
      --noheading

--- a/docs/buildah-containers.md
+++ b/docs/buildah-containers.md
@@ -12,6 +12,10 @@ IDs, and the names and IDs of the images from which they were initialized.
 
 ## OPTIONS
 
+**--json**
+
+Output in JSON format.
+
 **--noheading, -n**
 
 Omit the table headings from the listing of containers.
@@ -36,6 +40,8 @@ buildah containers
 buildah containers --quiet
 
 buildah containers -q --noheading --notruncate
+
+buildah containers --json
 
 ## SEE ALSO
 buildah(1)


### PR DESCRIPTION
Consumers of the buildah output will need structured text like
the JSON format.  This commit adds a --json option to
buildah containers.

Example output:
```
[
    {
        "ID": "8911b523771cb2e0a26ab9bb324fb5be4e992764fdd5ead86a936aa6de964d9a",
        "Builder": true,
        "ImageId": "26db5ad6e82d85265d1609e6bffc04331537fdceb9740d36f576e7ee4e8d1be3",
        "ImageName": "docker.io/library/alpine:latest",
        "ContainerName": "alpine-working-container"
    }
]

```

Signed-off-by: Brent Baude <bbaude@redhat.com>