### PR TITLE
Show Config/Manifest as JSON string in inspect when format is not set

### DIFF
--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -96,9 +96,9 @@ func inspectCmd(c *cli.Context) error {
 	default:
 		return errors.Errorf("the only recognized types are %q and %q", inspectTypeContainer, inspectTypeImage)
 	}
-
+	out := buildah.GetBuildInfo(builder)
 	if c.IsSet("format") {
-		if err := t.Execute(os.Stdout, buildah.GetBuildInfo(builder)); err != nil {
+		if err := t.Execute(os.Stdout, out); err != nil {
 			return err
 		}
 		if terminal.IsTerminal(int(os.Stdout.Fd())) {
@@ -112,5 +112,5 @@ func inspectCmd(c *cli.Context) error {
 	if terminal.IsTerminal(int(os.Stdout.Fd())) {
 		enc.SetEscapeHTML(false)
 	}
-	return enc.Encode(builder)
+	return enc.Encode(out)
 }

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "inspect-config-is-json" {
+	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	out=$(buildah inspect alpine | grep "Config" | grep "{" | wc -l)
+	# if there is "{" it's a JSON string
+	[ "$out" -ne "0" ]
+	buildah rm $cid
+	buildah rmi -f alpine
+}
+
+@test "inspect-manifest-is-json" {
+	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	out=$(buildah inspect alpine | grep "Manifest" | grep "{" | wc -l)
+	# if there is "{" it's a JSON string
+	[ "$out" -ne "0" ]
+	buildah rm $cid
+	buildah rmi -f alpine
+}
+
+@test "inspect-format-config-is-json" {
+	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	out=$(buildah inspect --format "{{.Config}}" alpine | grep "{" | wc -l)
+	# if there is "{" it's a JSON string
+	[ "$out" -ne "0" ]
+	buildah rm $cid
+	buildah rmi -f alpine
+}
+
+@test "inspect-format-manifest-is-json" {
+	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	out=$(buildah inspect --format "{{.Manifest}}" alpine |  grep "{" | wc -l)
+	# if there is "{" it's a JSON string
+	[ "$out" -ne "0" ]
+	buildah rm $cid
+	buildah rmi -f alpine
+}
+


### PR DESCRIPTION
In https://github.com/projectatomic/buildah/issues/363:
Config and Manifest are displayed as a string representing JSON only when "--format" is set.
However, this is necessary too if "--format" is not set.

This patch fixes this by using the same technique in above to make the representation of Manifest and Config consistent.

Fixes #429 