### PR TITLE
Remove new errors and use established ones in rmi

### DIFF
--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -77,7 +77,7 @@ func rmiCmd(c *cli.Context) error {
 				fmt.Fprintln(os.Stderr, lastError)
 			}
 			if err == nil {
-				err = errors.New("Image does not Exist")
+				err = storage.ErrNotAnImage
 			}
 			lastError = errors.Wrapf(err, "could not get image %q", id)
 			continue
@@ -106,7 +106,7 @@ func rmiCmd(c *cli.Context) error {
 						if lastError != nil {
 							fmt.Fprintln(os.Stderr, lastError)
 						}
-						lastError = errors.Wrapf(errors.New("Container Exists"), "Could not remove image %q (must force) - container %q is using its reference image", id, ctrID)
+						lastError = errors.Wrapf(storage.ErrImageUsedByContainer, "Could not remove image %q (must force) - container %q is using its reference image", id, ctrID)
 					}
 					continue
 				}


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

These were changes @rhatdan had asked for in #384.  I thought I'd included them in the last commit of that PR, but just found them in my sandbox.  Hopefully they'll stick this time.
