### PR TITLE
Add authfile param to commit

### DIFF
--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -17,6 +17,10 @@ import (
 var (
 	commitFlags = []cli.Flag{
 		cli.StringFlag{
+			Name:  "authfile",
+			Usage: "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
+		},
+		cli.StringFlag{
 			Name:  "cert-dir",
 			Value: "",
 			Usage: "use certificates at the specified path to access the registry",

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -302,6 +302,7 @@ return 1
   "
 
      local options_with_args="
+          --authfile
           --cert-dir
           --creds
           --signature-policy
@@ -352,15 +353,17 @@ return 1
 
      local options_with_args="
      --authfile
-     --signature-policy
-     --runtime
-     --runtime-flag
-     --tag
-     -t
+     --build-arg
+     --cert-dir
+     --creds
      --file
      -f
-     --build-arg
      --format
+     --runtime
+     --runtime-flag
+     --signature-policy
+     --tag
+     -t
   "
 
      local all_options="$options_with_args $boolean_options"

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -16,7 +16,7 @@ to a temporary location.
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `kpod login`.
+Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--build-arg** *arg=value*
@@ -25,6 +25,16 @@ Specifies a build argument and its value, which will be interpolated in
 instructions read from the Dockerfiles in the same way that environment
 variables are, but which will not be added to environment variable list in the
 resulting image's configuration.
+
+**--cert-dir** *path*
+
+Use certificates at *path* (*.crt, *.cert, *.key) to connect to the registry
+
+**--creds** *creds*
+
+The [username[:password]] to use to authenticate with the registry if required.
+If one or both values are not supplied, a command line prompt will appear and the
+value can be entered.  The password is entered without echo.
 
 **-f, --file** *Dockerfile*
 
@@ -105,5 +115,7 @@ buildah bud --runtime-flag log-format=json .
 
 buildah bud --runtime-flag debug .
 
+buildah bud --authfile /tmp/auths/myauths.json --cert-dir ~/auth --tls-verify=true --creds=username:password -t imageName -f Dockerfile.simple
+
 ## SEE ALSO
-buildah(1), kpod-login(1), docker-login(1)
+buildah(1), podman-login(1), docker-login(1)

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -13,6 +13,11 @@ specified, an ID is assigned, but no name is assigned to the image.
 
 ## OPTIONS
 
+**--authfile** *path*
+
+Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+
 **--cert-dir** *path*
 
 Use certificates at *path* (*.crt, *.cert, *.key) to connect to the registry
@@ -72,6 +77,9 @@ This example commits the container to the image on the local registry while turn
 
 This example commits the container to the image on the local registry using credentials and certificates for authentication.
  `buildah commit --cert-dir ~/auth  --tls-verify=true --creds=username:password containerID docker://localhost:5000/imageId`
+
+This example commits the container to the image on the local registry using credentials from the /tmp/auths/myauths.json file and certificates for authentication.
+ `buildah commit --authfile /tmp/auths/myauths.json --cert-dir ~/auth  --tls-verify=true --creds=username:password containerID docker://localhost:5000/imageId`
 
 ## SEE ALSO
 buildah(1)

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -17,7 +17,7 @@ Multiple transports are supported:
   An existing local directory _path_ retrieving the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
   **docker://**_docker-reference_ (Default)
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set using `(kpod login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set using `(podman login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
 
   **docker-archive:**_path_
   An image is retrieved as a `docker load` formatted file.
@@ -38,7 +38,7 @@ The container ID of the container that was created.  On error, -1 is returned an
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `kpod login`.
+Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--cert-dir** *path*
@@ -96,4 +96,4 @@ buildah from myregistry/myrepository/imagename:imagetag --creds=myusername:mypas
 buildah from myregistry/myrepository/imagename:imagetag --authfile=/tmp/auths/myauths.json
 
 ## SEE ALSO
-buildah(1), kpod-login(1), docker-login(1)
+buildah(1), podman-login(1), docker-login(1)

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -24,7 +24,7 @@ Image stored in local container/storage
   An existing local directory _path_ storing the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
   **docker://**_docker-reference_
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set using `(kpod login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set using `(podman login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
 
   **docker-archive:**_path_[**:**_docker-reference_]
   An image is stored in the `docker save` formatted file.  _docker-reference_ is only used when creating such a file, and it must not contain a digest.
@@ -42,7 +42,7 @@ Image stored in local container/storage
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `kpod login`.
+Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--cert-dir** *path*
@@ -106,4 +106,4 @@ This example extracts the imageID image and puts it into the registry on the loc
  `# buildah push --cert-dir ~/auth --tls-verify=true --creds=username:password imageID docker://localhost:5000/my-imageID`
 
 ## SEE ALSO
-buildah(1), kpod-login(1), docker-login(1)
+buildah(1), podman-login(1), docker-login(1)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Added the missing --authfile to show the file location of the credentials as stored by podman login to the commit command.  While doing so noted we still had a number of 'kpod login' references in the man pages and have converted them to 'podman login'