### PR TITLE
Return a better error message when failed to resolve an image

### DIFF
--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -8,9 +8,9 @@ import (
 	"github.com/containers/image/storage"
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/storage/pkg/archive"
-	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
+	"github.com/projectatomic/buildah/util"
 	"github.com/urfave/cli"
 )
 
@@ -144,14 +144,10 @@ func commitCmd(c *cli.Context) error {
 	}
 	err = builder.Commit(dest, options)
 	if err != nil {
-		switch nErr := errors.Cause(err).(type) {
-		case errcode.Errors:
-			return cli.NewMultiError([]error(nErr)...)
-		case errcode.Error:
-			return nErr
-		default:
-			return errors.Wrapf(err, "error committing container %q to %q", builder.Container, image)
-		}
+		return util.GetFailureCause(
+			err,
+			errors.Wrapf(err, "error committing container %q to %q", builder.Container, image),
+		)
 	}
 
 	if c.Bool("rm") {

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -12,6 +12,7 @@ import (
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
+	"github.com/projectatomic/buildah/util"
 	"github.com/urfave/cli"
 )
 
@@ -141,7 +142,10 @@ func pushCmd(c *cli.Context) error {
 
 	err = buildah.Push(src, dest, options)
 	if err != nil {
-		return errors.Wrapf(err, "error pushing image %q to %q", src, destSpec)
+		return util.GetFailureCause(
+			err,
+			errors.Wrapf(err, "error pushing image %q to %q", src, destSpec),
+		)
 	}
 
 	return nil


### PR DESCRIPTION
During the creation of a new builder object there are errors that are only logged into `logrus.Debugf`.

If in the end of the process `ref` or `img` are `nil` and options.FromImage` is set then it means that there was an issue. By default, it was assumed that the image name is wrong.
Yet, this assumption isn't always correct. For example, it might fail due to authorization or connection errors.

In this patch, I am attempting to fix this problem by checking the last error stored in the `err` variable and returning the cause of the failure.

Fixes #401