### PR TITLE
Add go 1.9.x to .travis.yml and remove go tip build temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 go:
     - 1.7
     - 1.8
-    - tip
+    - 1.9.x
 dist: trusty
 sudo: required
 services:
@@ -13,7 +13,7 @@ before_install:
     - sudo apt-get -qq install bats btrfs-tools git libapparmor-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libselinux1-dev
     - sudo apt-get -qq remove libseccomp2
 script:
-    - make install.tools install.libseccomp.sudo all runc validate TAGS="apparmor seccomp"
+    - make install.tools install.libseccomp.sudo all runc validate TAGS="apparmor seccomp containers_image_ostree_stub"
     - go test -c -tags "apparmor seccomp `./btrfs_tag.sh` `./libdm_tag.sh` `./ostree_tag.sh` `./selinux_tag.sh`" ./cmd/buildah
     - tmp=`mktemp -d`; mkdir $tmp/root $tmp/runroot; sudo PATH="$PATH" ./buildah.test -test.v -root $tmp/root -runroot $tmp/runroot -storage-driver vfs -signature-policy `pwd`/tests/policy.json
     - cd tests; sudo PATH="$PATH" ./test_runner.sh


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add go v1.9.x to the mix and remove go tip temporarily.  This will fix #304's build issues.