### PR TITLE
COPR enablement

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,28 @@
+#!/usr/bin/make -f
+
+spec := contrib/rpm/buildah_copr.spec
+outdir := $(CURDIR)
+tmpdir := build
+gitdir := $(PWD)/.git
+
+rev := $(shell sed 's/\(.......\).*/\1/' $(gitdir)/$$(sed -n '/^ref:/{s/.* //;p}' $(gitdir)/HEAD))
+date := $(shell date +%Y%m%d.%H%M)
+
+version := $(shell sed -n '/Version:/{s/.* //;p}' $(spec))
+release := $(date).git.$(rev)
+
+srpm: $(outdir)/buildah-$(version)-$(release).src.rpm
+
+$(tmpdir)/buildah.spec: $(spec)
+	@mkdir -p $(tmpdir)
+	sed '/^Release:/s/\(: *\).*/\1$(release)%{?dist}/' $< >$@
+
+$(tmpdir)/$(version).tar.gz: $(gitdir)/..
+	@mkdir -p $(tmpdir)
+	tar c --exclude-vcs --exclude-vcs-ignores -C $< --transform 's|^\.|buildah-$(version)|' . | gzip -9 >$@
+
+$(outdir)/buildah-$(version)-$(release).src.rpm: $(tmpdir)/buildah.spec $(tmpdir)/$(version).tar.gz
+	@mkdir -p $(outdir)
+	rpmbuild -D'_srcrpmdir $(outdir)' -D'_sourcedir $(tmpdir)' -bs $(tmpdir)/buildah.spec
+
+.PHONY: srpm

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docs/buildah*.1
 /buildah
 /imgtype
+/build/

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ imgtype: *.go docker/*.go util/*.go tests/imgtype.go
 
 .PHONY: clean
 clean:
-	$(RM) buildah imgtype
+	$(RM) buildah imgtype build
 	$(MAKE) -C docs clean 
 
 .PHONY: docs


### PR DESCRIPTION
For COPR builds, we will use a a slightly modified spec and the
makesrpm method over SCM builds so we can have dynamic package
names.

Signed-off-by: baude <bbaude@redhat.com>