### PR TITLE
Add buildah export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ encounters a `RUN` instruction, so you'll also need to build and install a compa
 | [buildah-config(1)](/docs/buildah-config.md)         | Update image configuration settings.                                                                 |
 | [buildah-containers(1)](/docs/buildah-containers.md) | List the working containers and their base images.                                                   |
 | [buildah-copy(1)](/docs/buildah-copy.md)             | Copies the contents of a file, URL, or directory into a container's working directory.               |
+| [buildah-export(1)](/docs/buildah-export.md)         | Export the contents of a container's filesystem as a tar archive                                     |
 | [buildah-from(1)](/docs/buildah-from.md)             | Creates a new working container, either from scratch or using a specified image as a starting point. |
 | [buildah-images(1)](/docs/buildah-images.md)         | List images in local storage.                                                                        |
 | [buildah-inspect(1)](/docs/buildah-inspect.md)       | Inspects the configuration of a container or image.                                                  |

--- a/cmd/buildah/export.go
+++ b/cmd/buildah/export.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/containers/storage/pkg/archive"
+	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah"
+	"github.com/urfave/cli"
+)
+
+var (
+	exportFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "output, o",
+			Usage: "write to a file, instead of STDOUT",
+		},
+	}
+	exportCommand = cli.Command{
+		Name:  "export",
+		Usage: "Export container's filesystem contents as a tar archive",
+		Description: `This command exports the full or shortened container ID or container name to
+   STDOUT and should be redirected to a tar file.
+       `,
+		Flags:     exportFlags,
+		Action:    exportCmd,
+		ArgsUsage: "CONTAINER",
+	}
+)
+
+func exportCmd(c *cli.Context) error {
+	var builder *buildah.Builder
+
+	args := c.Args()
+	if len(args) == 0 {
+		return errors.Errorf("container name must be specified")
+	}
+	if len(args) > 1 {
+		return errors.Errorf("too many arguments specified")
+	}
+
+	name := args[0]
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	builder, err = openBuilder(store, name)
+	if err != nil {
+		return errors.Wrapf(err, "error reading build container %q", name)
+	}
+
+	mountPoint, err := builder.Mount("")
+	if err != nil {
+		return errors.Wrapf(err, "error mounting %q container %q", name, builder.Container)
+	}
+	defer func() {
+		if err := builder.Unmount(); err != nil {
+			fmt.Printf("Failed to umount %q: %v\n", builder.Container, err)
+		}
+	}()
+
+	input, err := archive.Tar(mountPoint, 0)
+	if err != nil {
+		return errors.Wrapf(err, "error reading directory %q", name)
+	}
+
+	outFile := os.Stdout
+	if c.IsSet("output") {
+		outfile := c.String("output")
+		outFile, err = os.Create(outfile)
+		if err != nil {
+			return errors.Wrapf(err, "error creating file %q", outfile)
+		}
+		defer outFile.Close()
+	}
+	if logrus.IsTerminal(outFile) {
+		return errors.Errorf("Refusing to save to a terminal. Use the -o flag or redirect.")
+	}
+
+	_, err = io.Copy(outFile, input)
+	return err
+}

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -78,6 +78,7 @@ func main() {
 		configCommand,
 		containersCommand,
 		copyCommand,
+		exportCommand,
 		fromCommand,
 		imagesCommand,
 		inspectCommand,

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -642,6 +642,18 @@ return 1
      "
 }
 
+ _buildah_export() {
+     local boolean_options="
+     --help
+     -h
+     "
+
+     local options_with_args="
+     -o
+     --output
+     "
+}
+
  _buildah() {
    local previous_extglob_setting=$(shopt -p extglob)
    shopt -s extglob
@@ -654,6 +666,7 @@ return 1
        config
        containers
        copy
+       export
        from
        images
        inspect

--- a/docs/buildah-export.md
+++ b/docs/buildah-export.md
@@ -1,0 +1,40 @@
+% BUILDAH(1) Buildah User Manuals
+% Buildah Community
+% JUNE 2017
+# NAME
+buildah-export - Export container's filesystem content as a tar archive
+
+# SYNOPSIS
+**buildah export**
+[**--help**]
+[**-o**|**--output**[=*""*]]
+CONTAINER
+
+# DESCRIPTION
+**buildah export** exports the full or shortened container ID or container name
+to STDOUT and should be redirected to a tar file.
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+**-o**, **--output**=""
+  Write to a file, instead of STDOUT
+
+# EXAMPLES
+Export the contents of the container called angry_bell to a tar file
+called angry_bell.tar:
+
+    # buildah export angry_bell > angry_bell.tar
+    # buildah export --output=angry_bell-latest.tar angry_bell
+    # ls -sh angry_bell.tar
+    321M angry_bell.tar
+    # ls -sh angry_bell-latest.tar
+    321M angry_bell-latest.tar
+
+# See also
+**buildah-import(1)** to create an empty filesystem image
+and import the contents of the tarball into it, then optionally tag it.
+
+# HISTORY
+July 2017, Originally copied from docker project docker-export.1.md

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -58,6 +58,7 @@ Print the version
 | buildah-config(1)     | Update image configuration settings.                                                                 |
 | buildah-containers(1) | List the working containers and their base images.                                                   |
 | buildah-copy(1)       | Copies the contents of a file, URL, or directory into a container's working directory.               |
+| buildah-export(1)     | Export the contents of a container's filesystem as a tar archive                                     |
 | buildah-from(1)       | Creates a new working container, either from scratch or using a specified image as a starting point. |
 | buildah-images(1)     | List images in local storage.                                                                        |
 | buildah-inspect(1)    | Inspects the configuration of a container or image                                                   |

--- a/tests/export.bats
+++ b/tests/export.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "extract" {
+  touch ${TESTDIR}/reference-time-file
+  for source in scratch alpine; do
+    cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json ${source})
+    mnt=$(buildah mount $cid)
+    touch ${mnt}/export.file
+    tar -cf - --transform s,^./,,g -C ${mnt} . | tar tf - | grep -v "^./$" | sort > ${TESTDIR}/tar.output
+    buildah umount $cid
+    buildah export "$cid" > ${TESTDIR}/${source}.tar
+    buildah export -o ${TESTDIR}/${source}1.tar "$cid"
+    diff ${TESTDIR}/${source}.tar ${TESTDIR}/${source}1.tar
+    tar -tf ${TESTDIR}/${source}.tar | sort > ${TESTDIR}/export.output
+    diff ${TESTDIR}/tar.output ${TESTDIR}/export.output
+    rm -f ${TESTDIR}/tar.output ${TESTDIR}/export.output
+    rm -f ${TESTDIR}/${source}1.tar ${TESTDIR}/${source}.tar
+    buildah rm "$cid"
+  done
+}


### PR DESCRIPTION
Will export the contents of a container as a tar ball.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>