### PR TITLE
images: don't list unnamed images twice

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -210,7 +210,7 @@ func outputImages(images []storage.Image, format string, store storage.Store, fi
 			}
 		}
 
-		names := []string{""}
+		names := []string{}
 		if len(image.Names) > 0 {
 			names = image.Names
 		} else {


### PR DESCRIPTION
The "images" command was erroneously listing images that don't have names twice, once with no name, and a second time with "<none>" as a placeholder.  Fixes #279.