### PR TITLE
Makefile: "clean" should also remove test helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ imgtype: *.go docker/*.go util/*.go tests/imgtype.go
 
 .PHONY: clean
 clean:
-	$(RM) buildah
+	$(RM) buildah imgtype
 	$(MAKE) -C docs clean 
 
 .PHONY: docs


### PR DESCRIPTION
Make "make clean" also remove the `imgtype` test helper.