### PR TITLE
format should override quiet for images

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -96,6 +96,10 @@ func imagesCmd(c *cli.Context) error {
 		return errors.Wrapf(err, "error reading images")
 	}
 
+	if c.IsSet("quiet") && c.IsSet("format") {
+		return errors.Errorf("quiet and format are mutually exclusive")
+	}
+
 	quiet := c.Bool("quiet")
 	truncate := !c.Bool("no-trunc")
 	digests := c.Bool("digests")


### PR DESCRIPTION
quiet was overriding format, but we want format to override quiet
if both the flags are set for buildah images.

Fixes issue https://github.com/projectatomic/buildah/issues/425

Signed-off-by: umohnani8 <umohnani@redhat.com>