### PR TITLE
Add various transport support to buildah from

### DIFF
--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -3,9 +3,11 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
+	util "github.com/projectatomic/buildah/util"
 	"github.com/urfave/cli"
 )
 
@@ -100,8 +102,17 @@ func fromCmd(c *cli.Context) error {
 		return err
 	}
 
+	transport := buildah.DefaultTransport
+	arr := strings.SplitN(args[0], ":", 2)
+	if len(arr) == 2 {
+		if _, ok := util.Transports[arr[0]]; ok {
+			transport = arr[0]
+		}
+	}
+
 	options := buildah.BuilderOptions{
 		FromImage:             args[0],
+		Transport:             transport,
 		Container:             c.String("name"),
 		PullPolicy:            pullPolicy,
 		SignaturePolicyPath:   signaturePolicy,

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -25,7 +25,7 @@ Multiple transports are supported:
   **docker-daemon:**_docker-reference_
   An image _docker-reference_ stored in the docker daemon internal storage.  _docker-reference_ must contain either a tag or a digest.  Alternatively, when reading images, the format can also be docker-daemon:algo:digest (an image ID).
 
-  **oci:**_path_**:**_tag_
+  **oci-archive:**_path_**:**_tag_
   An image _tag_ in a directory compliant with "Open Container Image Layout Specification" at _path_.
 
   **ostree:**_image_[**@**_/absolute/repo/path_]
@@ -271,6 +271,14 @@ mount can be changed directly. For instance if `/` is the source mount for
 buildah from imagename --pull
 
 buildah from docker://myregistry.example.com/imagename --pull
+
+buildah from docker-daemon:imagename:imagetag
+
+buildah from docker-archive:filename --name mycontainer
+
+buildah from oci-archive:filename
+
+buildah from dir:directoryname --name mycontainer
 
 buildah from imagename --signature-policy /etc/containers/policy.json
 

--- a/new.go
+++ b/new.go
@@ -177,7 +177,11 @@ func newBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
 				err = err2
 				continue
 			}
