### PR TITLE
Add --dangling option to rmi command

### DIFF
--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -22,6 +22,10 @@ var (
 			Usage: "remove all images",
 		},
 		cli.BoolFlag{
+			Name:  "prune, p",
+			Usage: "prune dangling images",
+		},
+		cli.BoolFlag{
 			Name:  "force, f",
 			Usage: "force removal of the image",
 		},
@@ -39,13 +43,17 @@ var (
 func rmiCmd(c *cli.Context) error {
 	force := c.Bool("force")
 	removeAll := c.Bool("all")
+	pruneDangling := c.Bool("prune")
 
 	args := c.Args()
-	if len(args) == 0 && !removeAll {
+	if len(args) == 0 && !removeAll && !pruneDangling {
 		return errors.Errorf("image name or ID must be specified")
 	}
 	if len(args) > 0 && removeAll {
 		return errors.Errorf("when using the --all switch, you may not pass any images names or IDs")
+	}
+	if removeAll && pruneDangling {
+		return errors.Errorf("when using the --all switch, you may not use --prune switch")
 	}
 
 	if err := validateFlags(c, rmiFlags); err != nil {
@@ -61,12 +69,16 @@ func rmiCmd(c *cli.Context) error {
 	var lastError error
 
 	if removeAll {
-		images, err := store.Images()
+		imagesToDelete, err = findAllImages(store)
 		if err != nil {
-			return errors.Wrapf(err, "error reading images")
+			return err
 		}
-		for _, image := range images {
-			imagesToDelete = append(imagesToDelete, image.ID)
+	}
+
+	if pruneDangling {
+		imagesToDelete, err = findDanglingImages(store)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -271,4 +283,36 @@ func storageImageID(store storage.Store, id string) (types.ImageReference, error
 		return nil, errors.Wrapf(err, "error confirming presence of storage image reference %q", transports.ImageName(ref))
 	}
 	return nil, errors.Wrapf(err, "error parsing %q as a storage image reference: %v", id)
+}
+
+// Returns a list of all existing images
+func findAllImages(store storage.Store) ([]string, error) {
+	imagesToDelete := []string{}
+
+	images, err := store.Images()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading images")
+	}
+	for _, image := range images {
+		imagesToDelete = append(imagesToDelete, image.ID)
+	}
+
+	return imagesToDelete, nil
+}
+
+// Returns a list of all dangling images
+func findDanglingImages(store storage.Store) ([]string, error) {
+	imagesToDelete := []string{}
+
+	images, err := store.Images()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading images")
+	}
+	for _, image := range images {
+		if len(image.Names) == 0 {
+			imagesToDelete = append(imagesToDelete, image.ID)
+		}
+	}
+
+	return imagesToDelete, nil
 }

--- a/docs/buildah-rmi.md
+++ b/docs/buildah-rmi.md
@@ -15,6 +15,10 @@ Removes one or more locally stored images.
 
 All local images will be removed from the system that do not have containers using the image as a reference image.
 
+**--prune, -p**
+
+All local images will be removed from the system that do not have a tag and do not have a child image pointing to them.
+
 **--force, -f**
 
 This option will cause Buildah to remove all containers that are using the image before removing the image from the system.
@@ -26,6 +30,8 @@ buildah rmi imageID
 buildah rmi --all
 
 buildah rmi --all --force
+
+buildah rmi --prune
 
 buildah rmi --force imageID
 

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -4,7 +4,7 @@ load helpers
 
 @test "remove one image" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  buildah rm "$cid" 
+  buildah rm "$cid"
   buildah rmi alpine
   run buildah --debug=false images -q
   [ "$output" == "" ]
@@ -14,31 +14,65 @@ load helpers
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
   cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
-  buildah rmi alpine busybox 
+  buildah rmi alpine busybox
   run buildah --debug=false images -q
   [ "$output" != "" ]
 
   buildah rm $cid1 $cid2 $cid3
-  buildah rmi alpine busybox 
+  buildah rmi alpine busybox
   run buildah --debug=false images -q
   [ "$output" == "" ]
- 
 }
 
 @test "remove all images" {
   cid1=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
-  buildah rmi -a -f 
+  buildah rmi -a -f
   run buildah --debug=false images -q
   [ "$output" == "" ]
 
   cid1=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
-  buildah rmi --all 
+  buildah rmi --all
   run buildah --debug=false images -q
   [ "$output" != "" ]
+
+  buildah rmi --all --force
+  run buildah --debug=false images -q
+  [ "$output" == "" ]
+}
+
+@test "use prune to remove dangling images" {
+  createrandom ${TESTDIR}/randomfile
+  createrandom ${TESTDIR}/other-randomfile
+
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
+
+  run buildah --debug=false images -q
+  [ $(wc -l <<< "$output") -eq 1 ]
+
+  root=$(buildah mount $cid)
+  cp ${TESTDIR}/randomfile $root/randomfile
+  buildah unmount $cid
+  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+
+  run buildah --debug=false images -q
+  [ $(wc -l <<< "$output") -eq 2 ]
+
+  root=$(buildah mount $cid)
+  cp ${TESTDIR}/other-randomfile $root/other-randomfile
+  buildah unmount $cid
+  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+
+  run buildah --debug=false images -q
+  [ $(wc -l <<< "$output") -eq 3 ]
+
+  buildah rmi --prune
+
+  run buildah --debug=false images -q
+  [ $(wc -l <<< "$output") -eq 2 ]
 
   buildah rmi --all --force
   run buildah --debug=false images -q


### PR DESCRIPTION
Hi,

After using buildah for a while I ended up with many dangling images at my images list, as described at issue #410. Checking the comments on such issue it was suggested adding a --dangling option to rmi. This is my try to implement such a feature. If you think this is not the correct approach, I am happy to re-work this patch. 

Thanks