### PR TITLE
Change image time to locale, add troubleshooting.md, add logo to othe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
+
 # Changelog
 
 ## 0.5 - 2017-11-07

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
+
 # Contributing to Buildah
 
 We'd love to have you join the community! Below summarizes the processes

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The Buildah package provides a command line tool that can be used to
 
 **[Installation notes](install.md)**
 
+**[Troubleshooting Guide](troubleshooting.md)**
+
 **[Tutorials](docs/tutorials/README.md)**
 
 ## Example

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -12,6 +12,7 @@ import (
 	is "github.com/containers/image/storage"
 	"github.com/containers/storage"
 	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah/util"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"golang.org/x/crypto/ssh/terminal"
@@ -228,6 +229,7 @@ func outputImages(images []storage.Image, format string, store storage.Store, fi
 				createdTime = inspectedTime
 			}
 		}
+		createdTime = util.GetLocalTime(createdTime)
 
 		names := []string{}
 		if len(image.Names) > 0 {

--- a/docs/buildah-images.md
+++ b/docs/buildah-images.md
@@ -7,7 +7,8 @@ buildah images - List images in local storage.
 **buildah** **images** [*options* [...]]
 
 ## DESCRIPTION
-Displays locally stored images, their names, and their IDs.
+Displays locally stored images, their names, sizes, created date and their IDs.
+The created date is displayed in the time locale of the local machine.
 
 ## OPTIONS
 

--- a/install.md
+++ b/install.md
@@ -1,3 +1,5 @@
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
+
 # Installation Instructions
 
 ## System Requirements

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1,0 +1,25 @@
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
+
+# Troubleshooting
+
+## A list of common issues and solutions for Buildah
+
+---
+### No such image
+
+When doing a `buildah pull` or `buildah bud` command and a "common" image can not be pulled,
+it is likely that the `/etc/containers/registries.conf` file is either not installed or possibly
+misconfigured.
+
+#### Symptom
+```
+sudo buildah bud -f Dockerfile 
+STEP 1: FROM alpine
+error building: error creating build container: no such image "alpine" in registry: image not known
+```
+
+#### Solution
+
+  * Verify that the `/etc/containers/registries.conf` file exists.  If not, verify that the skopeo-containers package is installed.
+  * Verify that the entries in the `[registries.search]` section of the /etc/containers/registries file are valid and reachable.
+---

--- a/util/util.go
+++ b/util/util.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/containers/image/directory"
 	dockerarchive "github.com/containers/image/docker/archive"
@@ -198,4 +199,13 @@ func GetFailureCause(err, defaultError error) error {
 	default:
 		return defaultError
 	}
+}
+
+// GetLocalTime discover the UTC offset and then add that to the
+// passed in time to arrive at the local time.
+func GetLocalTime(localTime time.Time) time.Time {
+	t := time.Now()
+	_, offset := t.Local().Zone()
+	localTime = localTime.Add(time.Second * time.Duration(offset))
+	return localTime
 }


### PR DESCRIPTION
This has a few different changes.  First of all the 'buildah images' command has been changed to show the machine local time rather than utc time for the Created Date column.   This addresses issue #537.

This PR also has the first rendition of a Buildah Troubleshooting guide listing common problems and their solutions.  Because I love our logo, I've also added it to several of our .md files.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>