### PR TITLE
Add/Copy need to support glob syntax

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -206,3 +206,16 @@ load helpers
   run buildah --debug=false images -q
   [ "$output" = "" ]
 }
+
+@test "bud-from-glob" {
+  target=alpine-image
+  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile2.glob ${TESTSDIR}/bud/from-multiple-files
+  cid=$(buildah from ${target})
+  root=$(buildah mount ${cid})
+  cmp $root/Dockerfile1.alpine ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.alpine
+  cmp $root/Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.withfrom
+  buildah rm ${cid}
+  buildah rmi $(buildah --debug=false images -q)
+  run buildah --debug=false images -q
+  [ "$output" = "" ]
+}

--- a/tests/bud/from-multiple-files/Dockerfile2.glob
+++ b/tests/bud/from-multiple-files/Dockerfile2.glob
@@ -1,0 +1,2 @@
+FROM alpine
+COPY Dockerfile* /

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -21,6 +21,13 @@ load helpers
   buildah copy $cid ${TESTDIR}/randomfile
   buildah copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile /etc
   buildah rm $cid
+
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  root=$(buildah mount $cid)
+  buildah config --workingdir / $cid
+  buildah copy $cid "${TESTDIR}/*randomfile" /etc
+  (cd ${TESTDIR}; for i in *randomfile; do cmp $i ${root}/etc/$i; done)
+  buildah rm $cid
 }
 
 @test "copy-local-plain" {


### PR DESCRIPTION
This patch allows users to do
buildah add $ctr * /dest

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>