### PR TITLE
Touch up rmi -f usage statement

### DIFF
--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -27,7 +27,7 @@ var (
 		},
 		cli.BoolFlag{
 			Name:  "force, f",
-			Usage: "force removal of the image",
+			Usage: "force removal of the image and any containers using the image",
 		},
 	}
 	rmiCommand = cli.Command{


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Touches up the usage to note that the containers are also removed with the -f param of rmi.  Addresses #438