### PR TITLE
Touchup README to re-enable logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
 
 # [Buildah](https://www.youtube.com/embed/YVk5NgSiUw8) - a tool that facilitates building OCI container images
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

An '!' was accidentally removed from the beginning of the README.md file which caused the logo to not be  displayed.  This adds it back in to get our Buildah Terrier back in their rightful place!