### PR TITLE
add new command: pull

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -158,6 +158,11 @@ func NewBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
 	return newBuilder(store, options)
 }
 
+// pull selected image and return its reference
+func PullImage(store storage.Store, options BuilderOptions, sc *types.SystemContext) (types.ImageReference, error) {
+	return pullImage(store, options, sc)
+}
+
 // ImportBuilder creates a new build configuration using an already-present
 // container.
 func ImportBuilder(store storage.Store, options ImportOptions) (*Builder, error) {

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -90,6 +90,7 @@ func main() {
 		tagCommand,
 		umountCommand,
 		versionCommand,
+		pullCommand,
 	}
 	err := app.Run(os.Args)
 	if err != nil {

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/containers/image/transports"
+	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah"
+	"github.com/urfave/cli"
+)
+
+var (
+	pullFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "cert-dir",
+			Value: "",
+			Usage: "use certificates at the specified path to access the registry",
+		},
+		cli.StringFlag{
+			Name:  "creds",
+			Value: "",
+			Usage: "use `username[:password]` for accessing the registry",
+		},
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "don't output progress information when pulling images",
+		},
+		cli.StringFlag{
+			Name:  "signature-policy",
+			Usage: "`pathname` of signature policy file (not usually used)",
+		},
+		cli.BoolTFlag{
+			Name:  "tls-verify",
+			Usage: "Require HTTPS and verify certificates when accessing the registry",
+		},
+	}
+	pullDescription = "Pull selected image, you can specify the source, please consult the man page for more info"
+
+	pullCommand = cli.Command{
+		Name:        "pull",
+		Usage:       "Pull selected image",
+		Description: pullDescription,
+		Flags:       pullFlags,
+		Action:      pullCmd,
+		ArgsUsage:   "IMAGE",
+	}
+)
+
+func pullCmd(c *cli.Context) error {
+
+	args := c.Args()
+	if len(args) == 0 {
+		return errors.Errorf("an image name must be specified")
+	}
+	if len(args) > 1 {
+		return errors.Errorf("too many arguments specified")
+	}
+	if err := validateFlags(c, fromFlags); err != nil {
+		return err
+	}
+
+	systemContext, err := systemContextFromOptions(c)
+	if err != nil {
+		return errors.Wrapf(err, "error building system context")
+	}
+
+	signaturePolicy := c.String("signature-policy")
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	options := buildah.BuilderOptions{
+		FromImage:           args[0],
+		SignaturePolicyPath: signaturePolicy,
+		SystemContext:       systemContext,
+	}
+	if !c.Bool("quiet") {
+		options.ReportWriter = os.Stderr
+	}
+	pulledReference, err := buildah.PullImage(store, options, systemContext)
+	if err != nil {
+		return errors.Wrapf(err, "error pulling image %q", args[0])
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// FIXME: I want to print the image digest here but am struggling to figure it out
+	fmt.Printf("%s\n", transports.ImageName(pulledReference))
+	return nil
+}


### PR DESCRIPTION
As you may know, I am trying to implement buildah backend for [ansible-container](https://github.com/ansible/ansible-container/pull/760).

One of the interfaces defined in a-c is [pull method](https://github.com/ansible/ansible-container/blob/ab8d4bdf6199f20969f09b42843cfb4f75ffa9c7/container/docker/engine.py#L613)
which returns ID to the pulled image. This is why I implemented dedicated pull
command for buildah. Unfortunately I wasn't able to figure out how to get this
ID/digest of the image which was just pulled. Could you please help me out?
Does it even make sense? a-c is using this digest for caching purposes -- if the
image didn't change, we don't need to rebuild.

The other issue I have actually is that one cannot do `buildah from <image-id>`.

- [ ] I also need to write a manpage.
- [ ] CI failures