### PR TITLE
If commonOpts do not exist, we should return rather then segfault

### DIFF
--- a/run.go
+++ b/run.go
@@ -107,6 +107,10 @@ func addHostsToFile(hosts []string) error {
 }
 
 func addCommonOptsToSpec(commonOpts *CommonBuildOptions, g *generate.Generator) error {
+	if commonOpts == nil {
+		return nil
+	}
+
 	// RESOURCES - CPU
 	if commonOpts.CPUPeriod != 0 {
 		g.SetLinuxResourcesCPUPeriod(commonOpts.CPUPeriod)


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>