### PR TITLE
Fix secrets patch for buildah bud

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -207,19 +207,20 @@ func budCmd(c *cli.Context) error {
 	}
 
 	options := imagebuildah.BuildOptions{
-		ContextDirectory:    contextDir,
-		PullPolicy:          pullPolicy,
-		Compression:         imagebuildah.Gzip,
-		Quiet:               c.Bool("quiet"),
-		SignaturePolicyPath: c.String("signature-policy"),
-		Args:                args,
-		Output:              output,
-		AdditionalTags:      tags,
-		Runtime:             c.String("runtime"),
-		RuntimeArgs:         runtimeFlags,
-		OutputFormat:        format,
-		SystemContext:       systemContext,
-		CommonBuildOpts:     commonOpts,
+		ContextDirectory:      contextDir,
+		PullPolicy:            pullPolicy,
+		Compression:           imagebuildah.Gzip,
+		Quiet:                 c.Bool("quiet"),
+		SignaturePolicyPath:   c.String("signature-policy"),
+		Args:                  args,
+		Output:                output,
+		AdditionalTags:        tags,
+		Runtime:               c.String("runtime"),
+		RuntimeArgs:           runtimeFlags,
+		OutputFormat:          format,
+		SystemContext:         systemContext,
+		CommonBuildOpts:       commonOpts,
+		DefaultMountsFilePath: c.GlobalString("default-mounts-file"),
 	}
 
 	if !c.Bool("quiet") {


### PR DESCRIPTION
buildah bud was failing to get the secrets data
The issue was buildah bud was not being given the /usr/share/containers/mounts.conf file path
so it had no secrets to mount
Also reworked the way the secrets data was being copied from the host to the container

Signed-off-by: umohnani8 <umohnani@redhat.com>