### PR TITLE
Add tls-verify to bud command

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -54,6 +54,10 @@ var (
 			Name:  "tag, t",
 			Usage: "`tag` to apply to the built image",
 		},
+		cli.BoolTFlag{
+			Name:  "tls-verify",
+			Usage: "Require HTTPS and verify certificates when accessing the registry",
+		},
 	}
 
 	budDescription = "Builds an OCI image using instructions in one or more Dockerfiles."
@@ -179,6 +183,7 @@ func budCmd(c *cli.Context) error {
 		Compression:         imagebuildah.Gzip,
 		Quiet:               c.Bool("quiet"),
 		SignaturePolicyPath: c.String("signature-policy"),
+		SkipTLSVerify:       !c.Bool("tls-verify"),
 		Args:                args,
 		Output:              output,
 		AdditionalTags:      tags,

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -340,6 +340,7 @@ return 1
      --pull-always
      --quiet
      -q
+     --tls-verify
   "
 
      local options_with_args="

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -74,6 +74,10 @@ option be used, as the default behavior of using the system-wide default policy
 Specifies the name which will be assigned to the resulting image if the build
 process completes successfully.
 
+**--tls-verify** *bool-value*
+
+Require HTTPS and verify certificates when talking to container registries (defaults to true)
+
 ## EXAMPLE
 
 buildah bud .
@@ -84,7 +88,9 @@ buildah bud -f Dockerfile.simple -f Dockerfile.notsosimple
 
 buildah bud -t imageName .
 
-buildah bud -t imageName -f Dockerfile.simple
+buildah bud --tls-verify=true -t imageName -f Dockerfile.simple
+
+buildah bud --tls-verify=false -t imageName .
 
 ## SEE ALSO
 buildah(1)

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -95,6 +95,8 @@ type BuildOptions struct {
 	// specified, indicating that the shared, system-wide default policy
 	// should be used.
 	SignaturePolicyPath string
+	// SkipTLSVerify denotes whether TLS verification should not be used.
+	SkipTLSVerify bool
 	// ReportWriter is an io.Writer which will be used to report the
 	// progress of the (possible) pulling of the source image and the
 	// writing of the new image.
@@ -136,11 +138,12 @@ type Executor struct {
 	reportWriter                   io.Writer
 }
 
-func makeSystemContext(signaturePolicyPath string) *types.SystemContext {
+func makeSystemContext(signaturePolicyPath string, skipTLSVerify bool) *types.SystemContext {
 	sc := &types.SystemContext{}
 	if signaturePolicyPath != "" {
 		sc.SignaturePolicyPath = signaturePolicyPath
 	}
+	sc.DockerInsecureSkipTLSVerify = skipTLSVerify
 	return sc
 }
 
@@ -420,7 +423,7 @@ func NewExecutor(store storage.Store, options BuildOptions) (*Executor, error) {
 		outputFormat:        options.OutputFormat,
 		additionalTags:      options.AdditionalTags,
 		signaturePolicyPath: options.SignaturePolicyPath,
-		systemContext:       makeSystemContext(options.SignaturePolicyPath),
+		systemContext:       makeSystemContext(options.SignaturePolicyPath, options.SkipTLSVerify),
 		volumeCache:         make(map[string]string),
 		volumeCacheInfo:     make(map[string]os.FileInfo),
 		log:                 options.Log,


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Adds the --tls-verify flag to the Buildah bud command.