### PR TITLE
Fix unintended reversal of the ignoreUnrecognizedInstructions flag

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -389,12 +389,12 @@ func (b *Executor) Run(run imagebuilder.Run, config docker.Config) error {
 // UnrecognizedInstruction is called when we encounter an instruction that the
 // imagebuilder parser didn't understand.
 func (b *Executor) UnrecognizedInstruction(step *imagebuilder.Step) error {
-	if !b.ignoreUnrecognizedInstructions {
-		logrus.Debugf("+(UNIMPLEMENTED?) %#v", step)
+	if b.ignoreUnrecognizedInstructions {
+		logrus.Debugf("+(UNIMPLEMENTED KEYWORD %q) %#v", step.Command, step)
 		return nil
 	}
-	logrus.Errorf("+(UNIMPLEMENTED?) %#v", step)
-	return errors.Errorf("Unrecognized instruction: %#v", step)
+	logrus.Errorf("+(UNIMPLEMENTED KEYWORD %q?) %#v", step.Command, step)
+	return errors.Errorf("Unrecognized instruction %q: %#v", step.Command, step)
 }
 
 // NewExecutor creates a new instance of the imagebuilder.Executor interface.

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -251,3 +251,14 @@ load helpers
   [ "$status" -eq 0 ]
   [ "$output" = "" ]
 }
+
+@test "bud-unrecognized-instruction" {
+  target=alpine-image
+  run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/unrecognized
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ BOGUS ]]
+  buildah rmi $(buildah --debug=false images -q)
+  run buildah --debug=false images -q
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}

--- a/tests/bud/unrecognized/Dockerfile
+++ b/tests/bud/unrecognized/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine
+BOGUS nope-nope-nope


### PR DESCRIPTION
We were interpreting the ignoreUnrecognizedInstructions incorrectly, so fix that, and call out the unrecognized instruction keyword in the error message (or debug message, if we're ignoring it).

Should fix #451.