### PR TITLE
Don't panic if an image's ID can't be parsed

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -297,7 +297,7 @@ func matchesDangling(name string, dangling string) bool {
 func matchesLabel(image storage.Image, store storage.Store, label string) bool {
 	storeRef, err := is.Transport.ParseStoreReference(store, "@"+image.ID)
 	if err != nil {
-
+		return false
 	}
 	img, err := storeRef.NewImage(nil)
 	if err != nil {


### PR DESCRIPTION
Return a "doesn't match" result if an image's ID can't be turned into a valid reference for any reason.