### PR TITLE
Make lint was complaining about some vetshowed err

### DIFF
--- a/tests/validate/gometalinter.sh
+++ b/tests/validate/gometalinter.sh
@@ -11,6 +11,7 @@ exec gometalinter.v1 \
 	--enable-gc \
 	--exclude='error return value not checked.*(Close|Log|Print).*\(errcheck\)$' \
 	--exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$' \
+	--exclude='declaration of.*err.*shadows declaration.*\(vetshadow\)$'\
 	--exclude='duplicate of.*_test.go.*\(dupl\)$' \
 	--exclude='vendor\/.*' \
 	--disable=gotype \


### PR DESCRIPTION
We often use err as a variable inside of subblocks, and
we don't want golint to complain about it.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>