### PR TITLE
Add a "docker-daemon:" example to buildah-push(1)

### DIFF
--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -34,5 +34,7 @@ buildah push imageID oci-layout:/path/to/layout
 
 buildah push imageID docker://registry/repository:tag
 
+buildah push imageID docker-daemon:repository:tag
+
 ## SEE ALSO
 buildah(1)


### PR DESCRIPTION
Add an example invocation that pushes to the docker daemon to the buildah-push(1) man page, fixing an oversight caught in #184.