### PR TITLE
Run(): create the right working directory

### DIFF
--- a/run.go
+++ b/run.go
@@ -219,8 +219,8 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	if spec.Process.Cwd == "" {
 		spec.Process.Cwd = DefaultWorkingDir
 	}
-	if err = os.MkdirAll(filepath.Join(mountPoint, b.WorkDir()), 0755); err != nil {
-		return errors.Wrapf(err, "error ensuring working directory %q exists", b.WorkDir())
+	if err = os.MkdirAll(filepath.Join(mountPoint, spec.Process.Cwd), 0755); err != nil {
+		return errors.Wrapf(err, "error ensuring working directory %q exists", spec.Process.Cwd)
 	}
 
 	bindFiles := []string{"/etc/hosts", "/etc/resolv.conf"}


### PR DESCRIPTION
When ensuring that the working directory exists before running a command, make sure we create the location that we actually set in the configuration file that we passed to runc.