### PR TITLE
Increase compile spead using go build -i

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ LDFLAGS := -ldflags '-X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_I
 all: buildah imgtype docs
 
 buildah: *.go imagebuildah/*.go cmd/buildah/*.go docker/*.go util/*.go
-	$(GO) build $(LDFLAGS) -o buildah $(BUILDFLAGS) ./cmd/buildah
+	$(GO) build -i $(LDFLAGS) -o buildah $(BUILDFLAGS) ./cmd/buildah
 
 imgtype: *.go docker/*.go util/*.go tests/imgtype.go
-	$(GO) build $(LDFLAGS) -o imgtype $(BUILDFLAGS) ./tests/imgtype.go
+	$(GO) build -i $(LDFLAGS) -o imgtype $(BUILDFLAGS) ./tests/imgtype.go
 
 .PHONY: clean
 clean:

--- a/tests/validate/gometalinter.sh
+++ b/tests/validate/gometalinter.sh
@@ -11,6 +11,7 @@ exec gometalinter.v1 \
 	--enable-gc \
 	--exclude='error return value not checked.*(Close|Log|Print).*\(errcheck\)$' \
 	--exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$' \
+	--exclude='declaration of.*err.*shadows declaration.*\(vetshadow\)$'\
 	--exclude='duplicate of.*_test.go.*\(dupl\)$' \
 	--exclude='vendor\/.*' \
 	--disable=gotype \


### PR DESCRIPTION
Brent found a feature in go that implements --incremental builds
Basically this flag caused builds to happen much quicker, making
developers lifes happier.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>