### PR TITLE
Buildah bud does not work with SELinux

### DIFF
--- a/add.go
+++ b/add.go
@@ -59,7 +59,7 @@ func addURL(destination, srcurl string) error {
 // filesystem, optionally extracting contents of local files that look like
 // non-empty archives.
 func (b *Builder) Add(destination string, extract bool, source ...string) error {
-	mountPoint, err := b.Mount("")
+	mountPoint, err := b.Mount(b.MountLabel)
 	if err != nil {
 		return err
 	}

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -46,7 +46,7 @@ func mountCmd(c *cli.Context) error {
 		if err != nil {
 			return errors.Wrapf(err, "error reading build container %q", name)
 		}
-		mountPoint, err := builder.Mount("")
+		mountPoint, err := builder.Mount(builder.MountLabel)
 		if err != nil {
 			return errors.Wrapf(err, "error mounting %q container %q", name, builder.Container)
 		}

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -521,7 +521,7 @@ func (b *Executor) Prepare(ib *imagebuilder.Builder, node *parser.Node, from str
 		}
 		return errors.Wrapf(err, "error updating build context")
 	}
-	mountPoint, err := builder.Mount("")
+	mountPoint, err := builder.Mount(builder.MountLabel)
 	if err != nil {
 		if err2 := builder.Delete(); err2 != nil {
 			logrus.Debugf("error deleting container which we failed to mount: %v", err2)


### PR DESCRIPTION
buildah bud was not setting the mount label on the image
so SELinux in enforcing mode is blocking writing to the image

This patch also fixes a similar problem with the `buildah mount`
command

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>