### PR TITLE
Make bud be really quiet

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -380,6 +380,7 @@ func (b *Executor) Run(run imagebuilder.Run, config docker.Config) error {
 		Entrypoint:      config.Entrypoint,
 		Cmd:             config.Cmd,
 		NetworkDisabled: config.NetworkDisabled,
+		Quiet:           b.quiet,
 	}
 
 	args := run.Args

--- a/run.go
+++ b/run.go
@@ -65,6 +65,8 @@ type RunOptions struct {
 	// decision can be overridden by specifying either WithTerminal or
 	// WithoutTerminal.
 	Terminal int
+	// Quiet tells the run to turn off output to stdout.
+	Quiet bool
 }
 
 func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, optionMounts []specs.Mount, bindFiles, volumes []string) error {
@@ -286,6 +288,9 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	cmd.Dir = mountPoint
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
+	if options.Quiet {
+		cmd.Stdout = nil
+	}
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

This changes makes the  'buildah bud -q .' command really be quiet.  Prior a portion but not all of the output from the build progression was shown when you did a build.  Now it's completely quiet, no output.