### PR TITLE
Fixes for rmi

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -96,7 +96,6 @@ func parseMetadata(image storage.Image) (imageMetadata, error) {
 }
 
 func getSize(image storage.Image, store storage.Store) (int64, error) {
-
 	is.Transport.SetStore(store)
 	storeRef, err := is.Transport.ParseStoreReference(store, "@"+image.ID)
 	if err != nil {
@@ -106,6 +105,7 @@ func getSize(image storage.Image, store storage.Store) (int64, error) {
 	if err != nil {
 		return -1, err
 	}
+	defer img.Close()
 	imgSize, err := img.Size()
 	if err != nil {
 		return -1, err

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -303,6 +303,7 @@ func matchesLabel(image storage.Image, store storage.Store, label string) bool {
 	if err != nil {
 		return false
 	}
+	defer img.Close()
 	info, err := img.Inspect()
 	if err != nil {
 		return false

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -350,8 +350,8 @@ func matchesSinceImage(image storage.Image, name string, params *filterParams) b
 	return false
 }
 
-func matchesID(id, argID string) bool {
-	return strings.HasPrefix(argID, id)
+func matchesID(imageID, argID string) bool {
+	return strings.HasPrefix(imageID, argID)
 }
 
 func matchesReference(name, argName string) bool {


### PR DESCRIPTION
* Switch to using storage APIs that don't bypass locking and synchronization.
* Properly close `Image` objects in a couple of places that we weren't.
* Look up images that may be specified using truncated IDs in `rmi`.
* Wrap some errors.