### PR TITLE
Run unit tests in CI

### DIFF
--- a/.papr.sh
+++ b/.papr.sh
@@ -15,6 +15,7 @@ dnf install -y \
   findutils \
   git \
   glib2-devel \
+  gnupg \
   golang \
   gpgme-devel \
   libassuan-devel \
@@ -28,5 +29,4 @@ dnf install -y \
 # short-commit-subject validation test, so tell git-validate.sh to only check
 # up to, but not including, the merge commit.
 export GITVALIDATE_TIP=$(cd $GOSRC; git log -2 --pretty='%H' | tail -n 1)
-make -C $GOSRC install.tools runc all validate TAGS="seccomp"
-$GOSRC/tests/test_runner.sh
+make -C $GOSRC install.tools runc all validate test-unit test-integration TAGS="seccomp"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,6 @@ before_install:
     - sudo apt-get -qq remove libseccomp2
 script:
     - make install.tools install.libseccomp.sudo all runc validate TAGS="apparmor seccomp"
+    - go test -c -tags "apparmor seccomp `./btrfs_tag.sh` `./libdm_tag.sh` `./ostree_tag.sh` `./selinux_tag.sh`" ./cmd/buildah
+    - tmp=`mktemp -d`; mkdir $tmp/root $tmp/runroot; sudo PATH="$PATH" ./buildah.test -test.v -root $tmp/root -runroot $tmp/runroot -storage-driver vfs -signature-policy `pwd`/tests/policy.json
     - cd tests; sudo PATH="$PATH" ./test_runner.sh

--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,13 @@ install:
 .PHONY: install.completions
 install.completions:
 	install -m 644 -D contrib/completions/bash/buildah $(DESTDIR)/${BASHINSTALLDIR}/buildah
+
+.PHONY: test-integration
+test-integration:
+	cd tests; ./test_runner.sh
+
+.PHONY: test-unit
+test-unit:
+	tmp=$(shell mktemp -d) ; \
+	mkdir -p $$tmp/root $$tmp/runroot; \
+	$(GO) test -v -tags "$(AUTOTAGS) $(TAGS)" ./cmd/buildah -args -root $$tmp/root -runroot $$tmp/runroot -storage-driver vfs -signature-policy $(shell pwd)/tests/policy.json

--- a/cmd/buildah/common_test.go
+++ b/cmd/buildah/common_test.go
@@ -74,7 +74,7 @@ func failTestIfNotRoot(t *testing.T) {
 	}
 }
 
