### PR TITLE
include Debian install docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,10 @@ install:
 install.completions:
 	install -m 644 -D contrib/completions/bash/buildah $(DESTDIR)/${BASHINSTALLDIR}/buildah
 
+.PHONY: install.runc
+install.runc:
+	install -m 755 ../../opencontainers/runc/runc $(DESTDIR)/$(BINDIR)/
+
 .PHONY: test-integration
 test-integration:
 	cd tests; ./test_runner.sh

--- a/install.md
+++ b/install.md
@@ -103,3 +103,18 @@ Then to install Buildah on Ubuntu follow the steps in this example:
   make install
   buildah --help
 ```
+
+## Debian
+
+To install the required dependencies, you can use those commands, tested under Debian GNU/Linux amd64 9.3 (stretch):
+
+```
+gpg --recv-keys 0x018BA5AD9DF57A4448F0E6CF8BECF1637AD8C79D
+gpg --export 0x018BA5AD9DF57A4448F0E6CF8BECF1637AD8C79D >> /usr/share/keyrings/projectatomic-ppa.gpg
+echo 'deb [signed-by=/usr/share/keyrings/projectatomic-ppa.gpg] http://ppa.launchpad.net/projectatomic/ppa/ubuntu zesty main' > /etc/apt/sources.list.d/projectatomic-ppa.list
+apt update
+apt -y install -t stretch-backports libostree-dev 
+apt -y install bats btrfs-tools git libapparmor-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libseccomp-dev libselinux1-dev skopeo-containers go-md2man golang-1.8
+``` 
+
+The build steps on Debian are otherwise the same as Ubuntu, above.

--- a/install.md
+++ b/install.md
@@ -100,7 +100,7 @@ Then to install Buildah on Ubuntu follow the steps in this example:
   git clone https://github.com/projectatomic/buildah ./src/github.com/projectatomic/buildah
   cd ./src/github.com/projectatomic/buildah
   PATH=/usr/lib/go-1.8/bin:$PATH make runc all TAGS="apparmor seccomp"
-  sudo make install
+  sudo make install install.runc
   buildah --help
 ```
 

--- a/install.md
+++ b/install.md
@@ -48,7 +48,7 @@ Then to install Buildah on Fedora follow the steps in this example:
   git clone https://github.com/projectatomic/buildah ./src/github.com/projectatomic/buildah
   cd ./src/github.com/projectatomic/buildah
   make
-  make install
+  sudo make install
   buildah --help
 ```
 
@@ -100,7 +100,7 @@ Then to install Buildah on Ubuntu follow the steps in this example:
   git clone https://github.com/projectatomic/buildah ./src/github.com/projectatomic/buildah
   cd ./src/github.com/projectatomic/buildah
   PATH=/usr/lib/go-1.8/bin:$PATH make runc all TAGS="apparmor seccomp"
-  make install
+  sudo make install
   buildah --help
 ```
 

--- a/install.md
+++ b/install.md
@@ -16,6 +16,8 @@ Prior to installing Buildah, install the following packages on your linux distro
 * runc (Requires version 1.0 RC4 or higher.)
 * skopeo-containers
 
+## Fedora
+
 In Fedora, you can use this command:
 
 ```
@@ -50,7 +52,9 @@ Then to install Buildah on Fedora follow the steps in this example:
   buildah --help
 ```
 
-In RHEL 7, ensure that you are subscribed to `rhel-7-server-rpms`,
+## RHEL, CentOS
+
+In RHEL and CentOS 7, ensure that you are subscribed to `rhel-7-server-rpms`,
 `rhel-7-server-extras-rpms`, and `rhel-7-server-optional-rpms`, then
 run this command:
 
@@ -72,7 +76,9 @@ run this command:
     skopeo-containers
 ```
 
-The build steps for Buildah on RHEL are the same as Fedora, above.
+The build steps for Buildah on RHEL or CentOS are the same as Fedora, above.
+
+## Ubuntu
 
 In Ubuntu zesty and xenial, you can use this command:
 

--- a/install.md
+++ b/install.md
@@ -113,8 +113,8 @@ gpg --recv-keys 0x018BA5AD9DF57A4448F0E6CF8BECF1637AD8C79D
 gpg --export 0x018BA5AD9DF57A4448F0E6CF8BECF1637AD8C79D >> /usr/share/keyrings/projectatomic-ppa.gpg
 echo 'deb [signed-by=/usr/share/keyrings/projectatomic-ppa.gpg] http://ppa.launchpad.net/projectatomic/ppa/ubuntu zesty main' > /etc/apt/sources.list.d/projectatomic-ppa.list
 apt update
-apt -y install -t stretch-backports libostree-dev 
-apt -y install bats btrfs-tools git libapparmor-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libseccomp-dev libselinux1-dev skopeo-containers go-md2man golang-1.8
+apt -y install -t stretch-backports libostree-dev golang
+apt -y install bats btrfs-tools git libapparmor-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libseccomp-dev libselinux1-dev skopeo-containers go-md2man
 ``` 
 
 The build steps on Debian are otherwise the same as Ubuntu, above.


### PR DESCRIPTION
This does small changes I have found necessary while installing Buildah on Debian stretch.

First, we splits install docs more clearly across different OSes - at first glance, you're tempted to copy-paste duplicate instructions, even across RHEL/Fedora. Then we explicitly run `make install` as root, showing how the build itself can be ran as non-root, and finally, include Debian-specific install docs, for which `apt-add-repository` unfortunately fails.