### PR TITLE
Make inspect try an image on failure if type not specified

### DIFF
--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -73,7 +73,13 @@ func inspectCmd(c *cli.Context) error {
 	case inspectTypeContainer:
 		builder, err = openBuilder(store, name)
 		if err != nil {
-			return errors.Wrapf(err, "error reading build container %q", name)
+			if c.IsSet("type") {
+				return errors.Wrapf(err, "error reading build container %q", name)
+			}
+			builder, err = openImage(store, name)
+			if err != nil {
+				return errors.Wrapf(err, "error reading build object %q", name)
+			}
 		}
 	case inspectTypeImage:
 		builder, err = openImage(store, name)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

When doing "buildah inspect {imageID}" one would receive an error saying the container was not found.  If you did "buildah inspect --type={imageID}" the output for the image would be found.  This change will have inspect check to see if the id that was passed in is an image if the lookup for the container fails AND the type parameter is not provided.  

This aligns the functionality to the man page documentation and addresses issue #212  