### PR TITLE
Cleanup buildah code

### DIFF
--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -18,58 +18,58 @@ const (
 
 var (
 	configFlags = []cli.Flag{
-		cli.StringFlag{
-			Name:  "author",
-			Usage: "image author contact `information`",
-		},
-		cli.StringFlag{
-			Name:  "created-by",
-			Usage: "`description` of how the image was created",
-			Value: DefaultCreatedBy,
+		cli.StringSliceFlag{
+			Name:  "annotation, a",
+			Usage: "add `annotation` e.g. annotation=value, for the target image",
 		},
 		cli.StringFlag{
 			Name:  "arch",
-			Usage: "`architecture` of the target image",
+			Usage: "set `architecture` of the target image",
 		},
 		cli.StringFlag{
-			Name:  "os",
-			Usage: "`operating system` of the target image",
-		},
-		cli.StringFlag{
-			Name:  "user, u",
-			Usage: "`user` to run containers based on image as",
-		},
-		cli.StringSliceFlag{
-			Name:  "port, p",
-			Usage: "`port` to expose when running containers based on image",
-		},
-		cli.StringSliceFlag{
-			Name:  "env, e",
-			Usage: "`environment variable` to set when running containers based on image",
-		},
-		cli.StringFlag{
-			Name:  "entrypoint",
-			Usage: "`entry point` for containers based on image",
+			Name:  "author",
+			Usage: "set image author contact `information`",
 		},
 		cli.StringFlag{
 			Name:  "cmd",
-			Usage: "`command` for containers based on image",
-		},
-		cli.StringSliceFlag{
-			Name:  "volume, v",
-			Usage: "`volume` to create for containers based on image",
+			Usage: "sets the default `command` to run for containers based on the image",
 		},
 		cli.StringFlag{
-			Name:  "workingdir",
-			Usage: "working `directory` for containers based on image",
+			Name:  "created-by",
+			Usage: "add `description` of how the image was created",
+			Value: DefaultCreatedBy,
+		},
+		cli.StringFlag{
+			Name:  "entrypoint",
+			Usage: "set `entry point` for containers based on image",
+		},
+		cli.StringSliceFlag{
+			Name:  "env, e",
+			Usage: "add `environment variable` to be set when running containers based on image",
 		},
 		cli.StringSliceFlag{
 			Name:  "label, l",
-			Usage: "image configuration `label` e.g. label=value",
+			Usage: "add image configuration `label` e.g. label=value",
+		},
+		cli.StringFlag{
+			Name:  "os",
+			Usage: "set `operating system` of the target image",
 		},
 		cli.StringSliceFlag{
-			Name:  "annotation, a",
-			Usage: "`annotation` e.g. annotation=value, for the target image",
+			Name:  "port, p",
+			Usage: "add `port` to expose when running containers based on image",
+		},
+		cli.StringFlag{
+			Name:  "user, u",
+			Usage: "set default `user` to run inside containers based on image",
+		},
+		cli.StringSliceFlag{
+			Name:  "volume, v",
+			Usage: "add default `volume` path to be created for containers based on image",
+		},
+		cli.StringFlag{
+			Name:  "workingdir",
+			Usage: "set working `directory` for containers based on image",
 		},
 	}
 	configDescription = "Modifies the configuration values which will be saved to the image"

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -27,6 +27,10 @@ func main() {
 		defaultStoreDriverOptions = &optionSlice
 	}
 	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "debug",
+			Usage: "print debugging information",
+		},
 		cli.StringFlag{
 			Name:  "root",
 			Usage: "storage root dir",
@@ -47,17 +51,11 @@ func main() {
 			Usage: "storage driver option",
 			Value: defaultStoreDriverOptions,
 		},
-		cli.BoolFlag{
-			Name:  "debug",
-			Usage: "print debugging information",
-		},
 	}
 	app.Before = func(c *cli.Context) error {
 		logrus.SetLevel(logrus.ErrorLevel)
-		if c.GlobalIsSet("debug") {
-			if c.GlobalBool("debug") {
-				logrus.SetLevel(logrus.DebugLevel)
-			}
+		if c.GlobalBool("debug") {
+			logrus.SetLevel(logrus.DebugLevel)
 		}
 		return nil
 	}

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -35,10 +35,7 @@ func mountCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	truncate := true
-	if c.IsSet("notruncate") {
-		truncate = !c.Bool("notruncate")
-	}
+	truncate := !c.Bool("notruncate")
 
 	if len(args) == 1 {
 		name := args[0]

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -31,10 +31,7 @@ var (
 )
 
 func rmiCmd(c *cli.Context) error {
-	force := false
-	if c.IsSet("force") {
-		force = c.Bool("force")
-	}
+	force := c.Bool("force")
 
 	args := c.Args()
 	if len(args) == 0 {

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -59,19 +59,6 @@ func runCmd(c *cli.Context) error {
 		args = args[1:]
 	}
 
-	runtime := ""
-	if c.IsSet("runtime") {
-		runtime = c.String("runtime")
-	}
-	flags := []string{}
-	if c.IsSet("runtime-flag") {
-		flags = c.StringSlice("runtime-flag")
-	}
-	volumes := []string{}
-	if c.IsSet("v") || c.IsSet("volume") {
-		volumes = c.StringSlice("volume")
-	}
-
 	store, err := getStore(c)
 	if err != nil {
 		return err
@@ -84,19 +71,17 @@ func runCmd(c *cli.Context) error {
 
 	options := buildah.RunOptions{
 		Hostname: c.String("hostname"),
-		Runtime:  runtime,
-		Args:     flags,
+		Runtime:  c.String("runtime"),
+		Args:     c.StringSlice("runtime-flag"),
 	}
 
-	if c.IsSet("tty") {
-		if c.Bool("tty") {
-			options.Terminal = buildah.WithTerminal
-		} else {
-			options.Terminal = buildah.WithoutTerminal
-		}
+	if c.Bool("tty") {
+		options.Terminal = buildah.WithTerminal
+	} else {
+		options.Terminal = buildah.WithoutTerminal
 	}
 
-	for _, volumeSpec := range volumes {
+	for _, volumeSpec := range c.StringSlice("volume") {
 		volSpec := strings.Split(volumeSpec, ":")
 		if len(volSpec) >= 2 {
 			mountOptions := "bind"

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -14,6 +14,13 @@ to a temporary location.
 
 ## OPTIONS
 
+**--build-arg** *arg=value*
+
+Specifies a build argument and its value, which will be interpolated in
+instructions read from the Dockerfiles in the same way that environment
+variables are, but which will not be added to environment variable list in the
+resulting image's configuration.
+
 **-f, --file** *Dockerfile*
 
 Specifies a Dockerfile which contains instructions for building the image,
@@ -25,6 +32,12 @@ If a build context is not specified, and at least one Dockerfile is a
 local file, the directory in which it resides will be used as the build
 context.
 
+**--format**
+
+Control the format for the built image's manifest and configuration data.
+Recognized formats include *oci* (OCI image-spec v1.0, the default) and
+*docker* (version 2, using schema format 2 for the manifest).
+
 **--pull**
 
 Pull the image if it is not present.  If this flag is disabled (with
@@ -35,18 +48,11 @@ Defaults to *true*.
 
 Pull the image even if a version of the image is already present.
 
-**--signature-policy** *signaturepolicy*
+**--quiet**
 
-Pathname of a signature policy file to use.  It is not recommended that this
-option be used, as the default behavior of using the system-wide default policy
-(frequently */etc/containers/policy.json*) is most often preferred.
-
-**--build-arg** *arg=value*
-
-Specifies a build argument and its value, which will be interpolated in
-instructions read from the Dockerfiles in the same way that environment
-variables are, but which will not be added to environment variable list in the
-resulting image's configuration.
+Suppress output messages which indicate which instruction is being processed,
+and of progress when pulling images from a registry, and when writing the
+output image.
 
 **--runtime** *path*
 
@@ -57,22 +63,16 @@ commands specified by the **RUN** instruction.
 
 Adds global flags for the container rutime.
 
+**--signature-policy** *signaturepolicy*
+
+Pathname of a signature policy file to use.  It is not recommended that this
+option be used, as the default behavior of using the system-wide default policy
+(frequently */etc/containers/policy.json*) is most often preferred.
+
 **-t, --tag** *imageName*
 
 Specifies the name which will be assigned to the resulting image if the build
 process completes successfully.
-
-**--format**
-
-Control the format for the built image's manifest and configuration data.
-Recognized formats include *oci* (OCI image-spec v1.0, the default) and
-*docker* (version 2, using schema format 2 for the manifest).
-
-**--quiet**
-
-Suppress output messages which indicate which instruction is being processed,
-and of progress when pulling images from a registry, and when writing the
-output image.
 
 ## EXAMPLE
 

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -25,6 +25,21 @@ The username[:password] to use to authenticate with the registry if required.
 
 Don't compress filesystem layers when building the image.
 
+
+**--format**
+
+Control the format for the image manifest and configuration data.  Recognized
+formats include *oci* (OCI image-spec v1.0, the default) and *docker* (version
+2, using schema format 2 for the manifest).
+
+**--quiet**
+
+When writing the output image, suppress progress output.
+
+**--rm**
+Remove the container and its content after committing it to an image.
+Default leaves the container and its content in place.
+
 **--signature-policy**
 
 Pathname of a signature policy file to use.  It is not recommended that this
@@ -34,20 +49,6 @@ option be used, as the default behavior of using the system-wide default policy
 **--tls-verify** *bool-value*
 
 Require HTTPS and verify certificates when talking to container registries (defaults to true)
-
-**--quiet**
-
-When writing the output image, suppress progress output.
-
-**--format**
-
-Control the format for the image manifest and configuration data.  Recognized
-formats include *oci* (OCI image-spec v1.0, the default) and *docker* (version
-2, using schema format 2 for the manifest).
-
-**--rm**
-Remove the container and its content after committing it to an image.
-Default leaves the container and its content in place.
 
 ## EXAMPLE
 

--- a/docs/buildah-containers.md
+++ b/docs/buildah-containers.md
@@ -12,6 +12,11 @@ IDs, and the names and IDs of the images from which they were initialized.
 
 ## OPTIONS
 
+**--all, -a**
+
+List information about all containers, including those which were not created
+by and are not being used by buildah.
+
 **--json**
 
 Output in JSON format.
@@ -27,11 +32,6 @@ Do not truncate IDs in output.
 **--quiet, -q**
 
 Displays only the container IDs.
-
-**--all, -a**
-
-List information about all containers, including those which were not created
-by and are not being used by buildah.
 
 ## EXAMPLE
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -58,6 +58,10 @@ Defaults to *true*.
 
 Pull the image even if a version of the image is already present.
 
+**--quiet**
+
+If an image needs to be pulled from the registry, suppress progress output.
+
 **--signature-policy** *signaturepolicy*
 
 Pathname of a signature policy file to use.  It is not recommended that this
@@ -67,10 +71,6 @@ option be used, as the default behavior of using the system-wide default policy
 **--tls-verify** *bool-value*
 
 Require HTTPS and verify certificates when talking to container registries (defaults to true)
-
-**--quiet**
-
-If an image needs to be pulled from the registry, suppress progress output.
 
 ## EXAMPLE
 

--- a/docs/buildah-images.md
+++ b/docs/buildah-images.md
@@ -11,10 +11,6 @@ Displays locally stored images, their names, and their IDs.
 
 ## OPTIONS
 
-**--json**
-
-Display the output in JSON format.
-
 **--digests**
 
 Show the image digests.
@@ -27,6 +23,10 @@ keywords are 'dangling', 'label', 'before' and 'since'.
 **--format="TEMPLATE"**
 
 Pretty-print images using a Go template.  Will override --quiet
+
+**--json**
+
+Display the output in JSON format.
 
 **--noheading, -n**
 

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -52,6 +52,10 @@ The username[:password] to use to authenticate with the registry if required.
 
 Don't compress copies of filesystem layers which will be pushed.
 
+**--quiet**
+
+When writing the output image, suppress progress output.
+
 **--signature-policy**
 
 Pathname of a signature policy file to use.  It is not recommended that this
@@ -61,10 +65,6 @@ option be used, as the default behavior of using the system-wide default policy
 **--tls-verify** *bool-value*
 
 Require HTTPS and verify certificates when talking to container registries (defaults to true)
-
-**--quiet**
-
-When writing the output image, suppress progress output.
 
 ## EXAMPLE
 

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -18,6 +18,14 @@ The buildah package provides a command line tool which can be used to:
 
 ## OPTIONS
 
+**--debug**
+
+Print debugging information
+
+**--help, -h**
+
+Show help
+
 **--root** **value**
 
 Storage root dir (default: "/var/lib/containers/storage")
@@ -33,14 +41,6 @@ Storage driver
 **--storage-opt** **value**
 
 Storage driver option
-
-**--debug**
-
-Print debugging information
-
-**--help, -h**
-
-Show help
 
 **--version, -v**
 


### PR DESCRIPTION
1. Sort options so they are in alphabet order
2. Remove extra lines of code for options parsing that really do not accomplish anything.
3. Remove variables when they are not necesary, IE Don't create a variable to hold an
option that is only used once, use the option instead.
