### PR TITLE
Add required runc version to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Prior to installing buildah, install the following packages on your linux distro
 * glib2-devel
 * libassuan-devel
 * ostree-devel
-* runc
+* runc (Requires version 1.0 RC4 or higher.)
 * skopeo-containers
 
 In Fedora, you can use this command:


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Quick fix to let people know that runc 1.0 RC4 is required.  Will work on better documentation to show how to get there in a later PR>