### PR TITLE
Improve "from" behavior with unnamed references

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -103,8 +103,13 @@ type BuilderOptions struct {
 	PullPolicy int
 	// Registry is a value which is prepended to the image's name, if it
 	// needs to be pulled and the image name alone can not be resolved to a
-	// reference to a source image.
+	// reference to a source image.  No separator is implicitly added.
 	Registry string
+	// Transport is a value which is prepended to the image's name, if it
+	// needs to be pulled and the image name alone, or the image name and
+	// the registry together, can not be resolved to a reference to a
+	// source image.  No separator is implicitly added.
+	Transport string
 	// Mount signals to NewBuilder() that the container should be mounted
 	// immediately.
 	Mount bool

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -18,9 +18,9 @@ var (
 			Usage: "refrain from announcing build instructions and image read/write progress",
 		},
 		cli.StringFlag{
-			Name:  "registry",
+			Name:  "transport",
 			Usage: "prefix to prepend to the image name in order to pull the image",
-			Value: DefaultRegistry,
+			Value: DefaultTransport,
 		},
 		cli.BoolTFlag{
 			Name:  "pull",
@@ -82,9 +82,9 @@ func budCmd(c *cli.Context) error {
 			tags = tags[1:]
 		}
 	}
-	registry := DefaultRegistry
-	if c.IsSet("registry") {
-		registry = c.String("registry")
+	transport := DefaultTransport
+	if c.IsSet("transport") {
+		transport = c.String("transport")
 	}
 	pull := true
 	if c.IsSet("pull") {
@@ -208,7 +208,7 @@ func budCmd(c *cli.Context) error {
 	options := imagebuildah.BuildOptions{
 		ContextDirectory:    contextDir,
 		PullPolicy:          pullPolicy,
-		Registry:            registry,
+		Transport:           transport,
 		Compression:         imagebuildah.Gzip,
 		Quiet:               quiet,
 		SignaturePolicyPath: signaturePolicy,

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	// DefaultRegistry is a prefix that we apply to an image name if we
+	// DefaultTransport is a prefix that we apply to an image name if we
 	// can't find one in the local Store, in order to generate a source
 	// reference for the image that we can then copy to the local Store.
-	DefaultRegistry = "docker://"
+	DefaultTransport = "docker://"
 )
 
 var (
@@ -31,9 +31,9 @@ var (
 			Usage: "pull the image even if one with the same name is already present",
 		},
 		cli.StringFlag{
-			Name:  "registry",
+			Name:  "transport",
 			Usage: "`prefix` to prepend to the image name in order to pull the image",
-			Value: DefaultRegistry,
+			Value: DefaultTransport,
 		},
 		cli.StringFlag{
 			Name:  "signature-policy",
@@ -67,9 +67,9 @@ func fromCmd(c *cli.Context) error {
 	}
 	image := args[0]
 
-	registry := DefaultRegistry
-	if c.IsSet("registry") {
-		registry = c.String("registry")
+	transport := DefaultTransport
+	if c.IsSet("transport") {
+		transport = c.String("transport")
 	}
 	pull := true
 	if c.IsSet("pull") {
@@ -111,7 +111,7 @@ func fromCmd(c *cli.Context) error {
 		FromImage:           image,
 		Container:           name,
 		PullPolicy:          pullPolicy,
-		Registry:            registry,
+		Transport:           transport,
 		SignaturePolicyPath: signaturePolicy,
 	}
 	if !quiet {

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -340,7 +340,7 @@ return 1
   "
 
      local options_with_args="
-     --registry
+     --transport
      --signature-policy
      --runtime
      --runtime-flag
@@ -619,7 +619,7 @@ return 1
 
      local options_with_args="
      --name
-     --registry
+     --transport
      --signature-policy
   "
 

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -35,10 +35,11 @@ Defaults to *true*.
 
 Pull the image even if a version of the image is already present.
 
-**--registry** *registry*
+**--transport** *transport*
 
-A prefix to prepend to the image name in order to pull the image.  Default
-value is "docker://"
+A prefix to prepend to the image name in order to pull the image.  The default
+value is "docker://".  Note that no separator is implicitly added when the
+values are combined.
 
 **--signature-policy** *signaturepolicy*
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -29,10 +29,11 @@ Defaults to *true*.
 
 Pull the image even if a version of the image is already present.
 
-**--registry** *registry*
+**--transport** *transport*
 
-A prefix to prepend to the image name in order to pull the image.  Default
-value is "docker://"
+A prefix to prepend to the image name in order to pull the image.  The default
+value is "docker://".  Note that no separator is implicitly added when the
+values are combined.
 
 **--signature-policy** *signaturepolicy*
 
@@ -46,13 +47,13 @@ If an image needs to be pulled from the registry, suppress progress output.
 
 ## EXAMPLE
 
-buildah from imagename --pull --registry "myregistry://"
+buildah from imagename --pull --transport "docker://myregistry.example.com/"
 
-buildah from myregistry://imagename --pull
+buildah from docker://myregistry.example.com/imagename --pull
 
 buildah from imagename --signature-policy /etc/containers/policy.json
 
-buildah from imagename --pull-always --registry "myregistry://" --name "mycontainer"
+buildah from imagename --pull-always --transport "docker://myregistry.example.com/" --name "mycontainer"
 
 ## SEE ALSO
 buildah(1)

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -51,8 +51,13 @@ type BuildOptions struct {
 	PullPolicy int
 	// Registry is a value which is prepended to the image's name, if it
 	// needs to be pulled and the image name alone can not be resolved to a
-	// reference to a source image.
+	// reference to a source image.  No separator is implicitly added.
 	Registry string
+	// Transport is a value which is prepended to the image's name, if it
+	// needs to be pulled and the image name alone, or the image name and
+	// the registry together, can not be resolved to a reference to a
+	// source image.  No separator is implicitly added.
+	Transport string
 	// IgnoreUnrecognizedInstructions tells us to just log instructions we
 	// don't recognize, and try to keep going.
 	IgnoreUnrecognizedInstructions bool
@@ -108,6 +113,7 @@ type Executor struct {
 	builder                        *buildah.Builder
 	pullPolicy                     int
 	registry                       string
+	transport                      string
 	ignoreUnrecognizedInstructions bool
 	quiet                          bool
 	runtime                        string
@@ -403,6 +409,7 @@ func NewExecutor(store storage.Store, options BuildOptions) (*Executor, error) {
 		contextDir:                     options.ContextDirectory,
 		pullPolicy:                     options.PullPolicy,
 		registry:                       options.Registry,
+		transport:                      options.Transport,
 		ignoreUnrecognizedInstructions: options.IgnoreUnrecognizedInstructions,
 		quiet:               options.Quiet,
 		runtime:             options.Runtime,
@@ -458,6 +465,7 @@ func (b *Executor) Prepare(ib *imagebuilder.Builder, node *parser.Node, from str
 		FromImage:           from,
 		PullPolicy:          b.pullPolicy,
 		Registry:            b.registry,
+		Transport:           b.transport,
 		SignaturePolicyPath: b.signaturePolicyPath,
 		ReportWriter:        b.reportWriter,
 	}

--- a/new.go
+++ b/new.go
@@ -48,7 +48,11 @@ func newBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
 			if err2 != nil {
 				srcRef2, err3 := alltransports.ParseImageName(options.Registry + image)
 				if err3 != nil {
-					return nil, errors.Wrapf(err3, "error parsing image name %q", options.Registry+image)
+					srcRef3, err4 := alltransports.ParseImageName(options.Transport + options.Registry + image)
+					if err4 != nil {
+						return nil, errors.Wrapf(err4, "error parsing image name %q", options.Transport+options.Registry+image)
+					}
+					srcRef2 = srcRef3
 				}
 				srcRef = srcRef2
 			}

--- a/pull.go
+++ b/pull.go
@@ -1,18 +1,59 @@
 package buildah
 
 import (
+	"strings"
+
 	"github.com/Sirupsen/logrus"
 	cp "github.com/containers/image/copy"
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/signature"
 	is "github.com/containers/image/storage"
+	"github.com/containers/image/transports"
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	"github.com/pkg/errors"
 )
 
-func pullImage(store storage.Store, options BuilderOptions, sc *types.SystemContext) error {
+func localImageNameForReference(store storage.Store, srcRef types.ImageReference) (string, error) {
+	if srcRef == nil {
+		return "", errors.Errorf("reference to image is empty")
+	}
+	ref := srcRef.DockerReference()
+	if ref == nil {
+		name := srcRef.StringWithinTransport()
+		_, err := is.Transport.ParseStoreReference(store, name)
+		if err == nil {
+			return name, nil
+		}
+		if strings.LastIndex(name, "/") != -1 {
+			name = name[strings.LastIndex(name, "/")+1:]
+			_, err = is.Transport.ParseStoreReference(store, name)
+			if err == nil {
+				return name, nil
+			}
+		}
+		return "", errors.Errorf("reference to image %q is not a named reference", transports.ImageName(srcRef))
+	}
+
+	name := ""
+	if named, ok := ref.(reference.Named); ok {
+		name = named.Name()
+		if namedTagged, ok := ref.(reference.NamedTagged); ok {
+			name = name + ":" + namedTagged.Tag()
+		}
+		if canonical, ok := ref.(reference.Canonical); ok {
+			name = name + "@" + canonical.Digest().String()
+		}
+	}
+
+	if _, err := is.Transport.ParseStoreReference(store, name); err != nil {
+		return "", errors.Wrapf(err, "error parsing computed local image name %q", name)
+	}
+	return name, nil
+}
+
+func pullImage(store storage.Store, options BuilderOptions, sc *types.SystemContext) (types.ImageReference, error) {
 	name := options.FromImage
 
 	spec := name
@@ -24,35 +65,36 @@ func pullImage(store storage.Store, options BuilderOptions, sc *types.SystemCont
 	if err != nil {
 		srcRef2, err2 := alltransports.ParseImageName(spec)
 		if err2 != nil {
-			return errors.Wrapf(err2, "error parsing image name %q", spec)
+			return nil, errors.Wrapf(err2, "error parsing image name %q", spec)
 		}
 		srcRef = srcRef2
 	}
 
-	if ref := srcRef.DockerReference(); ref != nil {
-		name = srcRef.DockerReference().Name()
-		if tagged, ok := srcRef.DockerReference().(reference.NamedTagged); ok {
-			name = name + ":" + tagged.Tag()
-		}
+	destName, err := localImageNameForReference(store, srcRef)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error computing local image name for %q", transports.ImageName(srcRef))
+	}
+	if destName == "" {
+		return nil, errors.Errorf("error computing local image name for %q", transports.ImageName(srcRef))
 	}
 
-	destRef, err := is.Transport.ParseStoreReference(store, name)
+	destRef, err := is.Transport.ParseStoreReference(store, destName)
 	if err != nil {
-		return errors.Wrapf(err, "error parsing full image name %q", name)
+		return nil, errors.Wrapf(err, "error parsing image name %q", destName)
 	}
 
 	policy, err := signature.DefaultPolicy(sc)
 	if err != nil {
-		return err
+		return nil, errors.Wrapf(err, "error obtaining default signature policy")
 	}
 
 	policyContext, err := signature.NewPolicyContext(policy)
 	if err != nil {
-		return err
+		return nil, errors.Wrapf(err, "error creating new signature policy context")
 	}
 
 	logrus.Debugf("copying %q to %q", spec, name)
 
 	err = cp.Image(policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter))
-	return err
+	return destRef, err
 }

--- a/pull.go
+++ b/pull.go
@@ -60,12 +60,20 @@ func pullImage(store storage.Store, options BuilderOptions, sc *types.SystemCont
 	if options.Registry != "" {
 		spec = options.Registry + spec
 	}
+	spec2 := spec
+	if options.Transport != "" {
+		spec2 = options.Transport + spec
+	}
 
 	srcRef, err := alltransports.ParseImageName(name)
 	if err != nil {
 		srcRef2, err2 := alltransports.ParseImageName(spec)
 		if err2 != nil {
-			return nil, errors.Wrapf(err2, "error parsing image name %q", spec)
+			srcRef3, err3 := alltransports.ParseImageName(spec2)
+			if err3 != nil {
+				return nil, errors.Wrapf(err3, "error parsing image name %q", spec2)
+			}
+			srcRef2 = srcRef3
 		}
 		srcRef = srcRef2
 	}
@@ -93,7 +101,7 @@ func pullImage(store storage.Store, options BuilderOptions, sc *types.SystemCont
 		return nil, errors.Wrapf(err, "error creating new signature policy context")
 	}
 
-	logrus.Debugf("copying %q to %q", spec, name)
+	logrus.Debugf("copying %q to %q", transports.ImageName(srcRef), transports.ImageName(destRef))
 
 	err = cp.Image(policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter))
 	return destRef, err

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -19,4 +19,18 @@ load helpers
   buildah rm $cid
   buildah rmi ${elsewhere}
   [ "$cid" = `basename ${elsewhere}`-working-container ]
+
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${elsewhere}
+  buildah rm $cid
+
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --transport dir: ${elsewhere})
+  buildah rm $cid
+  buildah rmi ${elsewhere}
+  [ "$cid" = elsewhere-img-working-container ]
+
+  cid=$(buildah from --pull-always --signature-policy ${TESTSDIR}/policy.json --transport dir: ${elsewhere})
+  buildah rm $cid
+  buildah rmi ${elsewhere}
+  [ "$cid" = `basename ${elsewhere}`-working-container ]
 }

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "commit-to-from-elsewhere" {
+  elsewhere=${TESTDIR}/elsewhere-img
+  mkdir -p ${elsewhere}
+
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${elsewhere}
+  buildah rm $cid
+
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere})
+  buildah rm $cid
+  buildah rmi ${elsewhere}
+  [ "$cid" = elsewhere-img-working-container ]
+
+  cid=$(buildah from --pull-always --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere})
+  buildah rm $cid
+  buildah rmi ${elsewhere}
+  [ "$cid" = `basename ${elsewhere}`-working-container ]
+}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -7,7 +7,7 @@ STORAGE_DRIVER=${STORAGE_DRIVER:-vfs}
 PATH=$(dirname ${BASH_SOURCE})/..:${PATH}
 
 function setup() {
-	suffix=$(dd if=/dev/urandom bs=12 count=1 status=none | base64 | tr +/ _.)
+	suffix=$(dd if=/dev/urandom bs=12 count=1 status=none | base64 | tr +/ABCDEFGHIJKLMNOPQRSTUVWXYZ _.abcdefghijklmnopqrstuvwxyz)
 	TESTDIR=${BATS_TMPDIR}/tmp.${suffix}
 	rm -fr ${TESTDIR}
 	mkdir -p ${TESTDIR}/{root,runroot}


### PR DESCRIPTION
Fix our instantiation behavior when the source image reference is not a named reference.  Take the opportunity to rename the `--registry` CLI flag to `--transport`.