### PR TITLE
build-using-dockerfile: set the 'author' field for MAINTAINER

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -575,6 +575,9 @@ func (b *Executor) Commit(ib *imagebuilder.Builder) (err error) {
 	if err != nil {
 		return errors.Wrapf(err, "error parsing reference for image to be written")
 	}
+	if ib.Author != "" {
+		b.builder.SetMaintainer(ib.Author)
+	}
 	config := ib.Config()
 	b.builder.SetHostname(config.Hostname)
 	b.builder.SetDomainname(config.Domainname)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -236,3 +236,18 @@ load helpers
   [ "$status" -eq 0 ]
   [ "$output" = "" ]
 }
+
+@test "bud-maintainer" {
+  target=alpine-image
+  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/maintainer
+  run buildah --debug=false inspect --type=image --format '{{.Docker.Author}}' ${target}
+  [ "$status" -eq 0 ]
+  [ "$output" = kilroy ]
+  run buildah --debug=false inspect --type=image --format '{{.OCIv1.Author}}' ${target}
+  [ "$status" -eq 0 ]
+  [ "$output" = kilroy ]
+  buildah rmi $(buildah --debug=false images -q)
+  run buildah --debug=false images -q
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}

--- a/tests/bud/maintainer/Dockerfile
+++ b/tests/bud/maintainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine
+MAINTAINER kilroy


### PR DESCRIPTION
When we encounter the MAINTAINER keyword in a Dockerfile, imagebuilder updates the Author field in the imagebuilder.Builder structure.  Pick up that value when we go to commit the image.

This should fix #448.