### PR TITLE
Add --all functionality to rmi

### DIFF
--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -13,7 +13,7 @@ var (
 	rmFlags       = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "all, a",
-			Usage: "Remove all containers",
+			Usage: "remove all containers",
 		},
 	}
 	rmCommand = cli.Command{

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -210,6 +210,8 @@ return 1
 
  _buildah_rmi() {
      local boolean_options="
+     --all
+     -a
      --force
      -f
      --help

--- a/docs/buildah-rmi.md
+++ b/docs/buildah-rmi.md
@@ -11,13 +11,21 @@ Removes one or more locally stored images.
 
 ## OPTIONS
 
+**--all, -a**
+
+All local images will be removed from the system that do not have containers using the image as a reference image.
+
 **--force, -f**
 
-Executing this command will stop all containers that are using the image and remove them from the system
+This option will cause Buildah to remove all containers that are using the image before removing the image from the system.
 
 ## EXAMPLE
 
 buildah rmi imageID
+
+buildah rmi --all
+
+buildah rmi --all --force
 
 buildah rmi --force imageID
 

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "remove one image" {
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah rm "$cid" 
+  buildah rmi alpine
+  run buildah --debug=false images -q
+  [ "$output" == "" ]
+}
+
+@test "remove multiple images" {
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
+  buildah rmi alpine busybox 
+  run buildah --debug=false images -q
+  [ "$output" != "" ]
+
+  buildah rm $cid1 $cid2 $cid3
+  buildah rmi alpine busybox 
+  run buildah --debug=false images -q
+  [ "$output" == "" ]
+ 
+}
+
+@test "remove all images" {
+  cid1=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
+  buildah rmi -a -f 
+  run buildah --debug=false images -q
+  [ "$output" == "" ]
+
+  cid1=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
+  buildah rmi --all 
+  run buildah --debug=false images -q
+  [ "$output" != "" ]
+
+  buildah rmi --all --force
+  run buildah --debug=false images -q
+  [ "$output" == "" ]
+}


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add --all functionality to the rmi command to remove all containers.  This does a force to remove all of the associated containers for the images too.  