### PR TITLE
Don't drop error on mix case imagename

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -567,6 +567,8 @@ func (b *Executor) Commit(ib *imagebuilder.Builder) (err error) {
 			if err2 == nil {
 				imageRef = imageRef2
 				err = nil
+			} else {
+				err = err2
 			}
 		}
 	} else {


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

When 'buildah bud -t MyF27 .'was invoked, it would error out with:
```
ERRO[0000] error building: error parsing reference for image to be written: Invalid image name "Myalpine", expected colon-separated transport:reference
```
The issue was the image name had to be all lower case.  The error noting that from containers/image/storage/storage_transport.go: ParseStoreReference() was being dropped.

The change now shows the error so the user know what's up:

```
new error: ERRO[0000] error building: error parsing reference for image to be written: error parsing named reference "Myalpine": invalid reference format: repository name must be lowercase 
```

This addresses: https://github.com/projectatomic/libpod/issues/301