### PR TITLE
Add default transport to push if not provided

### DIFF
--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -88,9 +88,20 @@ func pushCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
 	dest, err := alltransports.ParseImageName(destSpec)
+	// add the docker:// transport to see if they neglected it.
 	if err != nil {
-		return err
+		if strings.Contains(destSpec, "://") {
+			return err
+		}
+
+		destSpec = "docker://" + destSpec
+		dest2, err2 := alltransports.ParseImageName(destSpec)
+		if err2 != nil {
+			return err
+		}
+		dest = dest2
 	}
 
 	systemContext, err := systemContextFromOptions(c)

--- a/tests/test_buildah_authentication.sh
+++ b/tests/test_buildah_authentication.sh
@@ -8,7 +8,8 @@
 ########
 # Create creds and store in /root/auth/htpasswd
 ########
-docker run --entrypoint htpasswd registry:2 -Bbn testuser testpassword > /root/auth/htpasswd
+registry=$(buildah from registry:2)
+buildah run $registry -- htpasswd -Bbn testuser testpassword > /root/auth/htpasswd
 
 ########
 # Create certificate via openssl
@@ -93,12 +94,12 @@ docker logout localhost:5000
 buildah push --cert-dir /root/auth --tls-verify=true alpine docker://localhost:5000/my-alpine
 
 ########
-# Push using creds and certs, this should work.
+# Push using creds, certs and no transport, this should work.
 ########
-buildah push --cert-dir ~/auth --tls-verify=true --creds=testuser:testpassword alpine docker://localhost:5000/my-alpine
+buildah push --cert-dir ~/auth --tls-verify=true --creds=testuser:testpassword alpine localhost:5000/my-alpine
 
 ########
-# This should fail, no creds anywhere, only the certificate
+# No creds anywhere, only the certificate, this should fail.
 ########
 buildah from localhost:5000/my-alpine --cert-dir /root/auth  --tls-verify=true
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Currently with 'buildah push' if the transport is not defined, it will fail.  This change will retry if a transport was not found by adding "docker://" to the front of the destination image and retrying.

I tweaked a test in the test script to test for this condition and also converted the creation of htpasswd from Docker to Buildah.  I tried running the registry with Buildah too, but 'docker login' wasn't happy.  More investigation there in  a follow up.