### PR TITLE
Add credentials to buildah from

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ go:
     - tip
 dist: trusty
 sudo: required
+services:
+    - docker
 before_install:
     - sudo add-apt-repository -y ppa:duggan/bats
     - sudo apt-get -qq update

--- a/buildah.go
+++ b/buildah.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/opencontainers/image-spec/specs-go/v1"
@@ -122,6 +123,9 @@ type BuilderOptions struct {
 	// ReportWriter is an io.Writer which will be used to log the reading
 	// of the source image from a registry, if we end up pulling the image.
 	ReportWriter io.Writer
+	// github.com/containers/image/types SystemContext to hold credentials
+	// and other authentication/authorization information.
+	SystemContext *types.SystemContext
 }
 
 // ImportOptions are used to initialize a Builder from an existing container

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -20,6 +20,11 @@ var (
 			Usage: "don't compress layers",
 		},
 		cli.StringFlag{
+			Name:  "creds",
+			Value: "",
+			Usage: "use `username[:password]` for accessing the registry",
+		},
+		cli.StringFlag{
 			Name:  "signature-policy",
 			Usage: "`pathname` of signature policy file (not usually used)",
 		},

--- a/commit.go
+++ b/commit.go
@@ -249,7 +249,8 @@ func (b *Builder) Commit(dest types.ImageReference, options CommitOptions) error
 	}
 	if exporting {
 		// Copy everything.
-		err = cp.Image(policyContext, dest, src, getCopyOptions(options.ReportWriter))
+		// TODO: add credsContext
+		err = cp.Image(policyContext, dest, src, getCopyOptions(options.ReportWriter, nil, nil))
 		if err != nil {
 			return errors.Wrapf(err, "error copying layers and metadata")
 		}
@@ -321,7 +322,8 @@ func Push(image string, dest types.ImageReference, options PushOptions) error {
 		return errors.Wrapf(err, "error recomputing layer digests and building metadata")
 	}
 	// Copy everything.
-	err = cp.Image(policyContext, dest, src, getCopyOptions(options.ReportWriter))
+	// TODO: add credsContext
+	err = cp.Image(policyContext, dest, src, getCopyOptions(options.ReportWriter, nil, nil))
 	if err != nil {
 		return errors.Wrapf(err, "error copying layers and metadata")
 	}

--- a/common.go
+++ b/common.go
@@ -7,9 +7,11 @@ import (
 	"github.com/containers/image/types"
 )
 
-func getCopyOptions(reportWriter io.Writer) *cp.Options {
+func getCopyOptions(reportWriter io.Writer, sourceSystemContext *types.SystemContext, destinationSystemContext *types.SystemContext) *cp.Options {
 	return &cp.Options{
-		ReportWriter: reportWriter,
+		ReportWriter:   reportWriter,
+		SourceCtx:      sourceSystemContext,
+		DestinationCtx: destinationSystemContext,
 	}
 }
 

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -618,9 +618,12 @@ return 1
   "
 
      local options_with_args="
+     --cert-dir
+     --creds
      --name
      --transport
      --signature-policy
+     --tls-verify
   "
 
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -15,6 +15,14 @@ The container ID of the container that was created.  On error, -1 is returned an
 
 ## OPTIONS
 
+**--cert-dir** *path*
+
+Use certificates at *path* (*.crt, *.cert, *.key) to connect to the registry
+
+**--creds** *creds*
+
+The username and password to use to authenticate with the registry if required.
+
 **--name** *name*
 
 A *name* for the working container
@@ -41,6 +49,10 @@ Pathname of a signature policy file to use.  It is not recommended that this
 option be used, as the default behavior of using the system-wide default policy
 (frequently */etc/containers/policy.json*) is most often preferred.
 
+**--tls-verify** *bool-value*
+
+Require HTTPS and verify certificates when talking to container registries (defaults to true)
+
 **--quiet**
 
 If an image needs to be pulled from the registry, suppress progress output.
@@ -54,6 +66,8 @@ buildah from docker://myregistry.example.com/imagename --pull
 buildah from imagename --signature-policy /etc/containers/policy.json
 
 buildah from imagename --pull-always --transport "docker://myregistry.example.com/" --name "mycontainer"
+
+buildah from myregistry/myrepository/imagename:imagetag --creds=myusername:mypassword
 
 ## SEE ALSO
 buildah(1)

--- a/pull.go
+++ b/pull.go
@@ -109,6 +109,6 @@ func pullImage(store storage.Store, options BuilderOptions, sc *types.SystemCont
 
 	logrus.Debugf("copying %q to %q", spec, name)
 
-	err = cp.Image(policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter))
+	err = cp.Image(policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter, options.SystemContext, nil))
 	return destRef, err
 }


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

This adds the --creds parameter to the 'buildah from' command and stubs in a few other places.  Those places that need further work are marked with '// TOM: todo'.   The plan is to fix those up in a followup PR.  This new functionality does not have any tests for it yet, I'd like to do that as a follow up too, but can be persuaded otherwise.

Please don't merge this until I take another look in the morning and give it my LGTM.  The eyeballs are a bit glossy at the moment.