### PR TITLE
Docs: note that buildah needs to run as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The Buildah package provides a command line tool which can be used to
 From [`./examples/lighttpd.sh`](examples/lighttpd.sh):
 
 ```bash
-cat > lighttpd.sh <<EOF
+$ cat > lighttpd.sh <<EOF
 #!/bin/bash -x
 
 ctr1=`buildah from ${1:-fedora}`
@@ -48,8 +48,8 @@ buildah config $ctr1 --port 80
 buildah commit $ctr1 ${2:-$USER/lighttpd}
 EOF
 
-chmod +x lighttpd.sh
-./lighttpd.sh
+$ chmod +x lighttpd.sh
+$ sudo ./lighttpd.sh
 ```
 
 ## Commands

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -16,6 +16,8 @@ The Buildah package provides a command line tool which can be used to:
     * Use the updated contents of a container's root filesystem as a filesystem layer to create a new image.
     * Delete a working container or an image.
 
+This tool needs to be run as the root user.
+
 ## OPTIONS
 
 **--debug**


### PR DESCRIPTION
You have to be root to run buildah. This commit adds a notice to the
buildah(1) man-page and improves the front-page README.md a bit so that
this is more obvious to the user.

Fixes issue #420.