### PR TITLE
Use credentials from kpod login for buildah

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -13,6 +13,10 @@ import (
 
 var (
 	budFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "authfile",
+			Usage: "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
+		},
 		cli.StringSliceFlag{
 			Name:  "build-arg",
 			Usage: "`argument=value` to supply to the builder",
@@ -56,7 +60,7 @@ var (
 		},
 		cli.BoolTFlag{
 			Name:  "tls-verify",
-			Usage: "Require HTTPS and verify certificates when accessing the registry",
+			Usage: "require HTTPS and verify certificates when accessing the registry",
 		},
 	}
 
@@ -190,6 +194,7 @@ func budCmd(c *cli.Context) error {
 		Runtime:             c.String("runtime"),
 		RuntimeArgs:         c.StringSlice("runtime-flag"),
 		OutputFormat:        format,
+		AuthFilePath:        c.String("authfile"),
 	}
 	if !c.Bool("quiet") {
 		options.ReportWriter = os.Stderr

--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -133,6 +133,9 @@ func systemContextFromOptions(c *cli.Context) (*types.SystemContext, error) {
 	if c.IsSet("signature-policy") {
 		ctx.SignaturePolicyPath = c.String("signature-policy")
 	}
+	if c.IsSet("authfile") {
+		ctx.AuthFilePath = c.String("authfile")
+	}
 	return ctx, nil
 }
 

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -12,6 +12,10 @@ import (
 var (
 	fromFlags = []cli.Flag{
 		cli.StringFlag{
+			Name:  "authfile",
+			Usage: "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
+		},
+		cli.StringFlag{
 			Name:  "cert-dir",
 			Value: "",
 			Usage: "use certificates at the specified path to access the registry",
@@ -43,7 +47,7 @@ var (
 		},
 		cli.BoolTFlag{
 			Name:  "tls-verify",
-			Usage: "Require HTTPS and verify certificates when accessing the registry",
+			Usage: "require HTTPS and verify certificates when accessing the registry",
 		},
 	}
 	fromDescription = "Creates a new working container, either from scratch or using a specified\n   image as a starting point"

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -18,6 +18,10 @@ import (
 var (
 	pushFlags = []cli.Flag{
 		cli.StringFlag{
+			Name:  "authfile",
+			Usage: "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
+		},
+		cli.StringFlag{
 			Name:  "cert-dir",
 			Value: "",
 			Usage: "use certificates at the specified path to access the registry",
@@ -45,7 +49,7 @@ var (
 		},
 		cli.BoolTFlag{
 			Name:  "tls-verify",
-			Usage: "Require HTTPS and verify certificates when accessing the registry",
+			Usage: "require HTTPS and verify certificates when accessing the registry",
 		},
 	}
 	pushDescription = fmt.Sprintf(`

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -345,6 +345,7 @@ return 1
   "
 
      local options_with_args="
+     --authfile
      --signature-policy
      --runtime
      --runtime-flag
@@ -481,6 +482,7 @@ return 1
   "
 
      local options_with_args="
+          --authfile
           --cert-dir
           --creds
           --format
@@ -629,6 +631,7 @@ return 1
   "
 
      local options_with_args="
+     --authfile
      --cert-dir
      --creds
      --name

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -14,6 +14,11 @@ to a temporary location.
 
 ## OPTIONS
 
+**--authfile** *path*
+
+Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
+which is set using `kpod login`
+
 **--build-arg** *arg=value*
 
 Specifies a build argument and its value, which will be interpolated in
@@ -93,4 +98,4 @@ buildah bud --tls-verify=true -t imageName -f Dockerfile.simple
 buildah bud --tls-verify=false -t imageName .
 
 ## SEE ALSO
-buildah(1)
+buildah(1) kpod-login(1)

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -17,7 +17,7 @@ Multiple transports are supported:
   An existing local directory _path_ retrieving the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
   **docker://**_docker-reference_ (Default)
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$HOME/.docker/config.json`, which is set e.g. using `(docker login)`.
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set e.g. using `(kpod login)`.
 
   **docker-archive:**_path_
   An image is retrieved as a `docker load` formatted file.
@@ -35,6 +35,11 @@ Multiple transports are supported:
 The container ID of the container that was created.  On error, -1 is returned and errno is returned.
 
 ## OPTIONS
+
+**--authfile** *path*
+
+Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
+which is set using `kpod login`
 
 **--cert-dir** *path*
 
@@ -86,5 +91,7 @@ buildah from myregistry/myrepository/imagename:imagetag --tls-verify=false
 
 buildah from myregistry/myrepository/imagename:imagetag --creds=myusername:mypassword --cert-dir ~/auth
 
+buildah from myregistry/myrepository/imagename:imagetag --authfile=/tmp/auths/myauths.json
+
 ## SEE ALSO
-buildah(1)
+buildah(1) kpod-login(1)

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -24,7 +24,7 @@ Image stored in local container/storage
   An existing local directory _path_ storing the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
   **docker://**_docker-reference_
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$HOME/.docker/config.json`, which is set e.g. using `(docker login)`.
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set e.g. using `(kpod login)`.
 
   **docker-archive:**_path_[**:**_docker-reference_]
   An image is stored in the `docker save` formatted file.  _docker-reference_ is only used when creating such a file, and it must not contain a digest.
@@ -39,6 +39,11 @@ Image stored in local container/storage
   An image in local OSTree repository.  _/absolute/repo/path_ defaults to _/ostree/repo_.
 
 ## OPTIONS
+
+**--authfile** *path*
+
+Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
+which is set using `kpod login`
 
 **--cert-dir** *path*
 
@@ -84,6 +89,10 @@ This example extracts the imageID image to a container registry named registry.e
 
  `# buildah push imageID docker://registry.example.com/repository:tag`
 
+This example extracts the imageID image to a private container registry named registry.example.com with authentication from /tmp/auths/myauths.json.
+
+ `# buildah push --authfile /tmp/auths/myauths.json imageID docker://registry.example.com/repository:tag`
+
 This example extracts the imageID image and puts into the local docker container store.
 
  `# buildah push imageID docker-daemon:image:tag`
@@ -95,4 +104,4 @@ This example extracts the imageID image and puts it into the registry on the loc
  `# buildah push --cert-dir ~/auth --tls-verify=true --creds=username:password imageID docker://localhost:5000/my-imageID`
 
 ## SEE ALSO
-buildah(1)
+buildah(1) kpod-login(1)

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -105,6 +105,7 @@ type BuildOptions struct {
 	// configuration data.
 	// Accepted values are OCIv1ImageFormat and Dockerv2ImageFormat.
 	OutputFormat string
+	AuthFilePath string
 }
 
 // Executor is a buildah-based implementation of the imagebuilder.Executor
@@ -138,10 +139,13 @@ type Executor struct {
 	reportWriter                   io.Writer
 }
 
-func makeSystemContext(signaturePolicyPath string, skipTLSVerify bool) *types.SystemContext {
+func makeSystemContext(signaturePolicyPath, authFilePath string, skipTLSVerify bool) *types.SystemContext {
 	sc := &types.SystemContext{}
 	if signaturePolicyPath != "" {
 		sc.SignaturePolicyPath = signaturePolicyPath
+	}
+	if authFilePath != "" {
+		sc.AuthFilePath = authFilePath
 	}
 	sc.DockerInsecureSkipTLSVerify = skipTLSVerify
 	return sc
@@ -423,7 +427,7 @@ func NewExecutor(store storage.Store, options BuildOptions) (*Executor, error) {
 		outputFormat:        options.OutputFormat,
 		additionalTags:      options.AdditionalTags,
 		signaturePolicyPath: options.SignaturePolicyPath,
-		systemContext:       makeSystemContext(options.SignaturePolicyPath, options.SkipTLSVerify),
+		systemContext:       makeSystemContext(options.SignaturePolicyPath, options.AuthFilePath, options.SkipTLSVerify),
 		volumeCache:         make(map[string]string),
 		volumeCacheInfo:     make(map[string]os.FileInfo),
 		log:                 options.Log,


### PR DESCRIPTION
buildah push and from now use the credentials stored in ${XDG_RUNTIME_DIR}/containers/auth.json by kpod login
if the auth file path is changed, buildah push and from can get the credentials from the custom auth file
using the --authfile flag
e.g buildah push --authfile /tmp/auths/myauths.json alpine docker://username/image

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>