### PR TITLE
Set option.terminal appropriately in run

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -79,10 +79,12 @@ func runCmd(c *cli.Context) error {
 		Args:     c.StringSlice("runtime-flag"),
 	}
 
-	if c.Bool("tty") {
-		options.Terminal = buildah.WithTerminal
-	} else {
-		options.Terminal = buildah.WithoutTerminal
+	if c.IsSet("tty") {
+		if c.Bool("tty") {
+			options.Terminal = buildah.WithTerminal
+		} else {
+			options.Terminal = buildah.WithoutTerminal
+		}
 	}
 
 	for _, volumeSpec := range c.StringSlice("volume") {


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

The options.terminal field was never set to DefaultTerminal.  Unless the --tty was specified, the options.terminal field defaults to "WithoutTerminal" or the --tty=false value.  It should instead use the current terminal unless --tty is specified to use a pseudo terminal (or not).

This behaviour follows the man page description.

Testing results.  Notice in the --tty=false case, there is not a prompt from the container.  Prior to this change that prompt was not present when the --tty parameter was not specified.  It is now present as illustrated in the fourth example.
```
[root@localhost buildah]# ./buildah run $container bash --tty=false
exit
[root@localhost buildah]# ./buildah run $container bash --tty=true
[root@mrsdalloway /]# exit
exit
[root@localhost buildah]# ./buildah run $container bash --tty
[root@mrsdalloway /]# exit
exit
[root@localhost buildah]# ./buildah run $container bash
[root@mrsdalloway /]# exit
```