-			srcRef2, err3 := alltransports.ParseImageName(options.Transport + image)
+			transport := options.Transport
+			if transport != DefaultTransport {
+				transport = transport + ":"
+			}
+			srcRef2, err3 := alltransports.ParseImageName(transport + image)
 			if err3 != nil {
 				logrus.Debugf("error parsing image name %q: %v", image, err2)
 				err = err3
@@ -186,7 +190,7 @@ func newBuilder(store storage.Store, options BuilderOptions) (*Builder, error) {
 			srcRef = srcRef2
 		}
 
-		destImage, err2 := localImageNameForReference(store, srcRef)
+		destImage, err2 := localImageNameForReference(store, srcRef, options.FromImage)
 		if err2 != nil {
 			return nil, errors.Wrapf(err2, "error computing local image name for %q", transports.ImageName(srcRef))
 		}

--- a/pull.go
+++ b/pull.go
@@ -5,6 +5,8 @@ import (
 
 	cp "github.com/containers/image/copy"
 	"github.com/containers/image/docker/reference"
+	tarfile "github.com/containers/image/docker/tarfile"
+	ociarchive "github.com/containers/image/oci/archive"
 	"github.com/containers/image/signature"
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/transports"
@@ -12,38 +14,88 @@ import (
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah/util"
 	"github.com/sirupsen/logrus"
 )
 
-func localImageNameForReference(store storage.Store, srcRef types.ImageReference) (string, error) {
+func localImageNameForReference(store storage.Store, srcRef types.ImageReference, spec string) (string, error) {
 	if srcRef == nil {
 		return "", errors.Errorf("reference to image is empty")
 	}
-	ref := srcRef.DockerReference()
-	if ref == nil {
-		name := srcRef.StringWithinTransport()
-		_, err := is.Transport.ParseStoreReference(store, name)
-		if err == nil {
-			return name, nil
+	split := strings.SplitN(spec, ":", 2)
+	file := split[len(split)-1]
+	var name string
+	switch srcRef.Transport().Name() {
+	case util.DockerArchive:
+		tarSource, err := tarfile.NewSourceFromFile(file)
+		if err != nil {
+			return "", err
 		}
-		if strings.LastIndex(name, "/") != -1 {
-			name = name[strings.LastIndex(name, "/")+1:]
-			_, err = is.Transport.ParseStoreReference(store, name)
+		manifest, err := tarSource.LoadTarManifest()
+		if err != nil {
+			return "", errors.Errorf("error retrieving manifest.json: %v", err)
+		}
+		// to pull the first image stored in the tar file
+		if len(manifest) == 0 {
+			// use the hex of the digest if no manifest is found
+			name, err = getImageDigest(srcRef, nil)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			if len(manifest[0].RepoTags) > 0 {
+				name = manifest[0].RepoTags[0]
+			} else {
+				// If the input image has no repotags, we need to feed it a dest anyways
+				name, err = getImageDigest(srcRef, nil)
+				if err != nil {
+					return "", err
+				}
+			}
+		}
+	case util.OCIArchive:
+		// retrieve the manifest from index.json to access the image name
+		manifest, err := ociarchive.LoadManifestDescriptor(srcRef)
+		if err != nil {
+			return "", errors.Wrapf(err, "error loading manifest for %q", srcRef)
+		}
+		if manifest.Annotations == nil || manifest.Annotations["org.opencontainers.image.ref.name"] == "" {
+			return "", errors.Errorf("error, archive doesn't have a name annotation. Cannot store image with no name")
+		}
+		name = manifest.Annotations["org.opencontainers.image.ref.name"]
+	case util.DirTransport:
+		// supports pull from a directory
+		name = split[1]
+		// remove leading "/"
+		if name[:1] == "/" {
+			name = name[1:]
+		}
+	default:
+		ref := srcRef.DockerReference()
+		if ref == nil {
+			name := srcRef.StringWithinTransport()
+			_, err := is.Transport.ParseStoreReference(store, name)
 			if err == nil {
 				return name, nil
 			}
+			if strings.LastIndex(name, "/") != -1 {
+				name = name[strings.LastIndex(name, "/")+1:]
+				_, err = is.Transport.ParseStoreReference(store, name)
+				if err == nil {
+					return name, nil
+				}
+			}
+			return "", errors.Errorf("reference to image %q is not a named reference", transports.ImageName(srcRef))
 		}
-		return "", errors.Errorf("reference to image %q is not a named reference", transports.ImageName(srcRef))
-	}
 
-	name := ""
-	if named, ok := ref.(reference.Named); ok {
-		name = named.Name()
-		if namedTagged, ok := ref.(reference.NamedTagged); ok {
-			name = name + ":" + namedTagged.Tag()
-		}
-		if canonical, ok := ref.(reference.Canonical); ok {
-			name = name + "@" + canonical.Digest().String()
+		if named, ok := ref.(reference.Named); ok {
+			name = named.Name()
+			if namedTagged, ok := ref.(reference.NamedTagged); ok {
+				name = name + ":" + namedTagged.Tag()
+			}
+			if canonical, ok := ref.(reference.Canonical); ok {
+				name = name + "@" + canonical.Digest().String()
+			}
 		}
 	}
 
@@ -60,7 +112,11 @@ func pullImage(store storage.Store, imageName string, options BuilderOptions, sc
 		if options.Transport == "" {
 			return nil, errors.Wrapf(err, "error parsing image name %q", spec)
 		}
-		spec = options.Transport + spec
+		transport := options.Transport
+		if transport != DefaultTransport {
+			transport = transport + ":"
+		}
+		spec = transport + spec
 		srcRef2, err2 := alltransports.ParseImageName(spec)
 		if err2 != nil {
 			return nil, errors.Wrapf(err2, "error parsing image name %q", spec)
@@ -68,7 +124,7 @@ func pullImage(store storage.Store, imageName string, options BuilderOptions, sc
 		srcRef = srcRef2
 	}
 
-	destName, err := localImageNameForReference(store, srcRef)
+	destName, err := localImageNameForReference(store, srcRef, spec)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error computing local image name for %q", transports.ImageName(srcRef))
 	}
@@ -110,4 +166,20 @@ func pullImage(store storage.Store, imageName string, options BuilderOptions, sc
 		return destRef, nil
 	}
 	return nil, err
+}
+
+// getImageDigest creates an image object and uses the hex value of the digest as the image ID
+// for parsing the store reference
+func getImageDigest(src types.ImageReference, ctx *types.SystemContext) (string, error) {
+	newImg, err := src.NewImage(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer newImg.Close()
+
+	digest := newImg.ConfigInfo().Digest
+	if err = digest.Validate(); err != nil {
+		return "", errors.Wrapf(err, "error getting config info")
+	}
+	return "@" + digest.Hex(), nil
 }

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -129,6 +129,33 @@ load helpers
   buildah rmi alpine alpine2
 }
 
+@test "from the following transports: docker-archive, oci-archive, and dir" {
+  cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah rm $cid
+  buildah push --signature-policy ${TESTSDIR}/policy.json alpine docker-archive:docker-alp.tar:alpine
+  buildah push --signature-policy ${TESTSDIR}/policy.json alpine oci-archive:oci-alp.tar:alpine
+  buildah push --signature-policy ${TESTSDIR}/policy.json alpine dir:alp-dir
+  buildah rmi alpine
+
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json docker-archive:docker-alp.tar)
+  [ "$cid" == alpine-working-container ]
+  buildah rm ${cid}
+  buildah rmi alpine
+  rm -f docker-alp.tar
+
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json oci-archive:oci-alp.tar)
+  [ "$cid" == alpine-working-container ]
+  buildah rm ${cid}
+  buildah rmi alpine
+  rm -f oci-alp.tar
+
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json dir:alp-dir)
+  [ "$cid" == alp-dir-working-container ]
+  buildah rm ${cid}
+  buildah rmi alp-dir
+  rm -rf alp-dir
+}
+
 @test "from cpu-period test" {
   cid=$(buildah from --cpu-period=5000 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   run buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_period_us


### PR DESCRIPTION
buildah from now supports pulling images using the following transports:
docker-archive, oci-archive, and dir.

Fixes issue https://github.com/projectatomic/buildah/issues/511

Signed-off-by: umohnani8 <umohnani@redhat.com>