### PR TITLE
Make sure pushing ends up with CLI on a fresh new line

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -2,6 +2,7 @@ package buildah
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"time"
 
@@ -330,6 +331,9 @@ func Push(image string, dest types.ImageReference, options PushOptions) error {
 	err = cp.Image(policyContext, dest, src, getCopyOptions(options.ReportWriter, nil, options.SystemContext))
 	if err != nil {
 		return errors.Wrapf(err, "error copying layers and metadata")
+	}
+	if options.ReportWriter != nil {
+		fmt.Fprintf(options.ReportWriter, "\n")
 	}
 	return nil
 }


### PR DESCRIPTION
While doing a buildah push I ended up not on a new line.
```
 buildah push securepipe docker-daemon:securepipe:latest
Getting image source signatures
Copying blob sha256:00ddb097f3f5c1afe2bc6bc6af1ffb9d2f75b300709f69cf02ded0c66318848e
 50.47 MiB / 75.60 MiB [====================================>------------------]
Copying blob sha256:357837eab19610a6282147b6fbba874278ed99aa8eafea0c9a219b3c1559edc9
 108.06 MiB / 123.84 MiB [==============================================>------]
Copying config sha256:1d5f00eae5c8d45c7bc7243310f5b68960f1aeb1f36d8d10b7c1cb31165baa25
 0 B / 1.96 KiB [--------------------------------------------------------------]
Writing manifest to image destination
Storing signatures
 1.96 KiB / 1.96 KiB [=========================================================]sh-4.4#
```

This patch will end up printing a new line if user does not specify quiet. 
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>