### PR TITLE
Avoid trying to print a nil ImageReference

### DIFF
--- a/new.go
+++ b/new.go
@@ -86,10 +86,11 @@ func newBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
 			if errors.Cause(err) == storage.ErrImageUnknown && options.PullPolicy != PullIfMissing {
 				return nil, errors.Wrapf(err, "no such image %q", transports.ImageName(ref))
 			}
-			ref, err = pullImage(store, options, systemContext)
-			if err != nil {
-				return nil, errors.Wrapf(err, "error pulling image %q", transports.ImageName(ref))
+			ref2, err2 := pullImage(store, options, systemContext)
+			if err2 != nil {
+				return nil, errors.Wrapf(err2, "error pulling image %q", image)
 			}
+			ref = ref2
 			img, err = is.Transport.GetStoreImage(store, ref)
 		}
 		if err != nil {


### PR DESCRIPTION
When we fail to pull an image, don't try to include the name of the image that pullImage() returned in the error text - it will have returned nil for the pulled reference in most cases.  Instead, use the name of the image as we were told it.