### PR TITLE
Turn on --enable-gc when running gometalinter

### DIFF
--- a/tests/validate/gometalinter.sh
+++ b/tests/validate/gometalinter.sh
@@ -8,6 +8,7 @@ if ! which gometalinter.v1 > /dev/null 2> /dev/null ; then
 	exit 1
 fi
 exec gometalinter.v1 \
+	--enable-gc \
 	--exclude='error return value not checked.*(Close|Log|Print).*\(errcheck\)$' \
 	--exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$' \
 	--exclude='duplicate of.*_test.go.*\(dupl\)$' \


### PR DESCRIPTION
It looks like the metalinter is running out of memory while running tests under PAPR, so give this a try.