-func pullTestImage(t *testing.T, imageName string) error {
+func pullTestImage(t *testing.T, imageName string) (string, error) {
 	store, err := storage.GetStore(storage.DefaultStoreOptions)
 	if err != nil {
 		t.Fatal(err)
@@ -88,5 +88,10 @@ func pullTestImage(t *testing.T, imageName string) error {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return b.Delete()
+	id := b.FromImageID
+	err = b.Delete()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id, nil
 }

--- a/cmd/buildah/common_test.go
+++ b/cmd/buildah/common_test.go
@@ -54,6 +54,12 @@ func TestGetSize(t *testing.T) {
 		is.Transport.SetStore(store)
 	}
 
+	// Pull an image so that we know we have at least one
+	_, err = pullTestImage(t, "busybox:latest")
+	if err != nil {
+		t.Fatalf("could not pull image to remove: %v", err)
+	}
+
 	images, err := store.Images()
 	if err != nil {
 		t.Fatalf("Error reading images: %v", err)

--- a/cmd/buildah/common_test.go
+++ b/cmd/buildah/common_test.go
@@ -6,6 +6,7 @@ import (
 	"os/user"
 	"testing"
 
+	"github.com/Sirupsen/logrus"
 	is "github.com/containers/image/storage"
 	"github.com/containers/storage"
 	"github.com/projectatomic/buildah"
@@ -14,13 +15,27 @@ import (
 
 var (
 	signaturePolicyPath = ""
+	storeOptions        = storage.DefaultStoreOptions
 )
 
 func TestMain(m *testing.M) {
 	flag.StringVar(&signaturePolicyPath, "signature-policy", "", "pathname of signature policy file (not usually used)")
+	options := storage.StoreOptions{}
+	debug := false
+	flag.StringVar(&options.GraphRoot, "root", "", "storage root dir")
+	flag.StringVar(&options.RunRoot, "runroot", "", "storage state dir")
+	flag.StringVar(&options.GraphDriverName, "storage-driver", "", "storage driver")
+	flag.BoolVar(&debug, "debug", false, "turn on debug logging")
 	flag.Parse()
+	if options.GraphRoot != "" || options.RunRoot != "" || options.GraphDriverName != "" {
+		storeOptions = options
+	}
 	if buildah.InitReexec() {
 		return
+	}
+	logrus.SetLevel(logrus.ErrorLevel)
+	if debug {
+		logrus.SetLevel(logrus.DebugLevel)
 	}
 	os.Exit(m.Run())
 }
@@ -31,9 +46,14 @@ func TestGetStore(t *testing.T) {
 
 	set := flag.NewFlagSet("test", 0)
 	globalSet := flag.NewFlagSet("test", 0)
-	globalSet.String("root", "", "path to the root directory in which data, including images,  is stored")
+	globalSet.String("root", "", "path to the directory in which data, including images, is stored")
+	globalSet.String("runroot", "", "path to the directory in which state is stored")
+	globalSet.String("storage-driver", "", "storage driver")
 	globalCtx := cli.NewContext(nil, globalSet, nil)
-	command := cli.Command{Name: "imagesCommand"}
+	globalCtx.GlobalSet("root", storeOptions.GraphRoot)
+	globalCtx.GlobalSet("runroot", storeOptions.RunRoot)
+	globalCtx.GlobalSet("storage-driver", storeOptions.GraphDriverName)
+	command := cli.Command{Name: "TestGetStore"}
 	c := cli.NewContext(nil, set, globalCtx)
 	c.Command = command
 
@@ -47,7 +67,7 @@ func TestGetSize(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -81,7 +101,7 @@ func failTestIfNotRoot(t *testing.T) {
 }
 
 func pullTestImage(t *testing.T, imageName string) (string, error) {
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -163,7 +163,7 @@ func TestOutputImagesQuietTruncated(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -197,7 +197,7 @@ func TestOutputImagesQuietNotTruncated(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -231,7 +231,7 @@ func TestOutputImagesFormatString(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -265,7 +265,7 @@ func TestOutputImagesFormatTemplate(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -299,7 +299,7 @@ func TestOutputImagesArgNoMatch(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -335,7 +335,7 @@ func TestOutputMultipleImages(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -373,7 +373,7 @@ func TestParseFilterAllParams(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -427,7 +427,7 @@ func TestParseFilterInvalidDangling(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -454,7 +454,7 @@ func TestParseFilterInvalidBefore(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -481,7 +481,7 @@ func TestParseFilterInvalidSince(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -508,7 +508,7 @@ func TestParseFilterInvalidFilter(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -563,7 +563,7 @@ func TestMatchesBeforeImageTrue(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -594,7 +594,7 @@ func TestMatchesBeforeImageFalse(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -624,7 +624,7 @@ func TestMatchesSinceeImageTrue(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {
@@ -653,7 +653,7 @@ func TestMatchesSinceImageFalse(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	store, err := storage.GetStore(storage.DefaultStoreOptions)
+	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
 	} else if store != nil {

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -175,6 +175,12 @@ func TestOutputImagesQuietTruncated(t *testing.T) {
 		t.Fatalf("Error reading images: %v", err)
 	}
 
+	// Pull an image so that we know we have at least one
+	_, err = pullTestImage(t, "busybox:latest")
+	if err != nil {
+		t.Fatalf("could not pull image to remove: %v", err)
+	}
+
 	// Tests quiet and truncated output
 	output, err := captureOutputWithError(func() error {
 		return outputImages(images[:1], "", store, nil, "", false, true, false, true)
@@ -196,6 +202,12 @@ func TestOutputImagesQuietNotTruncated(t *testing.T) {
 		t.Fatal(err)
 	} else if store != nil {
 		is.Transport.SetStore(store)
+	}
+
+	// Pull an image so that we know we have at least one
+	_, err = pullTestImage(t, "busybox:latest")
+	if err != nil {
+		t.Fatalf("could not pull image to remove: %v", err)
 	}
 
 	images, err := store.Images()
@@ -226,6 +238,12 @@ func TestOutputImagesFormatString(t *testing.T) {
 		is.Transport.SetStore(store)
 	}
 
+	// Pull an image so that we know we have at least one
+	_, err = pullTestImage(t, "busybox:latest")
+	if err != nil {
+		t.Fatalf("could not pull image to remove: %v", err)
+	}
+
 	images, err := store.Images()
 	if err != nil {
 		t.Fatalf("Error reading images: %v", err)
@@ -252,6 +270,12 @@ func TestOutputImagesFormatTemplate(t *testing.T) {
 		t.Fatal(err)
 	} else if store != nil {
 		is.Transport.SetStore(store)
+	}
+
+	// Pull an image so that we know we have at least one
+	_, err = pullTestImage(t, "busybox:latest")
+	if err != nil {
+		t.Fatalf("could not pull image to remove: %v", err)
 	}
 
 	images, err := store.Images()
@@ -282,6 +306,12 @@ func TestOutputImagesArgNoMatch(t *testing.T) {
 		is.Transport.SetStore(store)
 	}
 
+	// Pull an image so that we know we have at least one
+	_, err = pullTestImage(t, "busybox:latest")
+	if err != nil {
+		t.Fatalf("could not pull image to remove: %v", err)
+	}
+
 	images, err := store.Images()
 	if err != nil {
 		t.Fatalf("Error reading images: %v", err)
@@ -310,6 +340,16 @@ func TestOutputMultipleImages(t *testing.T) {
 		t.Fatal(err)
 	} else if store != nil {
 		is.Transport.SetStore(store)
+	}
+
+	// Pull two images so that we know we have at least two
+	_, err = pullTestImage(t, "busybox:latest")
+	if err != nil {
+		t.Fatalf("could not pull image to remove: %v", err)
+	}
+	_, err = pullTestImage(t, "alpine:latest")
+	if err != nil {
+		t.Fatalf("could not pull image to remove: %v", err)
 	}
 
 	images, err := store.Images()
@@ -529,6 +569,13 @@ func TestMatchesBeforeImageTrue(t *testing.T) {
 	} else if store != nil {
 		is.Transport.SetStore(store)
 	}
+
+	// Pull an image so that we know we have at least one
+	_, err = pullTestImage(t, "busybox:latest")
+	if err != nil {
+		t.Fatalf("could not pull image to remove: %v", err)
+	}
+
 	images, err := store.Images()
 	if err != nil {
 		t.Fatalf("Error reading images: %v", err)
@@ -552,6 +599,11 @@ func TestMatchesBeforeImageFalse(t *testing.T) {
 		t.Fatal(err)
 	} else if store != nil {
 		is.Transport.SetStore(store)
+	}
+	// Pull an image so that we know we have at least one
+	_, err = pullTestImage(t, "busybox:latest")
+	if err != nil {
+		t.Fatalf("could not pull image to remove: %v", err)
 	}
 	images, err := store.Images()
 	if err != nil {
@@ -578,6 +630,11 @@ func TestMatchesSinceeImageTrue(t *testing.T) {
 	} else if store != nil {
 		is.Transport.SetStore(store)
 	}
+	// Pull an image so that we know we have at least one
+	_, err = pullTestImage(t, "busybox:latest")
+	if err != nil {
+		t.Fatalf("could not pull image to remove: %v", err)
+	}
 	images, err := store.Images()
 	if err != nil {
 		t.Fatalf("Error reading images: %v", err)
@@ -601,6 +658,11 @@ func TestMatchesSinceImageFalse(t *testing.T) {
 		t.Fatal(err)
 	} else if store != nil {
 		is.Transport.SetStore(store)
+	}
+	// Pull an image so that we know we have at least one
+	_, err = pullTestImage(t, "busybox:latest")
+	if err != nil {
+		t.Fatalf("could not pull image to remove: %v", err)
 	}
 	images, err := store.Images()
 	if err != nil {

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -62,7 +62,7 @@ func TestFormatStringOutput(t *testing.T) {
 	output := captureOutput(func() {
 		outputUsingFormatString(true, true, params)
 	})
-	expectedOutput := fmt.Sprintf("%-12.12s %-40s %-64s %-22s %s\n", params.ID, params.Name, params.Digest, params.CreatedAt, params.Size)
+	expectedOutput := fmt.Sprintf("%-20.12s %-56s %-64s %-22s %s\n", params.ID, params.Name, params.Digest, params.CreatedAt, params.Size)
 	if output != expectedOutput {
 		t.Errorf("Error outputting using format string:\n\texpected: %s\n\treceived: %s\n", expectedOutput, output)
 	}
@@ -89,7 +89,7 @@ func TestOutputHeader(t *testing.T) {
 	output := captureOutput(func() {
 		outputHeader(true, false)
 	})
-	expectedOutput := fmt.Sprintf("%-12s %-40s %-22s %s\n", "IMAGE ID", "IMAGE NAME", "CREATED AT", "SIZE")
+	expectedOutput := fmt.Sprintf("%-20s %-56s %-22s %s\n", "IMAGE ID", "IMAGE NAME", "CREATED AT", "SIZE")
 	if output != expectedOutput {
 		t.Errorf("Error outputting header:\n\texpected: %s\n\treceived: %s\n", expectedOutput, output)
 	}
@@ -97,7 +97,7 @@ func TestOutputHeader(t *testing.T) {
 	output = captureOutput(func() {
 		outputHeader(true, true)
 	})
-	expectedOutput = fmt.Sprintf("%-12s %-40s %-64s %-22s %s\n", "IMAGE ID", "IMAGE NAME", "DIGEST", "CREATED AT", "SIZE")
+	expectedOutput = fmt.Sprintf("%-20s %-56s %-64s %-22s %s\n", "IMAGE ID", "IMAGE NAME", "DIGEST", "CREATED AT", "SIZE")
 	if output != expectedOutput {
 		t.Errorf("Error outputting header:\n\texpected: %s\n\treceived: %s\n", expectedOutput, output)
 	}
@@ -105,7 +105,7 @@ func TestOutputHeader(t *testing.T) {
 	output = captureOutput(func() {
 		outputHeader(false, false)
 	})
-	expectedOutput = fmt.Sprintf("%-64s %-40s %-22s %s\n", "IMAGE ID", "IMAGE NAME", "CREATED AT", "SIZE")
+	expectedOutput = fmt.Sprintf("%-64s %-56s %-22s %s\n", "IMAGE ID", "IMAGE NAME", "CREATED AT", "SIZE")
 	if output != expectedOutput {
 		t.Errorf("Error outputting header:\n\texpected: %s\n\treceived: %s\n", expectedOutput, output)
 	}

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -344,7 +344,7 @@ func TestParseFilterAllParams(t *testing.T) {
 		t.Fatalf("Error reading images: %v", err)
 	}
 	// Pull an image so we know we have it
-	err = pullTestImage("busybox:latest")
+	err = pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatalf("could not pull image to remove: %v", err)
 	}
@@ -352,7 +352,7 @@ func TestParseFilterAllParams(t *testing.T) {
 	label := "dangling=true,label=a=b,before=busybox:latest,since=busybox:latest,reference=abcdef"
 	params, err := parseFilter(images, label)
 	if err != nil {
-		t.Fatalf("error parsing filter")
+		t.Fatalf("error parsing filter: %v", err)
 	}
 
 	expectedParams := &filterParams{dangling: "true", label: "a=b", beforeImage: "busybox:latest", sinceImage: "busybox:latest", referencePattern: "abcdef"}
@@ -376,7 +376,7 @@ func TestParseFilterInvalidDangling(t *testing.T) {
 		t.Fatalf("Error reading images: %v", err)
 	}
 	// Pull an image so we know we have it
-	err = pullTestImage("busybox:latest")
+	err = pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatalf("could not pull image to remove: %v", err)
 	}
@@ -403,7 +403,7 @@ func TestParseFilterInvalidBefore(t *testing.T) {
 		t.Fatalf("Error reading images: %v", err)
 	}
 	// Pull an image so we know we have it
-	err = pullTestImage("busybox:latest")
+	err = pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatalf("could not pull image to remove: %v", err)
 	}
@@ -430,7 +430,7 @@ func TestParseFilterInvalidSince(t *testing.T) {
 		t.Fatalf("Error reading images: %v", err)
 	}
 	// Pull an image so we know we have it
-	err = pullTestImage("busybox:latest")
+	err = pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatalf("could not pull image to remove: %v", err)
 	}
@@ -457,7 +457,7 @@ func TestParseFilterInvalidFilter(t *testing.T) {
 		t.Fatalf("Error reading images: %v", err)
 	}
 	// Pull an image so we know we have it
-	err = pullTestImage("busybox:latest")
+	err = pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatalf("could not pull image to remove: %v", err)
 	}

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/Sirupsen/logrus"
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/transports/alltransports"
@@ -58,7 +59,10 @@ func rmiCmd(c *cli.Context) error {
 			}
 			if len(ctrIDs) > 0 && len(image.Names) <= 1 {
 				if force {
-					removeContainers(ctrIDs, store)
+					err = removeContainers(ctrIDs, store)
+					if err != nil {
+						return errors.Wrapf(err, "error removing containers %v for image %q", ctrIDs, id)
+					}
 				} else {
 					for _, ctrID := range ctrIDs {
 						return fmt.Errorf("Could not remove image %q (must force) - container %q is using its reference image", id, ctrID)
@@ -98,16 +102,16 @@ func getImage(id string, store storage.Store) (*storage.Image, error) {
 	var ref types.ImageReference
 	ref, err := properImageRef(id)
 	if err != nil {
-		//logrus.Debug(err)
+		logrus.Debug(err)
 	}
 	if ref == nil {
 		if ref, err = storageImageRef(store, id); err != nil {
-			//logrus.Debug(err)
+			logrus.Debug(err)
 		}
 	}
 	if ref == nil {
 		if ref, err = storageImageID(store, id); err != nil {
-			//logrus.Debug(err)
+			logrus.Debug(err)
 		}
 	}
 	if ref != nil {

--- a/cmd/buildah/rmi_test.go
+++ b/cmd/buildah/rmi_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestProperImageRefTrue(t *testing.T) {
 	// Pull an image so we know we have it
-	err := pullTestImage("busybox:latest")
+	err := pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatalf("could not pull image to remove")
 	}
@@ -25,7 +25,7 @@ func TestProperImageRefTrue(t *testing.T) {
 
 func TestProperImageRefFalse(t *testing.T) {
 	// Pull an image so we know we have it
-	err := pullTestImage("busybox:latest")
+	err := pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatal("could not pull image to remove")
 	}
@@ -49,7 +49,7 @@ func TestStorageImageRefTrue(t *testing.T) {
 		t.Fatalf("could not get store: %v", err)
 	}
 	// Pull an image so we know we have it
-	err = pullTestImage("busybox:latest")
+	err = pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatalf("could not pull image to remove: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestStorageImageRefFalse(t *testing.T) {
 		t.Fatalf("could not get store: %v", err)
 	}
 	// Pull an image so we know we have it
-	err = pullTestImage("busybox:latest")
+	err = pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatalf("could not pull image to remove: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestStorageImageIDTrue(t *testing.T) {
 		t.Fatalf("could not get store: %v", err)
 	}
 	// Pull an image so we know we have it
-	err = pullTestImage("busybox:latest")
+	err = pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatalf("could not pull image to remove: %v", err)
 	}

--- a/cmd/buildah/rmi_test.go
+++ b/cmd/buildah/rmi_test.go
@@ -40,8 +40,7 @@ func TestStorageImageRefTrue(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	options := storage.DefaultStoreOptions
-	store, err := storage.GetStore(options)
+	store, err := storage.GetStore(storeOptions)
 	if store != nil {
 		is.Transport.SetStore(store)
 	}
@@ -65,8 +64,7 @@ func TestStorageImageRefFalse(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	options := storage.DefaultStoreOptions
-	store, err := storage.GetStore(options)
+	store, err := storage.GetStore(storeOptions)
 	if store != nil {
 		is.Transport.SetStore(store)
 	}
@@ -88,8 +86,7 @@ func TestStorageImageIDTrue(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	options := storage.DefaultStoreOptions
-	store, err := storage.GetStore(options)
+	store, err := storage.GetStore(storeOptions)
 	if store != nil {
 		is.Transport.SetStore(store)
 	}
@@ -126,8 +123,7 @@ func TestStorageImageIDFalse(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	options := storage.DefaultStoreOptions
-	store, err := storage.GetStore(options)
+	store, err := storage.GetStore(storeOptions)
 	if store != nil {
 		is.Transport.SetStore(store)
 	}

--- a/cmd/buildah/rmi_test.go
+++ b/cmd/buildah/rmi_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestProperImageRefTrue(t *testing.T) {
 	// Pull an image so we know we have it
-	err := pullTestImage(t, "busybox:latest")
+	_, err := pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatalf("could not pull image to remove")
 	}
@@ -25,7 +25,7 @@ func TestProperImageRefTrue(t *testing.T) {
 
 func TestProperImageRefFalse(t *testing.T) {
 	// Pull an image so we know we have it
-	err := pullTestImage(t, "busybox:latest")
+	_, err := pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatal("could not pull image to remove")
 	}
@@ -49,7 +49,7 @@ func TestStorageImageRefTrue(t *testing.T) {
 		t.Fatalf("could not get store: %v", err)
 	}
 	// Pull an image so we know we have it
-	err = pullTestImage(t, "busybox:latest")
+	_, err = pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatalf("could not pull image to remove: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestStorageImageRefFalse(t *testing.T) {
 		t.Fatalf("could not get store: %v", err)
 	}
 	// Pull an image so we know we have it
-	err = pullTestImage(t, "busybox:latest")
+	_, err = pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatalf("could not pull image to remove: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestStorageImageIDTrue(t *testing.T) {
 		t.Fatalf("could not get store: %v", err)
 	}
 	// Pull an image so we know we have it
-	err = pullTestImage(t, "busybox:latest")
+	_, err = pullTestImage(t, "busybox:latest")
 	if err != nil {
 		t.Fatalf("could not pull image to remove: %v", err)
 	}


### PR DESCRIPTION
This patch set fixes up the unit tests (updating filter parsing to prefer the creation timestamp in the image), and updates our CI configurations to run them.