### PR TITLE
Fix versioning to 0.12

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -19,7 +19,8 @@ const (
 	// Package is the name of this package, used in help output and to
 	// identify working containers.
 	Package = "buildah"
-	// Version for the Package
+	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
+	// too.
 	Version = "0.12"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -25,7 +25,8 @@
 %global shortcommit    %(c=%{commit}; echo ${c:0:7})
 
 Name:           buildah
-Version:        0.11
+# Bump version in buildah.go too
+Version:        0.12
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Somehow the tests didn't fllag that we missed a version bump in the rpm file yesterday, but they're flagging it now.  @umohnani8 @baude this is at least part of your test failures.