### PR TITLE
Touchup baseline and rpm tests

### DIFF
--- a/tests/test_buildah_baseline.sh
+++ b/tests/test_buildah_baseline.sh
@@ -74,9 +74,9 @@ scratchmnt=$(buildah mount $newcontainer)
 echo $scratchmnt
 
 ########
-# Install Fedora 26 bash and coreutils
+# Install Fedora 27 bash and coreutils
 ########
-dnf install --installroot $scratchmnt --release 26 bash coreutils --setopt install_weak_deps=false -y
+dnf install --installroot $scratchmnt --release 27 bash coreutils --setopt install_weak_deps=false -y
 
 ########
 # Check /usr/bin on the new container
@@ -107,7 +107,7 @@ buildah run $newcontainer
 # Add configuration information
 ########
 buildah config --created-by "ipbabble"  $newcontainer
-buildah config --author "wgh at redhat.com @ipbabble" --label name=fedora26-bashecho $newcontainer
+buildah config --author "wgh at redhat.com @ipbabble" --label name=fedora27-bashecho $newcontainer
 
 ########
 # Inspect the container, verifying above was put into it
@@ -153,7 +153,7 @@ buildah push fedora-bashecho docker-daemon:fedora-bashecho:latest
 ########
 # Run fedora-bashecho from Docker
 ########
-docker run fedoara-bashecho
+docker run fedora-bashecho
 
 ########
 # Time to remove Docker

--- a/tests/test_buildah_build_rpm.sh
+++ b/tests/test_buildah_build_rpm.sh
@@ -97,6 +97,12 @@ test $SHORTCOMMIT = $id
 test $bv = $rv
 
 ########
+# Clean up Buildah
+########
+buildah rm $(buildah containers -q)
+buildah rmi -f $(buildah --debug=false images -q)
+
+########
 # Kick off baseline testing against the installed Buildah 
 ########
 /bin/bash -v ${TESTSDIR}/test_buildah_baseline.sh


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

A few touchups on the rpm and baseline tests.  Both are run "by hand", neither is run by Travis. 
Bumped Fedora 26 to Fedora 27 in the baseline test and corrected an image name.  Added clean-up of images and containers in Buildah with the rpm test before it kicks off the baseline tests.