### PR TITLE
Display Config and Manifest as strings

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -95,6 +95,46 @@ type Builder struct {
 	DefaultMountsFilePath string `json:"defaultMountsFilePath,omitempty"`
 }
 
+// BuilderInfo are used as objects to display container information
+type BuilderInfo struct {
+	Type                  string
+	FromImage             string
+	FromImageID           string
+	Config                string
+	Manifest              string
+	Container             string
+	ContainerID           string
+	MountPoint            string
+	ProcessLabel          string
+	MountLabel            string
+	ImageAnnotations      map[string]string
+	ImageCreatedBy        string
+	OCIv1                 v1.Image
+	Docker                docker.V2Image
+	DefaultMountsFilePath string
+}
+
+// GetBuildInfo gets a pointer to a Builder object and returns a BuilderInfo object from it.
+// This is used in the inspect command to display Manifest and Config as string and not []byte.
+func GetBuildInfo(b *Builder) BuilderInfo {
+	return BuilderInfo{
+		Type:                  b.Type,
+		FromImage:             b.FromImage,
+		FromImageID:           b.FromImageID,
+		Config:                string(b.Config),
+		Manifest:              string(b.Manifest),
+		Container:             b.Container,
+		ContainerID:           b.ContainerID,
+		MountPoint:            b.MountPoint,
+		ProcessLabel:          b.ProcessLabel,
+		ImageAnnotations:      b.ImageAnnotations,
+		ImageCreatedBy:        b.ImageCreatedBy,
+		OCIv1:                 b.OCIv1,
+		Docker:                b.Docker,
+		DefaultMountsFilePath: b.DefaultMountsFilePath,
+	}
+}
+
 // BuilderOptions are used to initialize a new Builder.
 type BuilderOptions struct {
 	// FromImage is the name of the image which should be used as the

--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -96,7 +96,7 @@ func inspectCmd(c *cli.Context) error {
 	}
 
 	if c.IsSet("format") {
-		return t.Execute(os.Stdout, builder)
+		return t.Execute(os.Stdout, buildah.GetBuildInfo(builder))
 	}
 
 	b, err := json.MarshalIndent(builder, "", "    ")


### PR DESCRIPTION
Builder has the Config and the Manifest fields which are `[]byte`. The type is `[]byte` because it's eaiser to serialize them that way. However, when these fields are displayed in the following way:

```
$ buildah inspect -f '{{.Config}} {{.Manifest}}' IMAGE
```

they might be shown as a byte slice.

This patch suggests to use a struct that wraps Builder's exposed fields such as Config, Manifest and Container as strings and thus make them readable when inspecting specific field.

related to #363 