### PR TITLE
Make CI tests pass again

### DIFF
--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -25,7 +25,7 @@
 %global shortcommit    %(c=%{commit}; echo ${c:0:7})
 
 Name:           buildah
-Version:        0.7
+Version:        0.8
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0

--- a/tests/validate/git-validation.sh
+++ b/tests/validate/git-validation.sh
@@ -8,6 +8,6 @@ if ! which git-validation > /dev/null 2> /dev/null ; then
 fi
 if test "$TRAVIS" != true ; then
 	#GITVALIDATE_EPOCH=":/git-validation epoch"
-	GITVALIDATE_EPOCH="b1bb73e01c9bf0b1b75e50a2d1947b14a8174eee"
+	GITVALIDATE_EPOCH="bf40000e72b351067ebae7b77d212a200f9ce051"
 fi
 exec git-validation -q -run DCO,short-subject ${GITVALIDATE_EPOCH:+-range "${GITVALIDATE_EPOCH}""..${GITVALIDATE_TIP:-@}"} ${GITVALIDATE_FLAGS}


### PR DESCRIPTION
This corrects a version mismatch that CI should have caught, and works around a problem that we can't undo without rewriting history.