### PR TITLE
When we say we skip a secrets config file, do so

### DIFF
--- a/run.go
+++ b/run.go
@@ -113,6 +113,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, optionMounts 
 		secretMounts, err := secretMounts(file, b.MountLabel, cdir)
 		if err != nil {
 			logrus.Warn("error mounting secrets, skipping...")
+			continue
 		}
 		for _, mount := range secretMounts {
 			if haveMount(mount.Destination) {


### PR DESCRIPTION
When we warn about not processing a secrets configuration file, actually skip anything we might have salvaged from it to make our behavior match the warning.