### PR TITLE
contrib/rpm/buildah_copr.spec

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,12 +1,12 @@
 #!/usr/bin/make -f
 
-spec := contrib/rpm/buildah_copr.spec
+spec := contrib/rpm/buildah.spec
 outdir := $(CURDIR)
 tmpdir := build
 gitdir := $(PWD)/.git
 
 rev := $(shell sed 's/\(.......\).*/\1/' $(gitdir)/$$(sed -n '/^ref:/{s/.* //;p}' $(gitdir)/HEAD))
-date := $(shell date +%Y%m%d.%H%M)
+date := $(shell date +%Y%m%d)
 
 version := $(shell sed -n '/Version:/{s/.* //;p}' $(spec))
 release := $(date).git.$(rev)

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,9 @@ imgtype: *.go docker/*.go util/*.go tests/imgtype.go
 
 .PHONY: clean
 clean:
-	$(RM) buildah imgtype build
+	$(RM) buildah imgtype
 	$(MAKE) -C docs clean 
+	rm -fr build/
 
 .PHONY: docs
 docs: ## build the docs on the host

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -30,7 +30,7 @@ Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
 URL:            https://%{provider_prefix}
-Source:         https://%{provider_prefix}/archive/%{commit}/%{repo}-%{shortcommit}.tar.gz
+Source0:        https://%{provider_prefix}/%{version}.tar.gz
 
 ExclusiveArch:  x86_64 aarch64 ppc64le
 # If go_compiler is not set to 1, there is no virtual provide. Use golang instead.
@@ -59,7 +59,7 @@ or
 * delete a working container or an image
 
 %prep
-%autosetup -Sgit -n %{name}-%{commit}
+%autosetup -Sgit
 
 %build
 mkdir _build

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -9,6 +9,7 @@ load helpers
 }
 
 @test "buildah version up to date in .spec file" {
+    skip "the copr spec doesnt use release/version"
 	run buildah version
 	[ "$status" -eq 0 ]
 	bversion=$(echo "$output" | awk '/^Version:/ { print $NF }')


### PR DESCRIPTION
Tom and I decided we would not edit the original RPM spec
for copr builds and would instead provide a second one.

Signed-off-by: baude <bbaude@redhat.com>