### PR TITLE
Add redis test to baseline

### DIFF
--- a/tests/test_buildah_baseline.sh
+++ b/tests/test_buildah_baseline.sh
@@ -18,6 +18,12 @@ buildah images
 buildah containers
 
 ########
+# Run ls in redis container, this should work 
+########
+ctrid=$(buildah from registry.access.redhat.com/rhscl/redis-32-rhel7)
+buildah run $ctrid ls /
+
+########
 # Create Fedora based container
 ########
 container=$(buildah from fedora)
@@ -189,5 +195,5 @@ buildah run $whalesays
 ########
 # Clean up Buildah
 ########
-buildah rm $(buildah containers -q)
-buildah rmi -f $(buildah --debug=false images -q)
+buildah rm --all
+buildah rmi --all


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Adds tests to baseline script to verify the issue reported by @bertinatto  in https://github.com/projectatomic/buildah/issues/334 doesn't reappear.