### PR TITLE
Run: don't complain about missing volume locations

### DIFF
--- a/run.go
+++ b/run.go
@@ -120,7 +120,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, optionMounts 
 				return errors.Wrapf(err, "error creating directory %q for volume %q in container %q", volumePath, volume, b.ContainerID)
 			}
 			srcPath := filepath.Join(mountPoint, volume)
-			if err = archive.CopyWithTar(srcPath, volumePath); err != nil {
+			if err = archive.CopyWithTar(srcPath, volumePath); err != nil && !os.IsNotExist(err) {
 				return errors.Wrapf(err, "error populating directory %q for volume %q in container %q using contents of %q", volumePath, volume, b.ContainerID, srcPath)
 			}
 


### PR DESCRIPTION
Don't worry about not being able to populate temporary volumes using the contents of the location in the image where they're expected to be mounted if we fail to do so because that location doesn't exist.