### PR TITLE
Mention docker login in documentation for authentication

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -16,8 +16,8 @@ to a temporary location.
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
-which is set using `kpod login`
+Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `kpod login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--build-arg** *arg=value*
 
@@ -98,4 +98,4 @@ buildah bud --tls-verify=true -t imageName -f Dockerfile.simple
 buildah bud --tls-verify=false -t imageName .
 
 ## SEE ALSO
-buildah(1) kpod-login(1)
+buildah(1), kpod-login(1), docker-login(1)

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -17,7 +17,7 @@ Multiple transports are supported:
   An existing local directory _path_ retrieving the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
   **docker://**_docker-reference_ (Default)
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set e.g. using `(kpod login)`.
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set using `(kpod login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
 
   **docker-archive:**_path_
   An image is retrieved as a `docker load` formatted file.
@@ -38,8 +38,8 @@ The container ID of the container that was created.  On error, -1 is returned an
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
-which is set using `kpod login`
+Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `kpod login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--cert-dir** *path*
 
@@ -94,4 +94,4 @@ buildah from myregistry/myrepository/imagename:imagetag --creds=myusername:mypas
 buildah from myregistry/myrepository/imagename:imagetag --authfile=/tmp/auths/myauths.json
 
 ## SEE ALSO
-buildah(1) kpod-login(1)
+buildah(1), kpod-login(1), docker-login(1)

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -24,7 +24,7 @@ Image stored in local container/storage
   An existing local directory _path_ storing the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
   **docker://**_docker-reference_
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set e.g. using `(kpod login)`.
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set using `(kpod login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
 
   **docker-archive:**_path_[**:**_docker-reference_]
   An image is stored in the `docker save` formatted file.  _docker-reference_ is only used when creating such a file, and it must not contain a digest.
@@ -42,8 +42,8 @@ Image stored in local container/storage
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
-which is set using `kpod login`
+Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `kpod login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--cert-dir** *path*
 
@@ -104,4 +104,4 @@ This example extracts the imageID image and puts it into the registry on the loc
  `# buildah push --cert-dir ~/auth --tls-verify=true --creds=username:password imageID docker://localhost:5000/my-imageID`
 
 ## SEE ALSO
-buildah(1) kpod-login(1)
+buildah(1), kpod-login(1), docker-login(1)


### PR DESCRIPTION
Since we fall back to reading the credentials from $HOME/.docker/config
set by docker login when kpod login doesn't have the credentials

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>