### PR TITLE
Display full error string instead of just status

### DIFF
--- a/new.go
+++ b/new.go
@@ -220,7 +220,7 @@ func newBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
 		// If options.FromImage is set but we ended up
 		// with nil in ref or in img then there was an error that
 		// we should return.
-		return nil, util.GetFailureCause(err, errors.Wrapf(storage.ErrImageUnknown, "no such image %q", options.FromImage))
+		return nil, util.GetFailureCause(err, errors.Wrapf(storage.ErrImageUnknown, "no such image %q in registry", options.FromImage))
 	}
 	image := options.FromImage
 	imageID := ""

--- a/util/util.go
+++ b/util/util.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"fmt"
 	"net/url"
 	"path"
 	"strings"
@@ -14,7 +13,6 @@ import (
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 )
 
 const (
@@ -163,16 +161,10 @@ func AddImageNames(store storage.Store, image *storage.Image, addNames []string)
 func GetFailureCause(err, defaultError error) error {
 	switch nErr := errors.Cause(err).(type) {
 	case errcode.Errors:
-		return cli.NewMultiError([]error(nErr)...)
+		return err
 	case errcode.Error, *url.Error:
 		return nErr
 	default:
-		// HACK: In case the error contains "not authorized" like in
-		//       https://github.com/containers/image/blob/master/docker/docker_image_dest.go#L193-L205
-		// TODO(bshuster): change "containers/images" to return "errcode" rather than "error".
-		if strings.Contains(nErr.Error(), "not authorized") {
-			return fmt.Errorf("unauthorized: authentication required")
-		}
 		return defaultError
 	}
 }


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Show the full error for commit and pull errors rather than just the error code.   As noted in #474 the error seen if the requested registry did not have an image was:

```
# buildah from busybox
unknown: Not Found
```

With this fix in place it's a lot more verbose, but perhaps not as pretty.  More adjustments might be made in the containers side, or even here.  New errors look like the following.  The first is a bad authentication to a private image, the second is the new error for the image not found situation line in #474.

```
# /usr/local/bin/buildah from docker.io/tomsweeneyredhat/testing:first
Error determining manifest MIME type for docker://tomsweeneyredhat/testing:first: errors:
denied: requested access to the resource is denied
unauthorized: authentication required

# /usr/local/bin/buildah from busybox
Error determining manifest MIME type for docker://registry.access.redhat.com/busybox:latest: unknown: Not Found
```

@ripcurld0 thoughts?