### PR TITLE
Cleanup

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -164,6 +164,9 @@ func budCmd(c *cli.Context) error {
 	if len(dockerfiles) == 0 {
 		dockerfiles = append(dockerfiles, filepath.Join(contextDir, "Dockerfile"))
 	}
+	if err := validateFlags(c, budFlags); err != nil {
+		return err
+	}
 
 	store, err := getStore(c)
 	if err != nil {

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -81,6 +81,9 @@ func commitCmd(c *cli.Context) error {
 		return errors.Errorf("too many arguments specified")
 	}
 	image := args[0]
+	if err := validateFlags(c, commitFlags); err != nil {
+		return err
+	}
 
 	compress := archive.Gzip
 	if c.Bool("disable-compression") {

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -171,6 +171,9 @@ func configCmd(c *cli.Context) error {
 		return errors.Errorf("too many arguments specified")
 	}
 	name := args[0]
+	if err := validateFlags(c, configFlags); err != nil {
+		return err
+	}
 
 	store, err := getStore(c)
 	if err != nil {

--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -52,6 +52,9 @@ var (
 )
 
 func containersCmd(c *cli.Context) error {
+	if err := validateFlags(c, containersFlags); err != nil {
+		return err
+	}
 	store, err := getStore(c)
 	if err != nil {
 		return err

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -67,6 +67,9 @@ func fromCmd(c *cli.Context) error {
 	if len(args) > 1 {
 		return errors.Errorf("too many arguments specified")
 	}
+	if err := validateFlags(c, fromFlags); err != nil {
+		return err
+	}
 
 	systemContext, err := systemContextFromOptions(c)
 	if err != nil {

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -83,6 +83,9 @@ var (
 )
 
 func imagesCmd(c *cli.Context) error {
+	if err := validateFlags(c, imagesFlags); err != nil {
+		return err
+	}
 	store, err := getStore(c)
 	if err != nil {
 		return err

--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -52,6 +52,9 @@ func inspectCmd(c *cli.Context) error {
 	if len(args) > 1 {
 		return errors.Errorf("too many arguments specified")
 	}
+	if err := validateFlags(c, inspectFlags); err != nil {
+		return err
+	}
 
 	format := defaultFormat
 	if c.String("format") != "" {

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -13,6 +13,8 @@ import (
 )
 
 func main() {
+	debug := false
+
 	var defaultStoreDriverOptions *cli.StringSlice
 	if buildah.InitReexec() {
 		return
@@ -55,6 +57,7 @@ func main() {
 	app.Before = func(c *cli.Context) error {
 		logrus.SetLevel(logrus.ErrorLevel)
 		if c.GlobalBool("debug") {
+			debug = true
 			logrus.SetLevel(logrus.DebugLevel)
 		}
 		return nil
@@ -90,7 +93,11 @@ func main() {
 	}
 	err := app.Run(os.Args)
 	if err != nil {
-		logrus.Errorf("%v", err)
-		os.Exit(1)
+		if debug {
+			logrus.Errorf(err.Error())
+		} else {
+			fmt.Fprintln(os.Stderr, err.Error())
+		}
+		cli.OsExiter(1)
 	}
 }

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -30,6 +30,9 @@ func mountCmd(c *cli.Context) error {
 	if len(args) > 1 {
 		return errors.Errorf("too many arguments specified")
 	}
+	if err := validateFlags(c, mountFlags); err != nil {
+		return err
+	}
 
 	store, err := getStore(c)
 	if err != nil {

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -68,6 +68,9 @@ func pushCmd(c *cli.Context) error {
 	if len(args) < 2 {
 		return errors.New("source and destination image IDs must be specified")
 	}
+	if err := validateFlags(c, pushFlags); err != nil {
+		return err
+	}
 	src := args[0]
 	destSpec := args[1]
 

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -37,6 +37,9 @@ func rmiCmd(c *cli.Context) error {
 	if len(args) == 0 {
 		return errors.Errorf("image name or ID must be specified")
 	}
+	if err := validateFlags(c, rmiFlags); err != nil {
+		return err
+	}
 
 	store, err := getStore(c)
 	if err != nil {

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -54,6 +54,10 @@ func runCmd(c *cli.Context) error {
 		return errors.Errorf("container ID must be specified")
 	}
 	name := args[0]
+	if err := validateFlags(c, runFlags); err != nil {
+		return err
+	}
+
 	args = args.Tail()
 	if len(args) > 0 && args[0] == "--" {
 		args = args[1:]


### PR DESCRIPTION
 Only print logrus if in debug mode 

 Validate options

If an string option is passed in, and it is not followed by a value,
then error out with a message saying the option requires a value.

For example

buildah from --creds --pull dan
option --creds requires a value

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>