### PR TITLE
Fix --runtime-flag for buildah run and buildah bud

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -196,6 +196,11 @@ func budCmd(c *cli.Context) error {
 		return errors.Wrapf(err, "error building system context")
 	}
 
+	runtimeFlags := []string{}
+	for _, arg := range c.StringSlice("runtime-flag") {
+		runtimeFlags = append(runtimeFlags, "--"+arg)
+	}
+
 	options := imagebuildah.BuildOptions{
 		ContextDirectory:    contextDir,
 		PullPolicy:          pullPolicy,
@@ -206,7 +211,7 @@ func budCmd(c *cli.Context) error {
 		Output:              output,
 		AdditionalTags:      tags,
 		Runtime:             c.String("runtime"),
-		RuntimeArgs:         c.StringSlice("runtime-flag"),
+		RuntimeArgs:         runtimeFlags,
 		OutputFormat:        format,
 		SystemContext:       systemContext,
 	}

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -73,10 +73,15 @@ func runCmd(c *cli.Context) error {
 		return errors.Wrapf(err, "error reading build container %q", name)
 	}
 
+	runtimeFlags := []string{}
+	for _, arg := range c.StringSlice("runtime-flag") {
+		runtimeFlags = append(runtimeFlags, "--"+arg)
+	}
+
 	options := buildah.RunOptions{
 		Hostname: c.String("hostname"),
 		Runtime:  c.String("runtime"),
-		Args:     c.StringSlice("runtime-flag"),
+		Args:     runtimeFlags,
 	}
 
 	if c.IsSet("tty") {

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -66,7 +66,11 @@ commands specified by the **RUN** instruction.
 
 **--runtime-flag** *flag*
 
-Adds global flags for the container rutime.
+Adds global flags for the container rutime. To list the supported flags, please
+consult manpages of your selected container runtime (`runc` is the default
+runtime, the manpage to consult is `runc(8)`).
+Note: Do not pass the leading `--` to the flag. To pass the runc flag `--log-format json`
+to buildah bud, the option given would be `--runtime-flag log-format=json`.
 
 **--signature-policy** *signaturepolicy*
 
@@ -96,6 +100,10 @@ buildah bud -t imageName .
 buildah bud --tls-verify=true -t imageName -f Dockerfile.simple
 
 buildah bud --tls-verify=false -t imageName .
+
+buildah bud --runtime-flag log-format=json .
+
+buildah bud --runtime-flag debug .
 
 ## SEE ALSO
 buildah(1), kpod-login(1), docker-login(1)

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -26,7 +26,9 @@ The *path* to an alternate OCI-compatible runtime.
 
 Adds global flags for the container runtime. To list the supported flags, please
 consult manpages of your selected container runtime (`runc` is the default
-runtime, the manpage to consult is `runc(8)`)
+runtime, the manpage to consult is `runc(8)`).
+Note: Do not pass the leading `--` to the flag. To pass the runc flag `--log-format json`
+to buildah run, the option given would be `--runtime-flag log-format=json`.
 
 **--tty**
 
@@ -49,7 +51,9 @@ buildah run containerID -- ps -auxw
 
 buildah run containerID --hostname myhost -- ps -auxw
 
-buildah run containerID --runtime-flag --no-new-keyring -- ps -auxw
+buildah run --runtime-flag log-format=json containerID /bin/bash
+
+buildah run --runtime-flag debug containerID /bin/bash
 
 buildah run --tty containerID /bin/bash
 


### PR DESCRIPTION
The --runtime-flag flag for buildah run would fail
whenever the global flags of the runtime were passed to it.
Changed it to accept the format [global-flag]=[value] where
global-flag would be converted to --[global-flag] in the code.

fixes https://github.com/projectatomic/buildah/issues/428

Signed-off-by: umohnani8 <umohnani@redhat.com>