### PR TITLE
Unescape HTML characters in inspect output

### DIFF
--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"text/template"
 
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
 	"github.com/urfave/cli"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 const (
@@ -99,10 +99,10 @@ func inspectCmd(c *cli.Context) error {
 		return t.Execute(os.Stdout, buildah.GetBuildInfo(builder))
 	}
 
-	b, err := json.MarshalIndent(builder, "", "    ")
-	if err != nil {
-		return errors.Wrapf(err, "error encoding build container as json")
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "    ")
+	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+		enc.SetEscapeHTML(false)
 	}
-	_, err = fmt.Println(string(b))
-	return err
+	return enc.Encode(builder)
 }

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -26,3 +26,15 @@ load helpers
   [ "$status" -eq 0 ]
   [ "$output" != "" ]
 }
+
+@test "HTML escaped" {
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah config --label maintainer="Darth Vader <dvader@darkside.io>" ${cid}
+  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid darkside-image
+  buildah rm ${cid}
+  output=$(buildah inspect --type image darkside-image)
+  [ $(output | grep "u003" | wc -l) -eq 0 ]
+  output=$(buildah inspect --type image darkside-image | grep "u003" | wc -l)
+  [ "$output" -ne 0 ]
+  buildah rmi darkside-image
+}


### PR DESCRIPTION
By default, the JSON encoder from the Go standard library escapes the HTML characters which causes the maintainer output looks strange:

```
"maintainer": "NGINX Docker Maintainers \u003cdocker-maint@nginx.com\u003e"
```
Instead of:
```
"maintainer": "NGINX Docker Maintainers <docker-maint@nginx.com>"
```

This patch fixes this issue in `buildah-inspect` only as this is the only place that such characters might be displayed.

closes #417 