### PR TITLE
Add limitation to buildah rmi man page

### DIFF
--- a/docs/buildah-rmi.md
+++ b/docs/buildah-rmi.md
@@ -9,6 +9,11 @@ buildah rmi - Removes one or more images.
 ## DESCRIPTION
 Removes one or more locally stored images.
 
+## LIMITATIONS
+If the image was pushed to a directory path using the 'dir:' transport
+the rmi command can not remove the image.  Instead standard file system
+commands should be used.
+
 ## OPTIONS
 
 **--all, -a**


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add clarity to the buildah rmi command man page to note that images pushed using 'dir:' as a transport can not  be removed using the rmi command.

Addresses https://github.com/projectatomic/buildah/issues/430