### PR TITLE
Remove --transport flag

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -17,11 +17,6 @@ var (
 			Name:  "quiet, q",
 			Usage: "refrain from announcing build instructions and image read/write progress",
 		},
-		cli.StringFlag{
-			Name:  "transport",
-			Usage: "prefix to prepend to the image name in order to pull the image",
-			Value: DefaultTransport,
-		},
 		cli.BoolTFlag{
 			Name:  "pull",
 			Usage: "pull the image if not present",
@@ -81,10 +76,6 @@ func budCmd(c *cli.Context) error {
 			output = tags[0]
 			tags = tags[1:]
 		}
-	}
-	transport := DefaultTransport
-	if c.IsSet("transport") {
-		transport = c.String("transport")
 	}
 	pull := true
 	if c.IsSet("pull") {
@@ -208,7 +199,6 @@ func budCmd(c *cli.Context) error {
 	options := imagebuildah.BuildOptions{
 		ContextDirectory:    contextDir,
 		PullPolicy:          pullPolicy,
-		Transport:           transport,
 		Compression:         imagebuildah.Gzip,
 		Quiet:               quiet,
 		SignaturePolicyPath: signaturePolicy,

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -9,13 +9,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-const (
-	// DefaultTransport is a prefix that we apply to an image name if we
-	// can't find one in the local Store, in order to generate a source
-	// reference for the image that we can then copy to the local Store.
-	DefaultTransport = "docker://"
-)
-
 var (
 	fromFlags = []cli.Flag{
 		cli.StringFlag{
@@ -29,11 +22,6 @@ var (
 		cli.BoolFlag{
 			Name:  "pull-always",
 			Usage: "pull the image even if one with the same name is already present",
-		},
-		cli.StringFlag{
-			Name:  "transport",
-			Usage: "`prefix` to prepend to the image name in order to pull the image",
-			Value: DefaultTransport,
 		},
 		cli.StringFlag{
 			Name:  "cert-dir",
@@ -81,10 +69,6 @@ func fromCmd(c *cli.Context) error {
 	}
 
 	image := args[0]
-	transport := DefaultTransport
-	if c.IsSet("transport") {
-		transport = c.String("transport")
-	}
 
 	systemContext, err := systemContextFromOptions(c)
 	if err != nil {
@@ -131,7 +115,6 @@ func fromCmd(c *cli.Context) error {
 		FromImage:           image,
 		Container:           name,
 		PullPolicy:          pullPolicy,
-		Transport:           transport,
 		SignaturePolicyPath: signaturePolicy,
 		SystemContext:       systemContext,
 	}

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -340,7 +340,6 @@ return 1
   "
 
      local options_with_args="
-     --transport
      --signature-policy
      --runtime
      --runtime-flag
@@ -621,7 +620,6 @@ return 1
      --cert-dir
      --creds
      --name
-     --transport
      --signature-policy
      --tls-verify
   "

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -35,12 +35,6 @@ Defaults to *true*.
 
 Pull the image even if a version of the image is already present.
 
-**--transport** *transport*
-
-A prefix to prepend to the image name in order to pull the image.  The default
-value is "docker://".  Note that no separator is implicitly added when the
-values are combined.
-
 **--signature-policy** *signaturepolicy*
 
 Pathname of a signature policy file to use.  It is not recommended that this

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -37,12 +37,6 @@ Defaults to *true*.
 
 Pull the image even if a version of the image is already present.
 
-**--transport** *transport*
-
-A prefix to prepend to the image name in order to pull the image.  The default
-value is "docker://".  Note that no separator is implicitly added when the
-values are combined.
-
 **--signature-policy** *signaturepolicy*
 
 Pathname of a signature policy file to use.  It is not recommended that this
@@ -59,13 +53,13 @@ If an image needs to be pulled from the registry, suppress progress output.
 
 ## EXAMPLE
 
-buildah from imagename --pull --transport "docker://myregistry.example.com/"
+buildah from imagename --pull
 
 buildah from docker://myregistry.example.com/imagename --pull
 
 buildah from imagename --signature-policy /etc/containers/policy.json
 
-buildah from imagename --pull-always --transport "docker://myregistry.example.com/" --name "mycontainer"
+buildah from docker://myregistry.example.com/imagename --pull-always --name "mycontainer"
 
 buildah from myregistry/myrepository/imagename:imagetag --creds=myusername:mypassword
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -8,7 +8,28 @@ buildah from - Creates a new working container, either from scratch or using a s
 
 ## DESCRIPTION
 Creates a working container based upon the specified image name.  If the
-supplied image name is "scratch" a new empty container is created.
+supplied image name is "scratch" a new empty container is created. Image names
+uses a "transport":"details" format.
+
+Multiple transports are supported:
+
+  **dir:**_path_
+  An existing local directory _path_ retrieving the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
+
+  **docker://**_docker-reference_ (Default)
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$HOME/.docker/config.json`, which is set e.g. using `(docker login)`.
+
+  **docker-archive:**_path_
+  An image is retrieved as a `docker load` formatted file.
+
+  **docker-daemon:**_docker-reference_
+  An image _docker-reference_ stored in the docker daemon internal storage.  _docker-reference_ must contain either a tag or a digest.  Alternatively, when reading images, the format can also be docker-daemon:algo:digest (an image ID).
+
+  **oci:**_path_**:**_tag_
+  An image _tag_ in a directory compliant with "Open Container Image Layout Specification" at _path_.
+
+  **ostree:**_image_[**@**_/absolute/repo/path_]
+  An image in local OSTree repository.  _/absolute/repo/path_ defaults to _/ostree/repo_.
 
 ## RETURN VALUE
 The container ID of the container that was created.  On error, -1 is returned and errno is returned.

--- a/new.go
+++ b/new.go
@@ -18,6 +18,11 @@ const (
 	// BaseImageFakeName is the "name" of a source image which we interpret
 	// as "no image".
 	BaseImageFakeName = imagebuilder.NoBaseImageSpecifier
+
+	// DefaultTransport is a prefix that we apply to an image name if we
+	// can't find one in the local Store, in order to generate a source
+	// reference for the image that we can then copy to the local Store.
+	DefaultTransport = "docker://"
 )
 
 func newBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
@@ -31,6 +36,10 @@ func newBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
 		options.FromImage = ""
 	}
 	image := options.FromImage
+
+	if options.Transport == "" {
+		options.Transport = DefaultTransport
+	}
 
 	systemContext := getSystemContext(options.SignaturePolicyPath)
 

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -24,12 +24,12 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${elsewhere}
   buildah rm $cid
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --transport dir: ${elsewhere})
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere})
   buildah rm $cid
   buildah rmi ${elsewhere}
   [ "$cid" = elsewhere-img-working-container ]
 
-  cid=$(buildah from --pull-always --signature-policy ${TESTSDIR}/policy.json --transport dir: ${elsewhere})
+  cid=$(buildah from --pull-always --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere})
   buildah rm $cid
   buildah rmi ${elsewhere}
   [ "$cid" = `basename ${elsewhere}`-working-container ]


### PR DESCRIPTION
This is no simpler then putting the transport in the image page,
we should default to the registry specified in containers/image
and not override it.  People are confused by this option, and I
see no value.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>