### PR TITLE
integration tests: default to /var/tmp

### DIFF
--- a/tests/run.bats
+++ b/tests/run.bats
@@ -181,11 +181,14 @@ load helpers
 	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json fedora)
 	root=$(buildah mount $cid)
 	run buildah --debug=false run  -- $cid dnf -y install hostname
+	echo "$output"
 	[ "$status" -eq 0 ]
 	run buildah --debug=false run $cid hostname
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "$output" != "foobar" ]
 	run buildah --debug=false run --hostname foobar $cid hostname
+	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "$output" = "foobar" ]
 	buildah unmount $cid

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -177,12 +177,7 @@ load helpers
 		skip
 	fi
 	runc --version
-	createrandom ${TESTDIR}/randomfile
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json fedora)
-	root=$(buildah mount $cid)
-	run buildah --debug=false run  -- $cid dnf -y install hostname
-	echo "$output"
-	[ "$status" -eq 0 ]
+	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
 	run buildah --debug=false run $cid hostname
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -191,6 +186,5 @@ load helpers
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "$output" = "foobar" ]
-	buildah unmount $cid
 	buildah rm $cid
 }

--- a/tests/test_runner.sh
+++ b/tests/test_runner.sh
@@ -3,6 +3,10 @@ set -e
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
+# Default to using /var/tmp for test space, since it's more likely to support
+# labels than /tmp, which is often on tmpfs.
+export TMPDIR=${TMPDIR:-/var/tmp}
+
 # Load the helpers.
 . helpers.bash
 


### PR DESCRIPTION
Default to running integration tests using /var/tmp as scratch space, since it's more likely to support proper SELinux labeling than /tmp, which is more likely to be on a tmpfs.