### PR TITLE
gitignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+docs/buildah*.1
+/buildah
+/imgtype


### PR DESCRIPTION
* manpages
* buildah binary
* imgtype binary

I get annoyed by this listing:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        buildah
        docs/buildah-add.1
        docs/buildah-bud.1
        docs/buildah-commit.1
        docs/buildah-config.1
        docs/buildah-containers.1
        docs/buildah-copy.1
        docs/buildah-export.1
        docs/buildah-from.1
        docs/buildah-images.1
        docs/buildah-inspect.1
        docs/buildah-mount.1
        docs/buildah-push.1
        docs/buildah-rm.1
        docs/buildah-rmi.1
        docs/buildah-run.1
        docs/buildah-tag.1
        docs/buildah-umount.1
        docs/buildah-version.1
        docs/buildah.1
        imgtype
```