### PR TITLE
Allow push to use the image id

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -314,7 +314,7 @@ func Push(image string, dest types.ImageReference, options PushOptions) error {
 		return errors.Wrap(err, "error importing builder information from image")
 	}
 	// Look up the image name and its layer.
-	ref, err := is.Transport.ParseStoreReference(options.Store, image)
+	ref, err := is.Transport.ParseStoreReference(options.Store, builder.FromImage)
 	if err != nil {
 		return errors.Wrapf(err, "error parsing reference to image %q", image)
 	}

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -43,6 +43,7 @@ BuildRequires:  btrfs-progs-devel
 BuildRequires:  libassuan-devel
 BuildRequires:  glib2-devel
 BuildRequires:  ostree-devel
+BuildRequires:  make
 Requires:       runc >= 1.0.0-6
 Requires:       container-selinux
 Requires:       skopeo-containers

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -38,3 +38,14 @@ load helpers
   buildah rmi alpine
   rm -rf my-dir
 }
+
+@test "push with imageid" {
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  imageid=$(buildah images -q)
+  run buildah push --signature-policy ${TESTSDIR}/policy.json $imageid dir:my-dir
+  echo "$output"
+  [ "$status" -eq 0 ]
+  buildah rm "$cid"
+  buildah rmi alpine
+  rm -rf my-dir
+}


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Allows this command to work:
```
./buildah push bea0ba3aafbf oci:/tmp/image:test
```
where  bea0ba3aafbf is the ImageId for the image.  Prior when we passed 'image' to ParseStoreReference it would package up the image name as "docker.io/library/bea0ba3aafbf:latest" rather than "docker.io/library/alpine:latest" which is the valid name.

At line 312 of the commit.go file below we do:

builder, err := importBuilderFromImage(options.Store, importOptions)

The value returned from that in the builder.FromImage variable is "docker.io/library/alpine:latest" which ParseStoreReference parses appropriately and the push now succeeds.

Fixes #324 
