### PR TITLE
Add --chown option to add/copy

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -2,10 +2,17 @@ package main
 
 import (
 	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah"
 	"github.com/urfave/cli"
 )
 
 var (
+	addAndCopyFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "chown",
+			Usage: "Set the user and group ownership of the destination content",
+		},
+	}
 	addDescription  = "Adds the contents of a file, URL, or directory to a container's working\n   directory.  If a local file appears to be an archive, its contents are\n   extracted and added instead of the archive file itself."
 	copyDescription = "Copies the contents of a file, URL, or directory into a container's working\n   directory"
 
@@ -13,6 +20,7 @@ var (
 		Name:        "add",
 		Usage:       "Add content to the container",
 		Description: addDescription,
+		Flags:       addAndCopyFlags,
 		Action:      addCmd,
 		ArgsUsage:   "CONTAINER-NAME-OR-ID [[FILE | DIRECTORY | URL] ...] [DESTINATION]",
 	}
@@ -21,6 +29,7 @@ var (
 		Name:        "copy",
 		Usage:       "Copy content into the container",
 		Description: copyDescription,
+		Flags:       addAndCopyFlags,
 		Action:      copyCmd,
 		ArgsUsage:   "CONTAINER-NAME-OR-ID [[FILE | DIRECTORY | URL] ...] [DESTINATION]",
 	}
@@ -33,6 +42,10 @@ func addAndCopyCmd(c *cli.Context, extractLocalArchives bool) error {
 	}
 	name := args[0]
 	args = args.Tail()
+
+	if err := validateFlags(c, addAndCopyFlags); err != nil {
+		return err
+	}
 
 	// If list is greater then one, the last item is the destination
 	dest := ""
@@ -52,8 +65,11 @@ func addAndCopyCmd(c *cli.Context, extractLocalArchives bool) error {
 		return errors.Wrapf(err, "error reading build container %q", name)
 	}
 
-	err = builder.Add(dest, extractLocalArchives, args...)
-	if err != nil {
+	options := buildah.AddAndCopyOptions{
+		Chown: c.String("chown"),
+	}
+
+	if err := builder.Add(dest, extractLocalArchives, options, args...); err != nil {
 		return errors.Wrapf(err, "error adding content to container %q", builder.Container)
 	}
 

--- a/docs/buildah-add.md
+++ b/docs/buildah-add.md
@@ -13,9 +13,17 @@ appears to be an archive, its contents are extracted and added instead of the
 archive file itself.  If a local directory is specified as a source, its
 *contents* are copied to the destination.
 
+## OPTIONS
+
+**--chown** *owner*:*group*
+
+Sets the user and group ownership of the destination content.
+
 ## EXAMPLE
 
 buildah add containerID '/myapp/app.conf' '/myapp/app.conf'
+
+buildah add --chown myuser:mygroup containerID '/myapp/app.conf' '/myapp/app.conf'
 
 buildah add containerID '/home/myuser/myproject.go'
 

--- a/docs/buildah-copy.md
+++ b/docs/buildah-copy.md
@@ -11,9 +11,17 @@ Copies the contents of a file, URL, or a directory to a container's working
 directory or a specified location in the container.  If a local directory is
 specified as a source, its *contents* are copied to the destination.
 
+## OPTIONS
+
+**--chown** *owner*:*group*
+
+Sets the user and group ownership of the destination content.
+
 ## EXAMPLE
 
 buildah copy containerID '/myapp/app.conf' '/myapp/app.conf'
+
+buildah copy --chown myuser:mygroup containerID '/myapp/app.conf' '/myapp/app.conf'
 
 buildah copy containerID '/home/myuser/myproject.go'
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -341,7 +341,7 @@ func (b *Executor) Copy(excludes []string, copies ...imagebuilder.Copy) error {
 				sources = append(sources, filepath.Join(b.contextDir, src))
 			}
 		}
-		if err := b.builder.Add(copy.Dest, copy.Download, sources...); err != nil {
+		if err := b.builder.Add(copy.Dest, copy.Download, buildah.AddAndCopyOptions{}, sources...); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Hi there,

I came across a permission error while I was automating the migration of a Redis setup into a container. Basically, `buildah copy` was copying my file into the container and leaving it owned by `root`.

While I know that an extra `buildah run containerID chown redis:redis /etc/redis.conf` would solve that issue, I would love to have a `--chown` option in `buildah add/copy`. I know that docker added something similar recently, but I haven't looked into their implementation.

This PR is simply a PoC to to get a feedback from you. It still needs some improvements, so if you think I can go ahead, I'll look into adding in some tests, docs and refactor the code.

This is an example of how it works:

```
# Create container
$ sudo ./buildah from registry.access.redhat.com/rhscl/redis-32-rhel7
redis-32-rhel7-working-container-15

# Copy some data into the container, setting the owner
$ sudo ./buildah copy --chown redis:redis redis-32-rhel7-working-container-15 contrib /data/contrib
$ sudo ./buildah copy --chown redis:redis redis-32-rhel7-working-container-15 add.go /data/
$ sudo ./buildah copy --chown redis:redis redis-32-rhel7-working-container-15 add.go /data/
$ sudo ./buildah copy --chown redis:redis redis-32-rhel7-working-container-15 https://github.com/projectatomic/buildah/blob/master/README.md /data/

# Owner is properly set
$ sudo ./buildah run redis-32-rhel7-working-container-15 sh
sh-4.2$ ls /data -l
total 64
-rw-------. 1 redis redis 45981 Nov 27 14:41 README.md
-rw-rw-r--. 1 redis redis  8779 Nov 27 14:35 add.go
drwxr-xr-x. 4 redis redis  4096 Nov 27 14:40 contrib
sh-4.2$ ls /data/contrib/ -l
completions/ rpm/
sh-4.2$ ls /data/contrib/rpm/buildah.spec -l
-rw-rw-r--. 1 redis redis 5347 Nov 23 13:49 /data/contrib/rpm/buildah.spec
sh-4.2$

```

Thanks for looking into this!