### PR TITLE
Add further tty verbiage to buildah run

### DIFF
--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -1,4 +1,3 @@
-
 ## buildah-run "1" "March 2017" "buildah"
 
 ## NAME
@@ -11,7 +10,8 @@ buildah run - Run a command inside of the container.
 Launches a container and runs the specified command in that container using the
 container's root filesystem as a root filesystem, using configuration settings
 inherited from the container's image or as specified using previous calls to
-the *buildah config* command.
+the *buildah config* command.  If you execute *buildah run* and expect an
+interactive shell, you need to specify the --tty flag.
 
 ## OPTIONS
 
@@ -31,8 +31,9 @@ runtime, the manpage to consult is `runc(8)`)
 **--tty**
 
 By default a pseudo-TTY is allocated only when buildah's standard input is
-attached to a pseudo-TTY. Setting the `--tty` option to `true` will cause a
-pseudo-TTY to be allocated inside the container. Setting the `--tty` option to
+attached to a pseudo-TTY.  Setting the `--tty` option to `true` will cause a
+pseudo-TTY to be allocated inside the container connecting the user's "terminal"
+with the stdin and stdout stream of the container.  Setting the `--tty` option to
 `false` will prevent the pseudo-TTY from being allocated.
 
 **--volume, -v** *source*:*destination*:*flags*
@@ -49,6 +50,10 @@ buildah run containerID -- ps -auxw
 buildah run containerID --hostname myhost -- ps -auxw
 
 buildah run containerID --runtime-flag --no-new-keyring -- ps -auxw
+
+buildah run --tty containerID /bin/bash
+
+buildah run --tty=false containerID ls /
 
 ## SEE ALSO
 buildah(1)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Added verbiage to the tty parameter to try and add a little clarity to it's use.  We recently had an issue raised and this parameter fixed the issue but that was not clear that it would do so.