### PR TITLE
Auto-set build tags for ostree and selinux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ before_install:
     - sudo apt-get -qq install bats btrfs-tools git libapparmor-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libselinux1-dev
     - sudo apt-get -qq remove libseccomp2
 script:
-    - make install.tools install.libseccomp.sudo all runc validate TAGS="containers_image_ostree_stub apparmor seccomp"
+    - make install.tools install.libseccomp.sudo all runc validate TAGS="apparmor seccomp"
     - cd tests; sudo PATH="$PATH" ./test_runner.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-AUTOTAGS := $(shell ./btrfs_tag.sh) $(shell ./libdm_tag.sh)
+AUTOTAGS := $(shell ./btrfs_tag.sh) $(shell ./libdm_tag.sh) $(shell ./ostree_tag.sh) $(shell ./selinux_tag.sh)
 TAGS := seccomp
 PREFIX := /usr/local
 BINDIR := $(PREFIX)/bin

--- a/ostree_tag.sh
+++ b/ostree_tag.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+if ! pkg-config ostree-1 2> /dev/null ; then
+	echo containers_image_ostree_stub
+fi

--- a/selinux_tag.sh
+++ b/selinux_tag.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+if pkg-config libselinux 2> /dev/null ; then
+	echo selinux
+fi


### PR DESCRIPTION
Try to use pkg-config to check for 'ostree-1' and 'libselinux'.

If ostree-1 is not found, use the containers_image_ostree_stub build tag to not require it, at the cost of not being able to use or write images to the 'ostree' transport.

If libselinux is found, build with the 'selinux' tag,