### PR TITLE
Prompt for un/pwd if not supplied with --creds

### DIFF
--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -19,7 +19,9 @@ Use certificates at *path* (*.crt, *.cert, *.key) to connect to the registry
 
 **--creds** *creds*
 
-The username[:password] to use to authenticate with the registry if required.
+The [username[:password]] to use to authenticate with the registry if required.
+If one or both values are not supplied, a command line prompt will appear and the
+value can be entered.  The password is entered without echo.
 
 **--disable-compression, -D**
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -47,7 +47,9 @@ Use certificates at *path* (*.crt, *.cert, *.key) to connect to the registry
 
 **--creds** *creds*
 
-The username[:password] to use to authenticate with the registry if required.
+The [username[:password]] to use to authenticate with the registry if required.
+If one or both values are not supplied, a command line prompt will appear and the
+value can be entered.  The password is entered without echo.
 
 **--name** *name*
 

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -51,7 +51,9 @@ Use certificates at *path* (*.crt, *.cert, *.key) to connect to the registry
 
 **--creds** *creds*
 
-The username[:password] to use to authenticate with the registry if required.
+The [username[:password]] to use to authenticate with the registry if required.
+If one or both values are not supplied, a command line prompt will appear and the
+value can be entered.  The password is entered without echo.
 
 **--disable-compression, -D**
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

If either the username or password is not supplied with the --creds parameter for Buildah, the user will be prompted to input either or both of them.  The value entered for the username is echo'd back to the user, the password is not.

Samples
```
# buildah from --creds "" docker.io/tomsweeneyredhat/testing:first
Username: tomsweeneyredhat
Password: 
Getting image source signatures
Copying blob sha256:188ab0d3421d19d043df1ec825d5d9faddf21083a8f3daff73aa438195136f2f
 7.07 MiB / 64.07 MiB [======>-------------------------------------------------]^C
# 
# buildah from --creds "tomsweeneyredhat" docker.io/tomsweeneyredhat/testing:first
Password: 
Getting image source signatures
Copying blob sha256:188ab0d3421d19d043df1ec825d5d9faddf21083a8f3daff73aa438195136f2f
 2.96 MiB / 64.07 MiB [==>-----------------------------------------------------]^C
# 
# buildah from --creds "tomsweeneyredhat:" docker.io/tomsweeneyredhat/testing:first
Password: 
Getting image source signatures
Copying blob sha256:188ab0d3421d19d043df1ec825d5d9faddf21083a8f3daff73aa438195136f2f
 7.37 MiB / 64.07 MiB [======>-------------------------------------------------]^C
# 
# buildah from --creds ":testpassword" docker.io/tomsweeneyredhat/testing:first
Username: tomsweeneyredhat
Getting image source signatures
Copying blob sha256:188ab0d3421d19d043df1ec825d5d9faddf21083a8f3daff73aa438195136f2f
 4.69 MiB / 64.07 MiB [====>---------------------------------------------------]^C
# 
# buildah from --creds tomsweeneyredhat:testpassword docker.io/tomsweeneyredhat/testing:first
Getting image source signatures
Copying blob sha256:188ab0d3421d19d043df1ec825d5d9faddf21083a8f3daff73aa438195136f2f
 4.63 MiB / 64.07 MiB [====>---------------------------------------------------]^C
```