### PR TITLE
Fix: setting the container name to the image

### DIFF
--- a/new_test.go
+++ b/new_test.go
@@ -1,0 +1,28 @@
+package buildah
+
+import (
+	"testing"
+
+	"github.com/containers/storage"
+)
+
+func TestGetImageName(t *testing.T) {
+	tt := []struct {
+		caseName string
+		name     string
+		names    []string
+		expected string
+	}{
+		{"tagged image", "busybox1", []string{"docker.io/library/busybox:latest", "docker.io/library/busybox1:latest"}, "docker.io/library/busybox1:latest"},
+		{"image name not in the resolved image names", "image1", []string{"docker.io/library/busybox:latest", "docker.io/library/busybox1:latest"}, "docker.io/library/busybox:latest"},
+		{"resolved image with empty name list", "image1", []string{}, "image1"},
+	}
+
+	for _, tc := range tt {
+		img := &storage.Image{Names: tc.names}
+		res := getImageName(tc.name, img)
+		if res != tc.expected {
+			t.Errorf("test case '%s' failed: expected %#v but got %#v", tc.caseName, tc.expected, res)
+		}
+	}
+}

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -73,7 +73,6 @@ load helpers
 }
 
 @test "from-authenticate-cert-and-creds" {
-
   mkdir -p  ${TESTDIR}/auth
   # Create creds and store in ${TESTDIR}/auth/htpasswd
 #  docker run --entrypoint htpasswd registry:2 -Bbn testuser testpassword > ${TESTDIR}/auth/htpasswd
@@ -111,4 +110,15 @@ load helpers
 #  docker rmi -f $(docker images -q)
 #  buildah rm $ctrid
 #  buildah rmi -f $(buildah --debug=false images -q)
+}
+
+@test "from-tagged-image" {
+  # Github #396: Make sure the container name starts with the correct image even when it's tagged.
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah commit --signature-policy ${TESTSDIR}/policy.json "$cid" scratch2
+  buildah rm $cid
+  buildah tag scratch2 scratch3
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch3)
+  [ "$cid" == scratch3-working-container ]
+  buildah rmi -f --all
 }


### PR DESCRIPTION
In commit [47ac96155f1573e](https://github.com/projectatomic/buildah/commit/47ac96155f1573e1bbf7804461f6850ff67e8747) the image name that is used for setting the container name is taken from the resolved image unless it is empty.

The resolved image has the `Names` field and right now the first name is taken. However, when the image is a tagged image, the container name will end up using the original name instead of the given one.

For example:
```sh
$ buildah tag busybox busybox1
$ buildah from busybox1
```

Will set the name of the container as `busybox-working-container` while it was expected to be `busybox1-working-container`.

This patch fixes this particular issue.
fixes #396