### PR TITLE
Fix list images with digest not aligned

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -207,7 +207,7 @@ func outputHeader(truncate, digests bool) {
 	}
 
 	if digests {
-		fmt.Printf("%-64s ", "DIGEST")
+		fmt.Printf("%-71s ", "DIGEST")
 	}
 
 	fmt.Printf("%-22s %s\n", "CREATED AT", "SIZE")

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -97,7 +97,7 @@ func TestOutputHeader(t *testing.T) {
 	output = captureOutput(func() {
 		outputHeader(true, true)
 	})
-	expectedOutput = fmt.Sprintf("%-20s %-56s %-64s %-22s %s\n", "IMAGE ID", "IMAGE NAME", "DIGEST", "CREATED AT", "SIZE")
+	expectedOutput = fmt.Sprintf("%-20s %-56s %-71s %-22s %s\n", "IMAGE ID", "IMAGE NAME", "DIGEST", "CREATED AT", "SIZE")
 	if output != expectedOutput {
 		t.Errorf("Error outputting header:\n\texpected: %s\n\treceived: %s\n", expectedOutput, output)
 	}


### PR DESCRIPTION
I play with buildah, and found this command `./buildah-format images --digests` get not aligned output

```
$ sudo ./buildah images --digests
IMAGE ID             IMAGE NAME                                               DIGEST                                                           CREATED AT             SIZE
7cf6fce9aa6c         docker.io/library/busybox:latest                         sha256:030fcb92e1487b18c974784dcc110a93147c9fc402188370fbfd17efabffc6af Sep 13, 2017 10:14     1.079 MB
ff38371cf81d         <none>                                                   sha256:5a3c8b8cb0d02e9fc01d5801c707b752f7b6bcc3aab469ffcdbb057fef0f77f0 Sep 13, 2017 10:14     1.104 KB
b04fef93a50a         docker.io/library/test:v1                                sha256:7ee5e83f6475ab1376acf04b5ba60e2c77618877fbc833c88295660d930a9474 Sep 13, 2017 10:14     1.104 KB
94b5dfceca36         docker.io/library/test:v2                                sha256:5c59bfd3156fcae8cb385eea0c3af408c451bd4ebf11abddfe38d02ee5e3ed58 Sep 13, 2017 10:14     1.104 KB
```

I think  the length here should be 71,  add length "sha256:"
```
diff --git a/cmd/buildah/images.go b/cmd/buildah/images.go
index 51979dd..ec0b806 100644
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -207,7 +207,7 @@ func outputHeader(truncate, digests bool) {
        }
 
        if digests {
-               fmt.Printf("%-64s ", "DIGEST")
+               fmt.Printf("%-71s ", "DIGEST")
        }
 
```

```
$ sudo ./buildah-format images --digests
IMAGE ID             IMAGE NAME                                               DIGEST                                                                  CREATED AT             SIZE
7cf6fce9aa6c         docker.io/library/busybox:latest                         sha256:030fcb92e1487b18c974784dcc110a93147c9fc402188370fbfd17efabffc6af Sep 13, 2017 10:14     1.079 MB
ff38371cf81d         <none>                                                   sha256:5a3c8b8cb0d02e9fc01d5801c707b752f7b6bcc3aab469ffcdbb057fef0f77f0 Sep 13, 2017 10:14     1.104 KB
b04fef93a50a         docker.io/library/test:v1                                sha256:7ee5e83f6475ab1376acf04b5ba60e2c77618877fbc833c88295660d930a9474 Sep 13, 2017 10:14     1.104 KB
94b5dfceca36         docker.io/library/test:v2                                sha256:5c59bfd3156fcae8cb385eea0c3af408c451bd4ebf11abddfe38d02ee5e3ed58 Sep 13, 2017 10:14     1.104 KB
```

I hope this output issue is not caused by my termianl
