### PR TITLE
Allow --cmd parameter to have commands as values

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -202,12 +202,17 @@ func validateFlags(c *cli.Context, flags []cli.Flag) error {
 		return errors.Wrap(err, "compiling regex failed")
 	}
 
+	// The --cmd flag can have a following command i.e. --cmd="--help".
+	// Let's skip this check just for the --cmd flag.
 	for _, flag := range flags {
 		switch reflect.TypeOf(flag).String() {
 		case "cli.StringSliceFlag":
 			{
 				f := flag.(cli.StringSliceFlag)
 				name := strings.Split(f.Name, ",")
+				if f.Name == "cmd" {
+					continue
+				}
 				val := c.StringSlice(name[0])
 				for _, v := range val {
 					if ok := re.MatchString(v); ok {
@@ -219,6 +224,9 @@ func validateFlags(c *cli.Context, flags []cli.Flag) error {
 			{
 				f := flag.(cli.StringFlag)
 				name := strings.Split(f.Name, ",")
+				if f.Name == "cmd" {
+					continue
+				}
 				val := c.String(name[0])
 				if ok := re.MatchString(val); ok {
 					return errors.Errorf("option --%s requires a value", name[0])


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

When the --cmd flag had a value in it with a dash  like the below, it would error out when it should not:
```
# buildah config --cmd "--help" $bldah
option --cmd requires a value
```
This fix stops checking the value that's passed in for --cmd.  There is a slight danger that a user could forget to add a value and then pass in a Buildah flag after the --cmd that would mess things up, but I don't think we can protect them from all possible permutations.

This addresses #461