### PR TITLE
Show ctrid when doing rm -all

### DIFF
--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -45,6 +45,7 @@ func rmCmd(c *cli.Context) error {
 		}
 
 		for _, builder := range builders {
+			id := builder.ContainerID
 			err = builder.Delete()
 			if e == nil {
 				e = err
@@ -53,6 +54,7 @@ func rmCmd(c *cli.Context) error {
 				fmt.Fprintf(os.Stderr, "error removing container %q: %v\n", builder.Container, err)
 				continue
 			}
+			fmt.Printf("%s\n", id)
 		}
 	} else {
 		for _, name := range args {


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

While testing for the demo, I realized that the 'buildah rm --all' command was not listing the deleted container ID's as the 'buildah rm {ctrid}" command does.  This patch now displays the container ID's that were deleted as part of the 'buildah rm --all' command.

```
# buildah rm --all
f6d0978ca640176cb2a0b5b06d728f1d4df8de8a27e63a034592a0dcd045e8aa
50ba80cc067e352190d62afdd7acc5dab244f8b25b50f100531bf9b14ab6a10c
```