### PR TITLE
Add support for -- ending options parsing to buildah run

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -51,6 +51,9 @@ func runCmd(c *cli.Context) error {
 	}
 	name := args[0]
 	args = args.Tail()
+	if len(args) > 0 && args[0] == "--" {
+		args = args[1:]
+	}
 
 	runtime := ""
 	if c.IsSet("runtime") {

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -1,3 +1,4 @@
+
 ## buildah-run "1" "March 2017" "buildah"
 
 ## NAME
@@ -35,11 +36,14 @@ runtime, the manpage to consult is `runc(8)`)
 
 Bind mount a location from the host into the container for its lifetime.
 
+NOTE: End parsing of options with the `--` option, so that you can pass other 
+options to the command inside of the container
+
 ## EXAMPLE
 
-buildah run containerID 'ps -auxw'
+buildah run containerID -- ps -auxw
 
-buildah run containerID --runtime-flag --no-new-keyring 'ps -auxw'
+buildah run containerID --runtime-flag --no-new-keyring -- ps -auxw
 
 ## SEE ALSO
 buildah(1)

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -19,6 +19,17 @@ load helpers
 	buildah run        $cid cp /tmp/randomfile /tmp/other-randomfile
 	test -s $root/tmp/other-randomfile
 	cmp ${TESTDIR}/randomfile $root/tmp/other-randomfile
+	run buildah run $cid echo -n test
+	[ $status != 0 ]
+	run buildah run $cid echo -- -n test
+	[ $status != 0 ]
+	run buildah run $cid -- echo -n -- test
+	[ "$output" = "-- test" ]
+	run buildah run $cid -- echo -- -n test --
+	[ "$output" = "-- -n -- test --" ]
+	run buildah run $cid -- echo -n "test"
+	[ "$output" = "test" ]
+
 	buildah unmount $cid
 	buildah rm $cid
 }


### PR DESCRIPTION
If you specify an option in a buildah run command, the command fails.
The proper syntax for this is to add --

buildah run $ctr -- ls -l /

Signed-off-by: Dan Walsh <dwalsh@redhat.com>