### PR TITLE
Add new line after executing template for buildah inspect

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 type jsonImage struct {
@@ -372,7 +373,9 @@ func outputUsingTemplate(format string, params imageOutputParams) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println()
+	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+		fmt.Println()
+	}
 	return nil
 }
 

--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"text/template"
 
@@ -96,7 +97,13 @@ func inspectCmd(c *cli.Context) error {
 	}
 
 	if c.IsSet("format") {
-		return t.Execute(os.Stdout, buildah.GetBuildInfo(builder))
+		if err := t.Execute(os.Stdout, buildah.GetBuildInfo(builder)); err != nil {
+			return err
+		}
+		if terminal.IsTerminal(int(os.Stdout.Fd())) {
+			fmt.Println()
+		}
+		return nil
 	}
 
 	enc := json.NewEncoder(os.Stdout)


### PR DESCRIPTION
No new line was returned when using the --format flag for buildah
inspect.

Fixes https://github.com/projectatomic/buildah/issues/427

Signed-off-by: umohnani8 <umohnani@redhat.com>