### PR TITLE
Add selinux test from #486

### DIFF
--- a/tests/test_buildah_baseline.sh
+++ b/tests/test_buildah_baseline.sh
@@ -23,6 +23,16 @@ buildah containers
 ctrid=$(buildah from registry.access.redhat.com/rhscl/redis-32-rhel7)
 buildah run $ctrid ls /
 
+
+########
+# Validate touch works after installing httpd, solved selinux
+# issue that should now work.
+########
+ctr=$(buildah from scratch)
+mnt=$(buildah mount $ctr)
+dnf -y install --installroot=$mnt --releasever=27 httpd
+buildah run $ctr touch /test
+
 ########
 # Create Fedora based container
 ########


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Adds a test to the baseline test suite to make sure an selinux issue is no more.  This is not run by the CI tests systems, only by hand to check on the health of a new kit.