### PR TITLE
Add documentation and completions for the following flags

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -15,9 +15,45 @@ import (
 
 var (
 	runFlags = []cli.Flag{
+		cli.StringSliceFlag{
+			Name:  "add-host",
+			Usage: "add a custom host-to-IP mapping (host:ip) (default [])",
+		},
+		cli.StringFlag{
+			Name:  "cgroup-parent",
+			Usage: "optional parent cgroup for the container",
+		},
+		cli.Uint64Flag{
+			Name:  "cpu-period",
+			Usage: "limit the CPU CFS (Completely Fair Scheduler) period",
+		},
+		cli.Int64Flag{
+			Name:  "cpu-quota",
+			Usage: "limit the CPU CFS (Completely Fair Scheduler) quota",
+		},
+		cli.Uint64Flag{
+			Name:  "cpu-shares, c",
+			Usage: "CPU shares (relative weight)",
+		},
+		cli.StringFlag{
+			Name:  "cpuset-cpus",
+			Usage: "CPUs in which to allow execution (0-3, 0,1)",
+		},
+		cli.StringFlag{
+			Name:  "cpuset-mems",
+			Usage: "memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.",
+		},
 		cli.StringFlag{
 			Name:  "hostname",
-			Usage: "Set the hostname inside of the container",
+			Usage: "set the hostname inside of the container",
+		},
+		cli.StringFlag{
+			Name:  "memory, m",
+			Usage: "memory limit (format: <number>[<unit>], where unit = b, k, m or g)",
+		},
+		cli.StringFlag{
+			Name:  "memory-swap",
+			Usage: "swap limit equal to memory plus swap: '-1' to enable unlimited swap",
 		},
 		cli.StringFlag{
 			Name:  "runtime",
@@ -28,9 +64,17 @@ var (
 			Name:  "runtime-flag",
 			Usage: "add global flags for the container runtime",
 		},
+		cli.StringSliceFlag{
+			Name:  "security-opt",
+			Usage: "security Options (default [])",
+		},
 		cli.BoolFlag{
 			Name:  "tty",
 			Usage: "allocate a pseudo-TTY in the container",
+		},
+		cli.StringSliceFlag{
+			Name:  "ulimit",
+			Usage: "Ulimit options (default [])",
 		},
 		cli.StringSliceFlag{
 			Name:  "volume, v",

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -352,18 +352,32 @@ return 1
   "
 
      local options_with_args="
+     --add-host
      --authfile
      --build-arg
+     -c
      --cert-dir
+     --cgroup-parent
+     --cpu-period
+     --cpu-quota
+     --cpu-shares
+     --cpuset-cpus
+     --cpuset-mems
      --creds
-     --file
      -f
+     --file
      --format
+     --label
+      -m
+     --memory
+     --memory-swap
      --runtime
      --runtime-flag
+     --security-opt
      --signature-policy
-     --tag
      -t
+     --tag
+     --ulimit
   "
 
      local all_options="$options_with_args $boolean_options"
@@ -396,11 +410,23 @@ return 1
   "
 
      local options_with_args="
+     --add-host
+     --cgroup-parent
+     --cpu-period
+     --cpu-quota
+     --cpu-shares
+     -c
+     --cpuset-cpus
+     --cpuset-mems
      --hostname
+     --memory , -m
+     --memory-swap
      --runtime
      --runtime-flag
+     --security-opt
      --volume
      -v
+     --ulimit
   "
 
      local all_options="$options_with_args $boolean_options"

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -13,6 +13,11 @@ build context directory.  The build context directory can be specified as the
 to a temporary location.
 
 ## OPTIONS
+**--add-host**=[]
+   Add a custom host-to-IP mapping (host:ip)
+
+   Add a line to /etc/hosts. The format is hostname:ip. The **--add-host**
+option can be set multiple times.
 
 **--authfile** *path*
 
@@ -29,6 +34,67 @@ resulting image's configuration.
 **--cert-dir** *path*
 
 Use certificates at *path* (*.crt, *.cert, *.key) to connect to the registry
+
+**--cgroup-parent**=""
+   Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
+
+**--cpu-period**=*0*
+    Limit the CPU CFS (Completely Fair Scheduler) period
+
+    Limit the container's CPU usage. This flag tell the kernel to restrict the container's CPU usage to the period you specify.
+
+**--cpu-quota**=*0*
+   Limit the CPU CFS (Completely Fair Scheduler) quota
+
+   Limit the container's CPU usage. By default, containers run with the full
+CPU resource. This flag tell the kernel to restrict the container's CPU usage
+to the quota specified.
+
+**--cpu-shares**=*0*
+   CPU shares (relative weight)
+
+   By default, all containers get the same proportion of CPU cycles. This proportion
+can be modified by changing the container's CPU share weighting relative
+to the weighting of all other running containers.
+
+To modify the proportion from the default of 1024, use the **--cpu-shares**
+flag to set the weighting to 2 or higher.
+
+The proportion will only apply when CPU-intensive processes are running.
+When tasks in one container are idle, other containers can use the
+left-over CPU time. The actual amount of CPU time will vary depending on
+the number of containers running on the system.
+
+For example, consider three containers, one has a cpu-share of 1024 and
+two others have a cpu-share setting of 512. When processes in all three
+containers attempt to use 100% of CPU, the first container would receive
+50% of the total CPU time. If you add a fourth container with a cpu-share
+of 1024, the first container only gets 33% of the CPU. The remaining containers
+receive 16.5%, 16.5% and 33% of the CPU.
+
+On a multi-core system, the shares of CPU time are distributed over all CPU
+cores. Even if a container is limited to less than 100% of CPU time, it can
+use 100% of each individual CPU core.
+
+For example, consider a system with more than three cores. If you start one
+container **{C0}** with **-c=512** running one process, and another container
+**{C1}** with **-c=1024** running two processes, this can result in the following
+division of CPU shares:
+
+    PID    container	CPU	CPU share
+    100    {C0}		0	100% of CPU0
+    101    {C1}		1	100% of CPU1
+    102    {C1}		2	100% of CPU2
+
+**--cpuset-cpus**=""
+   CPUs in which to allow execution (0-3, 0,1)
+
+**--cpuset-mems**=""
+   Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
+
+   If you have four memory nodes on your system (0-3), use `--cpuset-mems=0,1`
+then processes in your container will only use memory from the first
+two memory nodes.
 
 **--creds** *creds*
 

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -15,6 +15,73 @@ interactive shell, you need to specify the --tty flag.
 
 ## OPTIONS
 
+**--add-host**=[]
+   Add a custom host-to-IP mapping (host:ip)
+
+   Add a line to /etc/hosts. The format is hostname:ip. The **--add-host**
+option can be set multiple times.
+
+**--cgroup-parent**=""
+   Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
+
+**--cpu-period**=*0*
+    Limit the CPU CFS (Completely Fair Scheduler) period
+
+    Limit the container's CPU usage. This flag tell the kernel to restrict the container's CPU usage to the period you specify.
+
+**--cpu-quota**=*0*
+   Limit the CPU CFS (Completely Fair Scheduler) quota
+
+   Limit the container's CPU usage. By default, containers run with the full
+CPU resource. This flag tell the kernel to restrict the container's CPU usage
+to the quota specified.
+
+**--cpu-shares**=*0*
+   CPU shares (relative weight)
+
+   By default, all containers get the same proportion of CPU cycles. This proportion
+can be modified by changing the container's CPU share weighting relative
+to the weighting of all other running containers.
+
+To modify the proportion from the default of 1024, use the **--cpu-shares**
+flag to set the weighting to 2 or higher.
+
+The proportion will only apply when CPU-intensive processes are running.
+When tasks in one container are idle, other containers can use the
+left-over CPU time. The actual amount of CPU time will vary depending on
+the number of containers running on the system.
+
+For example, consider three containers, one has a cpu-share of 1024 and
+two others have a cpu-share setting of 512. When processes in all three
+containers attempt to use 100% of CPU, the first container would receive
+50% of the total CPU time. If you add a fourth container with a cpu-share
+of 1024, the first container only gets 33% of the CPU. The remaining containers
+receive 16.5%, 16.5% and 33% of the CPU.
+
+On a multi-core system, the shares of CPU time are distributed over all CPU
+cores. Even if a container is limited to less than 100% of CPU time, it can
+use 100% of each individual CPU core.
+
+For example, consider a system with more than three cores. If you start one
+container **{C0}** with **-c=512** running one process, and another container
+**{C1}** with **-c=1024** running two processes, this can result in the following
+division of CPU shares:
+
+    PID    container	CPU	CPU share
+    100    {C0}		0	100% of CPU0
+    101    {C1}		1	100% of CPU1
+    102    {C1}		2	100% of CPU2
+
+**--cpuset-cpus**=""
+   CPUs in which to allow execution (0-3, 0,1)
+
+**--cpuset-mems**=""
+   Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
+
+   If you have four memory nodes on your system (0-3), use `--cpuset-mems=0,1`
+then processes in your container will only use memory from the first
+two memory nodes.
+
 **--hostname**
 Set the hostname inside of the running container.
 


### PR DESCRIPTION
	--add-host
	--cgroup-parent
	--cpu-period
	--cpu-quota
	--cpu-shares
	--cpuset-mems
	--memory
	--memory-swap
	--security-opt
	--ulimit

These flags are going to be used by buildah run and bud.
The implementation will follow in another PR.

Signed-off-by: umohnani8 <umohnani@redhat.com>