### PR TITLE
tests/rpm.bats: use Fedora 27

### DIFF
--- a/tests/rpm.bats
+++ b/tests/rpm.bats
@@ -8,7 +8,7 @@ load helpers
 	fi
 
 	# Build a container to use for building the binaries.
-	image=registry.fedoraproject.org/fedora:26
+	image=registry.fedoraproject.org/fedora:27
 	cid=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
 	root=$(buildah --debug=false mount $cid)
 	commit=$(git log --format=%H -n 1)


### PR DESCRIPTION
Update tests/rpm.bats to use Fedora 27, and add "make" as a build requirement in the .spec file that it uses, which I don't think is part of the latest set of images.