### PR TITLE
Create Registry in Docker forTravis CI

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -9,6 +9,40 @@ host:
 required: true
 
 tests:
+  #  Let's create a self signed certificate and get it in the right places
+  - hostname
+  - ip a
+  - ping -c 3 localhost
+  - cat /etc/hostname
+  - mkdir -p /home/travis/auth
+  - openssl req -newkey rsa:4096 -nodes -sha256 -keyout /home/travis/auth/domain.key -x509 -days 2 -out /home/travis/auth/domain.crt -subj "/C=US/ST=Foo/L=Bar/O=Red Hat, Inc./CN=localhost"
+  - cp /home/travis/auth/domain.crt /home/travis/auth/domain.cert
+  - sudo mkdir -p /etc/docker/certs.d/docker.io/
+  - sudo cp /home/travis/auth/domain.crt /etc/docker/certs.d/docker.io/ca.crt
+  - sudo mkdir -p /etc/docker/certs.d/localhost:5000/
+  - sudo cp /home/travis/auth/domain.crt /etc/docker/certs.d/localhost:5000/ca.crt
+  - sudo cp /home/travis/auth/domain.crt /etc/docker/certs.d/localhost:5000/domain.crt
+  # Create the credentials file, then start up the Docker registry
+  - docker run --entrypoint htpasswd registry:2 -Bbn testuser testpassword > /home/travis/auth/htpasswd
+  - docker run -d -p 5000:5000 --name registry -v /home/travis/auth:/home/travis/auth:Z -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH=/home/travis/auth/htpasswd -e REGISTRY_HTTP_TLS_CERTIFICATE=/home/travis/auth/domain.crt -e REGISTRY_HTTP_TLS_KEY=/home/travis/auth/domain.key registry:2
+
+# Test Docker setup
+  - docker ps --all
+  - docker images
+  - ls -alF /home/travis/auth
+  - docker pull alpine
+  - docker login localhost:5000 --username testuser --password testpassword
+  - docker tag alpine localhost:5000/my-alpine
+  - docker push localhost:5000/my-alpine
+  - docker ps --all
+  - docker images
+  - docker rmi docker.io/alpine
+  - docker rmi localhost:5000/my-alpine
+  - docker pull localhost:5000/my-alpine
+  - docker ps --all
+  - docker images
+  - docker rmi localhost:5000/my-alpine
+
   # mount yum repos to inherit injected mirrors from PAPR
   - docker run --net=host --privileged -v /etc/yum.repos.d:/etc/yum.repos.d.host:ro
     -v $PWD:/code registry.fedoraproject.org/fedora:26 sh -c

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,46 @@ services:
     - docker
 before_install:
     - sudo add-apt-repository -y ppa:duggan/bats
-    - sudo apt-get -qq update
+    - sudo apt-get update
     - sudo apt-get -qq install bats btrfs-tools git libapparmor-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libselinux1-dev
     - sudo apt-get -qq remove libseccomp2
+    - sudo apt-get -qq update
+    - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+    - mkdir /home/travis/auth
+install:
+    #  Let's create a self signed certificate and get it in the right places
+    - hostname
+    - ip a
+    - ping -c 3 localhost
+    - cat /etc/hostname
+    - openssl req -newkey rsa:4096 -nodes -sha256 -keyout /home/travis/auth/domain.key -x509 -days 2 -out /home/travis/auth/domain.crt -subj "/C=US/ST=Foo/L=Bar/O=Red Hat, Inc./CN=localhost"
+    - cp /home/travis/auth/domain.crt /home/travis/auth/domain.cert
+    - sudo mkdir -p /etc/docker/certs.d/docker.io/
+    - sudo cp /home/travis/auth/domain.crt /etc/docker/certs.d/docker.io/ca.crt
+    - sudo mkdir -p /etc/docker/certs.d/localhost:5000/
+    - sudo cp /home/travis/auth/domain.crt /etc/docker/certs.d/localhost:5000/ca.crt
+    - sudo cp /home/travis/auth/domain.crt /etc/docker/certs.d/localhost:5000/domain.crt
+    # Create the credentials file, then start up the Docker registry
+    - docker run --entrypoint htpasswd registry:2 -Bbn testuser testpassword > /home/travis/auth/htpasswd
+    - docker run -d -p 5000:5000 --name registry -v /home/travis/auth:/home/travis/auth:Z -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH=/home/travis/auth/htpasswd -e REGISTRY_HTTP_TLS_CERTIFICATE=/home/travis/auth/domain.crt -e REGISTRY_HTTP_TLS_KEY=/home/travis/auth/domain.key registry:2
 script:
+    # Let's do some docker stuff just for verification purposes
+    - docker ps --all
+    - docker images
+    - ls -alF /home/travis/auth
+    - docker pull alpine
+    - docker login localhost:5000 --username testuser --password testpassword
+    - docker tag alpine localhost:5000/my-alpine
+    - docker push localhost:5000/my-alpine
+    - docker ps --all
+    - docker images
+    - docker rmi docker.io/alpine
+    - docker rmi localhost:5000/my-alpine
+    - docker pull localhost:5000/my-alpine
+    - docker ps --all
+    - docker images
+    - docker rmi localhost:5000/my-alpine
+    # Setting up  Docker Registry is complete, let's do Buildah testing! 
     - make install.tools install.libseccomp.sudo all runc validate TAGS="apparmor seccomp containers_image_ostree_stub"
     - go test -c -tags "apparmor seccomp `./btrfs_tag.sh` `./libdm_tag.sh` `./ostree_tag.sh` `./selinux_tag.sh`" ./cmd/buildah
     - tmp=`mktemp -d`; mkdir $tmp/root $tmp/runroot; sudo PATH="$PATH" ./buildah.test -test.v -root $tmp/root -runroot $tmp/runroot -storage-driver vfs -signature-policy `pwd`/tests/policy.json

--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "from-authenticate-cert-and-creds" {
+
+  buildah from --pull --name "alpine" --signature-policy ${TESTSDIR}/policy.json alpine
+  run buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword alpine localhost:5000/my-alpine
+  echo "$output"
+  [ "$status" -eq 0 ]
+
+  # This should fail
+  run buildah push localhost:5000/my-alpine --signature-policy ${TESTSDIR}/policy.json --tls-verify=true
+  [ "$status" -ne 0 ]
+
+  # This should fail
+  run buildah from localhost:5000/my-alpine --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds baduser:badpassword
+  [ "$status" -ne 0 ]
+
+  # This should work
+  run buildah from localhost:5000/my-alpine --name "my-alpine" --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword
+  [ "$status" -eq 0 ]
+
+  # Clean up
+  buildah rm my-alpine
+  buildah rm alpine 
+  buildah rmi -f $(buildah --debug=false images -q)
+}


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Creates and runs a registry using Docker inside of Travis CI that the Buildah Authenitcation tests can use.  There's a bunch of extraneous stuff doing some Docker stuff that I'd like to keep in for now until I can get the certificates in play.  Currently the authentication test turn off tls verification.  Will be changing that in a follow up submit.  Once that's all settled, I'll do something similar in kpod so we can test kpod login and other functions there.