### PR TITLE
Allow all auth params to work with bud

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -21,6 +21,16 @@ var (
 			Name:  "build-arg",
 			Usage: "`argument=value` to supply to the builder",
 		},
+		cli.StringFlag{
+			Name:  "cert-dir",
+			Value: "",
+			Usage: "use certificates at the specified path to access the registry",
+		},
+		cli.StringFlag{
+			Name:  "creds",
+			Value: "",
+			Usage: "use `[username[:password]]` for accessing the registry",
+		},
 		cli.StringSliceFlag{
 			Name:  "file, f",
 			Usage: "`pathname or URL` of a Dockerfile",
@@ -181,20 +191,24 @@ func budCmd(c *cli.Context) error {
 		return err
 	}
 
+	systemContext, err := systemContextFromOptions(c)
+	if err != nil {
+		return errors.Wrapf(err, "error building system context")
+	}
+
 	options := imagebuildah.BuildOptions{
 		ContextDirectory:    contextDir,
 		PullPolicy:          pullPolicy,
 		Compression:         imagebuildah.Gzip,
 		Quiet:               c.Bool("quiet"),
 		SignaturePolicyPath: c.String("signature-policy"),
-		SkipTLSVerify:       !c.Bool("tls-verify"),
 		Args:                args,
 		Output:              output,
 		AdditionalTags:      tags,
 		Runtime:             c.String("runtime"),
 		RuntimeArgs:         c.StringSlice("runtime-flag"),
 		OutputFormat:        format,
-		AuthFilePath:        c.String("authfile"),
+		SystemContext:       systemContext,
 	}
 	if !c.Bool("quiet") {
 		options.ReportWriter = os.Stderr

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -24,7 +24,7 @@ var (
 		cli.StringFlag{
 			Name:  "creds",
 			Value: "",
-			Usage: "use `username[:password]` for accessing the registry",
+			Usage: "use `[username[:password]]` for accessing the registry",
 		},
 		cli.BoolFlag{
 			Name:  "disable-compression, D",

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -23,7 +23,7 @@ var (
 		cli.StringFlag{
 			Name:  "creds",
 			Value: "",
-			Usage: "use `username[:password]` for accessing the registry",
+			Usage: "use `[username[:password]]` for accessing the registry",
 		},
 		cli.StringFlag{
 			Name:  "name",

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -30,7 +30,7 @@ var (
 		cli.StringFlag{
 			Name:  "creds",
 			Value: "",
-			Usage: "use `username[:password]` for accessing the registry",
+			Usage: "use `[username[:password]]` for accessing the registry",
 		},
 		cli.BoolFlag{
 			Name:  "disable-compression, D",


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add creds and cert-dir params to 'buildah bud'.  I also updated the usage statements for the creds in all commands, I neglected to do that in my last PR.  Added test to the authentication test script and did a few minor touch ups there too.  This should also hopefully adddress #414 and #413.