### PR TITLE
Don't overwrite directory permissions on --chown

### DIFF
--- a/add.go
+++ b/add.go
@@ -75,12 +75,17 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			logrus.Errorf("error unmounting container: %v", err2)
 		}
 	}()
+	// Find out which user (and group) the destination should belong to.
+	user, err := b.user(mountPoint, options.Chown)
+	if err != nil {
+		return err
+	}
 	dest := mountPoint
 	if destination != "" && filepath.IsAbs(destination) {
 		dest = filepath.Join(dest, destination)
 	} else {
-		if err = os.MkdirAll(filepath.Join(dest, b.WorkDir()), 0755); err != nil {
-			return errors.Wrapf(err, "error ensuring directory %q exists)", filepath.Join(dest, b.WorkDir()))
+		if err = ensureDir(filepath.Join(dest, b.WorkDir()), user, 0755); err != nil {
+			return err
 		}
 		dest = filepath.Join(dest, b.WorkDir(), destination)
 	}
@@ -88,8 +93,8 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	// with a '/', create it so that we can be sure that it's a directory,
 	// and any files we're copying will be placed in the directory.
 	if len(destination) > 0 && destination[len(destination)-1] == os.PathSeparator {
-		if err = os.MkdirAll(dest, 0755); err != nil {
-			return errors.Wrapf(err, "error ensuring directory %q exists", dest)
+		if err = ensureDir(dest, user, 0755); err != nil {
+			return err
 		}
 	}
 	// Make sure the destination's parent directory is usable.
@@ -106,11 +111,6 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	}
 	if len(source) > 1 && (destfi == nil || !destfi.IsDir()) {
 		return errors.Errorf("destination %q is not a directory", dest)
-	}
-	// Find out which user (and group) the destination should belong to.
-	user, err := b.user(mountPoint, options.Chown)
-	if err != nil {
-		return err
 	}
 	for _, src := range source {
 		if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
@@ -130,7 +130,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			if err := addURL(d, src); err != nil {
 				return err
 			}
-			if err := setOwner(d, user); err != nil {
+			if err := setOwner("", d, user); err != nil {
 				return err
 			}
 			continue
@@ -153,15 +153,14 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 				// the source directory into the target directory.  Try
 				// to create it first, so that if there's a problem,
 				// we'll discover why that won't work.
-				d := dest
-				if err := os.MkdirAll(d, 0755); err != nil {
-					return errors.Wrapf(err, "error ensuring directory %q exists", d)
+				if err = ensureDir(dest, user, 0755); err != nil {
+					return err
 				}
-				logrus.Debugf("copying %q to %q", gsrc+string(os.PathSeparator)+"*", d+string(os.PathSeparator)+"*")
-				if err := copyWithTar(gsrc, d); err != nil {
-					return errors.Wrapf(err, "error copying %q to %q", gsrc, d)
+				logrus.Debugf("copying %q to %q", gsrc+string(os.PathSeparator)+"*", dest+string(os.PathSeparator)+"*")
+				if err := copyWithTar(gsrc, dest); err != nil {
+					return errors.Wrapf(err, "error copying %q to %q", gsrc, dest)
 				}
-				if err := setOwner(d, user); err != nil {
+				if err := setOwner(gsrc, dest, user); err != nil {
 					return err
 				}
 				continue
@@ -179,7 +178,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 				if err := copyFileWithTar(gsrc, d); err != nil {
 					return errors.Wrapf(err, "error copying %q to %q", gsrc, d)
 				}
-				if err := setOwner(d, user); err != nil {
+				if err := setOwner(gsrc, d, user); err != nil {
 					return err
 				}
 				continue
@@ -210,26 +209,45 @@ func (b *Builder) user(mountPoint string, userspec string) (specs.User, error) {
 }
 
 // setOwner sets the uid and gid owners of a given path.
-// If path is a directory, recursively changes the owner.
-func setOwner(path string, user specs.User) error {
-	fi, err := os.Stat(path)
+func setOwner(src, dest string, user specs.User) error {
+	fid, err := os.Stat(dest)
 	if err != nil {
-		return errors.Wrapf(err, "error reading %q", path)
+		return errors.Wrapf(err, "error reading %q", dest)
 	}
-	if fi.IsDir() {
-		err2 := filepath.Walk(path, func(p string, info os.FileInfo, we error) error {
-			if err3 := os.Lchown(p, int(user.UID), int(user.GID)); err3 != nil {
-				return errors.Wrapf(err3, "error setting ownership of %q", p)
-			}
-			return nil
-		})
-		if err2 != nil {
-			return errors.Wrapf(err2, "error walking dir %q to set ownership", path)
+	if !fid.IsDir() || src == "" {
+		if err := os.Lchown(dest, int(user.UID), int(user.GID)); err != nil {
+			return errors.Wrapf(err, "error setting ownership of %q", dest)
 		}
 		return nil
 	}
-	if err := os.Lchown(path, int(user.UID), int(user.GID)); err != nil {
-		return errors.Wrapf(err, "error setting ownership of %q", path)
+	err = filepath.Walk(src, func(p string, info os.FileInfo, we error) error {
+		relPath, err2 := filepath.Rel(src, p)
+		if err2 != nil {
+			return errors.Wrapf(err2, "error getting relative path of %q to set ownership on destination", p)
+		}
+		if relPath != "." {
+			absPath := filepath.Join(dest, relPath)
+			if err2 := os.Lchown(absPath, int(user.UID), int(user.GID)); err != nil {
+				return errors.Wrapf(err2, "error setting ownership of %q", absPath)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "error walking dir %q to set ownership", src)
+	}
+	return nil
+}
+
+// ensureDir creates a directory if it doesn't exist, setting ownership and permissions as passed by user and perm.
+func ensureDir(path string, user specs.User, perm os.FileMode) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if err := os.MkdirAll(path, perm); err != nil {
+			return errors.Wrapf(err, "error ensuring directory %q exists", path)
+		}
+		if err := os.Chown(path, int(user.UID), int(user.GID)); err != nil {
+			return errors.Wrapf(err, "error setting ownership of %q", path)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
In a previous PR ( #336) I failed to check if my changes were changing the ownership of:

1) existent target directory
2) existing files in the target directory

As a result, I'm proposing these changes to fix that. 

I'm happy to re-work my patch if you think the approach isn't appropriate.

Thanks.