### PR TITLE
Add ginkgo tests to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,5 @@ script:
     - make install.tools install.libseccomp.sudo all runc validate TAGS="apparmor seccomp containers_image_ostree_stub"
     - go test -c -tags "apparmor seccomp `./btrfs_tag.sh` `./libdm_tag.sh` `./ostree_tag.sh` `./selinux_tag.sh`" ./cmd/buildah
     - tmp=`mktemp -d`; mkdir $tmp/root $tmp/runroot; sudo PATH="$PATH" ./buildah.test -test.v -root $tmp/root -runroot $tmp/runroot -storage-driver vfs -signature-policy `pwd`/tests/policy.json
+    - ginkgo -v tests/e2e/.
     - cd tests; sudo PATH="$PATH" ./test_runner.sh

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ validate:
 install.tools:
 	$(GO) get -u $(BUILDFLAGS) github.com/cpuguy83/go-md2man
 	$(GO) get -u $(BUILDFLAGS) github.com/vbatts/git-validation
+	$(GO) get github.com/onsi/gomega/...
 	$(GO) get -u $(BUILDFLAGS) github.com/onsi/ginkgo/ginkgo
 	$(GO) get -u $(BUILDFLAGS) gopkg.in/alecthomas/gometalinter.v1
 	gometalinter.v1 -i


### PR DESCRIPTION
The ginkgo e2e tests were never added to the travis test run.

Signed-off-by: baude <bbaude@redhat.com>