### PR TITLE
Vendor in latest containers/image

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -115,7 +115,7 @@ func getDateAndDigestAndSize(image storage.Image, store storage.Store) (time.Tim
 	}
 	inspectInfo, inspectErr := img.Inspect()
 	if inspectErr == nil && inspectInfo != nil {
-		created = inspectInfo.Created
+		created = *inspectInfo.Created
 	}
 	if sizeErr != nil {
 		err = sizeErr

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -196,7 +196,7 @@ func setFilterDate(store storage.Store, images []storage.Image, imgName string) 
 				if err != nil {
 					return time.Time{}, fmt.Errorf("error inspecting image %q: %v", image.ID, err)
 				}
-				date := inspect.Created
+				date := *inspect.Created
 				return date, nil
 			}
 		}

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -413,9 +413,9 @@ func TestParseFilterAllParams(t *testing.T) {
 		dangling:         "true",
 		label:            "a=b",
 		beforeImage:      "busybox:latest",
-		beforeDate:       inspect.Created,
+		beforeDate:       *inspect.Created,
 		sinceImage:       "busybox:latest",
-		sinceDate:        inspect.Created,
+		sinceDate:        *inspect.Created,
 		referencePattern: "abcdef",
 	}
 	if *params != *expectedParams {

--- a/vendor/github.com/containers/image/directory/directory_dest.go
+++ b/vendor/github.com/containers/image/directory/directory_dest.go
@@ -98,9 +98,11 @@ func (d *dirImageDestination) SupportsSignatures() error {
 	return nil
 }
 
-// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.
-func (d *dirImageDestination) ShouldCompressLayers() bool {
-	return d.compress
+func (d *dirImageDestination) DesiredLayerCompression() types.LayerCompression {
+	if d.compress {
+		return types.Compress
+	}
+	return types.PreserveOriginal
 }
 
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
@@ -120,7 +122,7 @@ func (d *dirImageDestination) MustMatchRuntimeOS() bool {
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *dirImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types.BlobInfo, error) {
+func (d *dirImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	blobFile, err := ioutil.TempFile(d.ref.path, "dir-put-blob")
 	if err != nil {
 		return types.BlobInfo{}, err

--- a/vendor/github.com/containers/image/docker/archive/dest.go
+++ b/vendor/github.com/containers/image/docker/archive/dest.go
@@ -46,6 +46,11 @@ func newImageDestination(ctx *types.SystemContext, ref archiveReference) (types.
 	}, nil
 }
 
+// DesiredLayerCompression indicates if layers must be compressed, decompressed or preserved
+func (d *archiveImageDestination) DesiredLayerCompression() types.LayerCompression {
+	return types.Decompress
+}
+
 // Reference returns the reference used to set up this destination.  Note that this should directly correspond to user's intent,
 // e.g. it should use the public hostname instead of the result of resolving CNAMEs or following redirects.
 func (d *archiveImageDestination) Reference() types.ImageReference {

--- a/vendor/github.com/containers/image/docker/daemon/daemon_dest.go
+++ b/vendor/github.com/containers/image/docker/daemon/daemon_dest.go
@@ -85,6 +85,11 @@ func imageLoadGoroutine(ctx context.Context, c *client.Client, reader *io.PipeRe
 	defer resp.Body.Close()
 }
 
+// DesiredLayerCompression indicates if layers must be compressed, decompressed or preserved
+func (d *daemonImageDestination) DesiredLayerCompression() types.LayerCompression {
+	return types.PreserveOriginal
+}
+
 // MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
 func (d *daemonImageDestination) MustMatchRuntimeOS() bool {
 	return d.mustMatchRuntimeOS

--- a/vendor/github.com/containers/image/docker/docker_client.go
+++ b/vendor/github.com/containers/image/docker/docker_client.go
@@ -495,7 +495,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 		defer resp.Body.Close()
 		logrus.Debugf("Ping %s status %d", url, resp.StatusCode)
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
-			return errors.Errorf("error pinging repository, response code %d", resp.StatusCode)
+			return errors.Errorf("error pinging registry %s, response code %d", c.registry, resp.StatusCode)
 		}
 		c.challenges = parseAuthHeader(resp.Header)
 		c.scheme = scheme
@@ -547,7 +547,7 @@ func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerRe
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return nil, client.HandleErrorResponse(res)
+		return nil, errors.Wrapf(client.HandleErrorResponse(res), "Error downloading signatures for %s in %s", manifestDigest, ref.ref.Name())
 	}
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {

--- a/vendor/github.com/containers/image/docker/docker_image_src.go
+++ b/vendor/github.com/containers/image/docker/docker_image_src.go
@@ -95,7 +95,7 @@ func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest strin
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return nil, "", client.HandleErrorResponse(res)
+		return nil, "", errors.Wrapf(client.HandleErrorResponse(res), "Error reading manifest %s in %s", tagOrDigest, s.ref.ref.Name())
 	}
 	manblob, err := ioutil.ReadAll(res.Body)
 	if err != nil {

--- a/vendor/github.com/containers/image/docker/tarfile/dest.go
+++ b/vendor/github.com/containers/image/docker/tarfile/dest.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/containers/image/docker/reference"
@@ -21,37 +22,21 @@ import (
 
 // Destination is a partial implementation of types.ImageDestination for writing to an io.Writer.
 type Destination struct {
-	writer  io.Writer
-	tar     *tar.Writer
-	repoTag string
+	writer    io.Writer
+	tar       *tar.Writer
+	reference reference.NamedTagged
 	// Other state.
-	blobs map[digest.Digest]types.BlobInfo // list of already-sent blobs
+	blobs  map[digest.Digest]types.BlobInfo // list of already-sent blobs
+	config []byte
 }
 
 // NewDestination returns a tarfile.Destination for the specified io.Writer.
 func NewDestination(dest io.Writer, ref reference.NamedTagged) *Destination {
-	// For github.com/docker/docker consumers, this works just as well as
-	//   refString := ref.String()
-	// because when reading the RepoTags strings, github.com/docker/docker/reference
-	// normalizes both of them to the same value.
-	//
-	// Doing it this way to include the normalized-out `docker.io[/library]` does make
-	// a difference for github.com/projectatomic/docker consumers, with the
-	// “Add --add-registry and --block-registry options to docker daemon” patch.
-	// These consumers treat reference strings which include a hostname and reference
-	// strings without a hostname differently.
-	//
-	// Using the host name here is more explicit about the intent, and it has the same
-	// effect as (docker pull) in projectatomic/docker, which tags the result using
-	// a hostname-qualified reference.
-	// See https://github.com/containers/image/issues/72 for a more detailed
-	// analysis and explanation.
-	refString := fmt.Sprintf("%s:%s", ref.Name(), ref.Tag())
 	return &Destination{
-		writer:  dest,
-		tar:     tar.NewWriter(dest),
-		repoTag: refString,
-		blobs:   make(map[digest.Digest]types.BlobInfo),
+		writer:    dest,
+		tar:       tar.NewWriter(dest),
+		reference: ref,
+		blobs:     make(map[digest.Digest]types.BlobInfo),
 	}
 }
 
@@ -67,11 +52,6 @@ func (d *Destination) SupportedManifestMIMETypes() []string {
 // Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
 func (d *Destination) SupportsSignatures() error {
 	return errors.Errorf("Storing signatures for docker tar files is not supported")
-}
-
-// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.
-func (d *Destination) ShouldCompressLayers() bool {
-	return false
 }
 
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
@@ -91,20 +71,10 @@ func (d *Destination) MustMatchRuntimeOS() bool {
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *Destination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types.BlobInfo, error) {
-	if inputInfo.Digest.String() == "" {
-		return types.BlobInfo{}, errors.Errorf("Can not stream a blob with unknown digest to docker tarfile")
-	}
-
-	ok, size, err := d.HasBlob(inputInfo)
-	if err != nil {
-		return types.BlobInfo{}, err
-	}
-	if ok {
-		return types.BlobInfo{Digest: inputInfo.Digest, Size: size}, nil
-	}
-
-	if inputInfo.Size == -1 { // Ouch, we need to stream the blob into a temporary file just to determine the size.
+func (d *Destination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+	// Ouch, we need to stream the blob into a temporary file just to determine the size.
+	// When the layer is decompressed, we also have to generate the digest on uncompressed datas.
+	if inputInfo.Size == -1 || inputInfo.Digest.String() == "" {
 		logrus.Debugf("docker tarfile: input with unknown size, streaming to disk first ...")
 		streamCopy, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(), "docker-tarfile-blob")
 		if err != nil {
@@ -113,7 +83,9 @@ func (d *Destination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types
 		defer os.Remove(streamCopy.Name())
 		defer streamCopy.Close()
 
-		size, err := io.Copy(streamCopy, stream)
+		digester := digest.Canonical.Digester()
+		tee := io.TeeReader(stream, digester.Hash())
+		size, err := io.Copy(streamCopy, tee)
 		if err != nil {
 			return types.BlobInfo{}, err
 		}
@@ -122,17 +94,43 @@ func (d *Destination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types
 			return types.BlobInfo{}, err
 		}
 		inputInfo.Size = size // inputInfo is a struct, so we are only modifying our copy.
+		if inputInfo.Digest == "" {
+			inputInfo.Digest = digester.Digest()
+		}
 		stream = streamCopy
 		logrus.Debugf("... streaming done")
 	}
 
-	digester := digest.Canonical.Digester()
-	tee := io.TeeReader(stream, digester.Hash())
-	if err := d.sendFile(inputInfo.Digest.String(), inputInfo.Size, tee); err != nil {
+	// Maybe the blob has been already sent
+	ok, size, err := d.HasBlob(inputInfo)
+	if err != nil {
 		return types.BlobInfo{}, err
 	}
-	d.blobs[inputInfo.Digest] = types.BlobInfo{Digest: digester.Digest(), Size: inputInfo.Size}
-	return types.BlobInfo{Digest: digester.Digest(), Size: inputInfo.Size}, nil
+	if ok {
+		return types.BlobInfo{Digest: inputInfo.Digest, Size: size}, nil
+	}
+
+	if isConfig {
+		buf, err := ioutil.ReadAll(stream)
+		if err != nil {
+			return types.BlobInfo{}, errors.Wrap(err, "Error reading Config file stream")
+		}
+		d.config = buf
+		if err := d.sendFile(inputInfo.Digest.Hex()+".json", inputInfo.Size, bytes.NewReader(buf)); err != nil {
+			return types.BlobInfo{}, errors.Wrap(err, "Error writing Config file")
+		}
+	} else {
+		// Note that this can't be e.g. filepath.Join(l.Digest.Hex(), legacyLayerFileName); due to the way
+		// writeLegacyLayerMetadata constructs layer IDs differently from inputinfo.Digest values (as described
+		// inside it), most of the layers would end up in subdirectories alone without any metadata; (docker load)
+		// tries to load every subdirectory as an image and fails if the config is missing.  So, keep the layers
+		// in the root of the tarball.
+		if err := d.sendFile(inputInfo.Digest.Hex()+".tar", inputInfo.Size, stream); err != nil {
+			return types.BlobInfo{}, err
+		}
+	}
+	d.blobs[inputInfo.Digest] = types.BlobInfo{Digest: inputInfo.Digest, Size: inputInfo.Size}
+	return types.BlobInfo{Digest: inputInfo.Digest, Size: inputInfo.Size}, nil
 }
 
 // HasBlob returns true iff the image destination already contains a blob with
@@ -160,6 +158,19 @@ func (d *Destination) ReapplyBlob(info types.BlobInfo) (types.BlobInfo, error) {
 	return info, nil
 }
 
+func (d *Destination) createRepositoriesFile(rootLayerID string) error {
+	repositories := map[string]map[string]string{
+		d.reference.Name(): {d.reference.Tag(): rootLayerID}}
+	b, err := json.Marshal(repositories)
+	if err != nil {
+		return errors.Wrap(err, "Error marshaling repositories")
+	}
+	if err := d.sendBytes(legacyRepositoriesFileName, b); err != nil {
+		return errors.Wrap(err, "Error writing config json file")
+	}
+	return nil
+}
+
 // PutManifest writes manifest to the destination.
 // FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 // If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
@@ -175,14 +186,37 @@ func (d *Destination) PutManifest(m []byte) error {
 		return errors.Errorf("Unsupported manifest type, need a Docker schema 2 manifest")
 	}
 
-	layerPaths := []string{}
-	for _, l := range man.LayersDescriptors {
-		layerPaths = append(layerPaths, l.Digest.String())
+	layerPaths, lastLayerID, err := d.writeLegacyLayerMetadata(man.LayersDescriptors)
+	if err != nil {
+		return err
 	}
 
+	if len(man.LayersDescriptors) > 0 {
+		if err := d.createRepositoriesFile(lastLayerID); err != nil {
+			return err
+		}
+	}
+
+	// For github.com/docker/docker consumers, this works just as well as
+	//   refString := ref.String()
+	// because when reading the RepoTags strings, github.com/docker/docker/reference
+	// normalizes both of them to the same value.
+	//
+	// Doing it this way to include the normalized-out `docker.io[/library]` does make
+	// a difference for github.com/projectatomic/docker consumers, with the
+	// “Add --add-registry and --block-registry options to docker daemon” patch.
+	// These consumers treat reference strings which include a hostname and reference
+	// strings without a hostname differently.
+	//
+	// Using the host name here is more explicit about the intent, and it has the same
+	// effect as (docker pull) in projectatomic/docker, which tags the result using
+	// a hostname-qualified reference.
+	// See https://github.com/containers/image/issues/72 for a more detailed
+	// analysis and explanation.
+	refString := fmt.Sprintf("%s:%s", d.reference.Name(), d.reference.Tag())
 	items := []ManifestItem{{
-		Config:       man.ConfigDescriptor.Digest.String(),
-		RepoTags:     []string{d.repoTag},
+		Config:       man.ConfigDescriptor.Digest.Hex() + ".json",
+		RepoTags:     []string{refString},
 		Layers:       layerPaths,
 		Parent:       "",
 		LayerSources: nil,
@@ -193,12 +227,81 @@ func (d *Destination) PutManifest(m []byte) error {
 	}
 
 	// FIXME? Do we also need to support the legacy format?
-	return d.sendFile(manifestFileName, int64(len(itemsBytes)), bytes.NewReader(itemsBytes))
+	return d.sendBytes(manifestFileName, itemsBytes)
+}
+
+// writeLegacyLayerMetadata writes legacy VERSION and configuration files for all layers
+func (d *Destination) writeLegacyLayerMetadata(layerDescriptors []manifest.Schema2Descriptor) (layerPaths []string, lastLayerID string, err error) {
+	var chainID digest.Digest
+	lastLayerID = ""
+	for i, l := range layerDescriptors {
+		// This chainID value matches the computation in docker/docker/layer.CreateChainID …
+		if chainID == "" {
+			chainID = l.Digest
+		} else {
+			chainID = digest.Canonical.FromString(chainID.String() + " " + l.Digest.String())
+		}
+		// … but note that this image ID does not match docker/docker/image/v1.CreateID. At least recent
+		// versions allocate new IDs on load, as long as the IDs we use are unique / cannot loop.
+		//
+		// Overall, the goal of computing a digest dependent on the full history is to avoid reusing an image ID
+		// (and possibly creating a loop in the "parent" links) if a layer with the same DiffID appears two or more
+		// times in layersDescriptors.  The ChainID values are sufficient for this, the v1.CreateID computation
+		// which also mixes in the full image configuration seems unnecessary, at least as long as we are storing
+		// only a single image per tarball, i.e. all DiffID prefixes are unique (can’t differ only with
+		// configuration).
+		layerID := chainID.Hex()
+
+		physicalLayerPath := l.Digest.Hex() + ".tar"
+		// The layer itself has been stored into physicalLayerPath in PutManifest.
+		// So, use that path for layerPaths used in the non-legacy manifest
+		layerPaths = append(layerPaths, physicalLayerPath)
+		// ... and create a symlink for the legacy format;
+		if err := d.sendSymlink(filepath.Join(layerID, legacyLayerFileName), filepath.Join("..", physicalLayerPath)); err != nil {
+			return nil, "", errors.Wrap(err, "Error creating layer symbolic link")
+		}
+
+		b := []byte("1.0")
+		if err := d.sendBytes(filepath.Join(layerID, legacyVersionFileName), b); err != nil {
+			return nil, "", errors.Wrap(err, "Error writing VERSION file")
+		}
+
+		// The legacy format requires a config file per layer
+		layerConfig := make(map[string]interface{})
+		layerConfig["id"] = layerID
+
+		// The root layer doesn't have any parent
+		if lastLayerID != "" {
+			layerConfig["parent"] = lastLayerID
+		}
+		// The root layer configuration file is generated by using subpart of the image configuration
+		if i == len(layerDescriptors)-1 {
+			var config map[string]*json.RawMessage
+			err := json.Unmarshal(d.config, &config)
+			if err != nil {
+				return nil, "", errors.Wrap(err, "Error unmarshaling config")
+			}
+			for _, attr := range [7]string{"architecture", "config", "container", "container_config", "created", "docker_version", "os"} {
+				layerConfig[attr] = config[attr]
+			}
+		}
+		b, err := json.Marshal(layerConfig)
+		if err != nil {
+			return nil, "", errors.Wrap(err, "Error marshaling layer config")
+		}
+		if err := d.sendBytes(filepath.Join(layerID, legacyConfigFileName), b); err != nil {
+			return nil, "", errors.Wrap(err, "Error writing config json file")
+		}
+
+		lastLayerID = layerID
+	}
+	return layerPaths, lastLayerID, nil
 }
 
 type tarFI struct {
-	path string
-	size int64
+	path      string
+	size      int64
+	isSymlink bool
 }
 
 func (t *tarFI) Name() string {
@@ -208,6 +311,9 @@ func (t *tarFI) Size() int64 {
 	return t.size
 }
 func (t *tarFI) Mode() os.FileMode {
+	if t.isSymlink {
+		return os.ModeSymlink
+	}
 	return 0444
 }
 func (t *tarFI) ModTime() time.Time {
@@ -218,6 +324,21 @@ func (t *tarFI) IsDir() bool {
 }
 func (t *tarFI) Sys() interface{} {
 	return nil
+}
+
+// sendSymlink sends a symlink into the tar stream.
+func (d *Destination) sendSymlink(path string, target string) error {
+	hdr, err := tar.FileInfoHeader(&tarFI{path: path, size: 0, isSymlink: true}, target)
+	if err != nil {
+		return nil
+	}
+	logrus.Debugf("Sending as tar link %s -> %s", path, target)
+	return d.tar.WriteHeader(hdr)
+}
+
+// sendBytes sends a path into the tar stream.
+func (d *Destination) sendBytes(path string, b []byte) error {
+	return d.sendFile(path, int64(len(b)), bytes.NewReader(b))
 }
 
 // sendFile sends a file into the tar stream.

--- a/vendor/github.com/containers/image/docker/tarfile/types.go
+++ b/vendor/github.com/containers/image/docker/tarfile/types.go
@@ -9,11 +9,11 @@ import (
 
 // Based on github.com/docker/docker/image/tarexport/tarexport.go
 const (
-	manifestFileName = "manifest.json"
-	// legacyLayerFileName        = "layer.tar"
-	// legacyConfigFileName       = "json"
-	// legacyVersionFileName      = "VERSION"
-	// legacyRepositoriesFileName = "repositories"
+	manifestFileName           = "manifest.json"
+	legacyLayerFileName        = "layer.tar"
+	legacyConfigFileName       = "json"
+	legacyVersionFileName      = "VERSION"
+	legacyRepositoriesFileName = "repositories"
 )
 
 // ManifestItem is an element of the array stored in the top-level manifest.json file.

--- a/vendor/github.com/containers/image/image/docker_schema1.go
+++ b/vendor/github.com/containers/image/image/docker_schema1.go
@@ -87,7 +87,8 @@ func (m *manifestSchema1) EmbeddedDockerReferenceConflicts(ref reference.Named) 
 	return m.m.Name != name || m.m.Tag != tag
 }
 
-func (m *manifestSchema1) imageInspectInfo() (*types.ImageInspectInfo, error) {
+// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
+func (m *manifestSchema1) Inspect() (*types.ImageInspectInfo, error) {
 	return m.m.Inspect(nil)
 }
 
@@ -187,7 +188,7 @@ func (m *manifestSchema1) convertToManifestSchema2(uploadedLayerInfos []types.Bl
 			diffIDs = append(diffIDs, d)
 		}
 	}
-	configJSON, err := m.m.ToSchema2(diffIDs)
+	configJSON, err := m.m.ToSchema2Config(diffIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/image/image/docker_schema2.go
+++ b/vendor/github.com/containers/image/image/docker_schema2.go
@@ -130,7 +130,8 @@ func (m *manifestSchema2) EmbeddedDockerReferenceConflicts(ref reference.Named) 
 	return false
 }
 
-func (m *manifestSchema2) imageInspectInfo() (*types.ImageInspectInfo, error) {
+// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
+func (m *manifestSchema2) Inspect() (*types.ImageInspectInfo, error) {
 	getter := func(info types.BlobInfo) ([]byte, error) {
 		if info.Digest != m.ConfigInfo().Digest {
 			// Shouldn't ever happen
@@ -251,7 +252,7 @@ func (m *manifestSchema2) convertToManifestSchema1(dest types.ImageDestination) 
 		if historyEntry.EmptyLayer {
 			if !haveGzippedEmptyLayer {
 				logrus.Debugf("Uploading empty layer during conversion to schema 1")
-				info, err := dest.PutBlob(bytes.NewReader(gzippedEmptyLayer), types.BlobInfo{Digest: gzippedEmptyLayerDigest, Size: int64(len(gzippedEmptyLayer))})
+				info, err := dest.PutBlob(bytes.NewReader(gzippedEmptyLayer), types.BlobInfo{Digest: gzippedEmptyLayerDigest, Size: int64(len(gzippedEmptyLayer))}, false)
 				if err != nil {
 					return nil, errors.Wrap(err, "Error uploading empty layer")
 				}

--- a/vendor/github.com/containers/image/image/manifest.go
+++ b/vendor/github.com/containers/image/image/manifest.go
@@ -34,7 +34,8 @@ type genericManifest interface {
 	// It returns false if the manifest does not embed a Docker reference.
 	// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)
 	EmbeddedDockerReferenceConflicts(ref reference.Named) bool
-	imageInspectInfo() (*types.ImageInspectInfo, error) // To be called by inspectManifest
+	// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
+	Inspect() (*types.ImageInspectInfo, error)
 	// UpdatedImageNeedsLayerDiffIDs returns true iff UpdatedImage(options) needs InformationOnly.LayerDiffIDs.
 	// This is a horribly specific interface, but computing InformationOnly.LayerDiffIDs can be very expensive to compute
 	// (most importantly it forces us to download the full layers even if they are already present at the destination).
@@ -59,9 +60,4 @@ func manifestInstanceFromBlob(ctx *types.SystemContext, src types.ImageSource, m
 	default: // Note that this may not be reachable, manifest.NormalizedMIMEType has a default for unknown values.
 		return nil, fmt.Errorf("Unimplemented manifest MIME type %s", mt)
 	}
-}
-
-// inspectManifest is an implementation of types.Image.Inspect
-func inspectManifest(m genericManifest) (*types.ImageInspectInfo, error) {
-	return m.imageInspectInfo()
 }

--- a/vendor/github.com/containers/image/image/memory.go
+++ b/vendor/github.com/containers/image/image/memory.go
@@ -57,11 +57,6 @@ func (i *memoryImage) Signatures(ctx context.Context) ([][]byte, error) {
 	return nil, errors.New("Internal error: Image.Signatures() is not supported for images modified in memory")
 }
 
-// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
-func (i *memoryImage) Inspect() (*types.ImageInspectInfo, error) {
-	return inspectManifest(i.genericManifest)
-}
-
 // LayerInfosForCopy returns an updated set of layer blob information which may not match the manifest.
 // The Digest field is guaranteed to be provided; Size may be -1.
 // WARNING: The list may contain duplicates, and they are semantically relevant.

--- a/vendor/github.com/containers/image/image/oci.go
+++ b/vendor/github.com/containers/image/image/oci.go
@@ -110,7 +110,8 @@ func (m *manifestOCI1) EmbeddedDockerReferenceConflicts(ref reference.Named) boo
 	return false
 }
 
-func (m *manifestOCI1) imageInspectInfo() (*types.ImageInspectInfo, error) {
+// Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
+func (m *manifestOCI1) Inspect() (*types.ImageInspectInfo, error) {
 	getter := func(info types.BlobInfo) ([]byte, error) {
 		if info.Digest != m.ConfigInfo().Digest {
 			// Shouldn't ever happen

--- a/vendor/github.com/containers/image/image/sourced.go
+++ b/vendor/github.com/containers/image/image/sourced.go
@@ -97,10 +97,6 @@ func (i *sourcedImage) Manifest() ([]byte, string, error) {
 	return i.manifestBlob, i.manifestMIMEType, nil
 }
 
-func (i *sourcedImage) Inspect() (*types.ImageInspectInfo, error) {
-	return inspectManifest(i.genericManifest)
-}
-
 func (i *sourcedImage) LayerInfosForCopy() ([]types.BlobInfo, error) {
-	return i.UnparsedImage.LayerInfosForCopy()
+	return i.UnparsedImage.src.LayerInfosForCopy()
 }

--- a/vendor/github.com/containers/image/image/unparsed.go
+++ b/vendor/github.com/containers/image/image/unparsed.go
@@ -93,10 +93,3 @@ func (i *UnparsedImage) Signatures(ctx context.Context) ([][]byte, error) {
 	}
 	return i.cachedSignatures, nil
 }
-
-// LayerInfosForCopy returns an updated set of layer blob information which may not match the manifest.
-// The Digest field is guaranteed to be provided; Size may be -1.
-// WARNING: The list may contain duplicates, and they are semantically relevant.
-func (i *UnparsedImage) LayerInfosForCopy() ([]types.BlobInfo, error) {
-	return i.src.LayerInfosForCopy()
-}

--- a/vendor/github.com/containers/image/manifest/docker_schema2.go
+++ b/vendor/github.com/containers/image/manifest/docker_schema2.go
@@ -142,13 +142,6 @@ type Schema2Image struct {
 	History    []Schema2History `json:"history,omitempty"`
 	OSVersion  string           `json:"os.version,omitempty"`
 	OSFeatures []string         `json:"os.features,omitempty"`
-
-	// rawJSON caches the immutable JSON associated with this image.
-	rawJSON []byte
-
-	// computedID is the ID computed from the hash of the image config.
-	// Not to be confused with the legacy V1 ID in V1Image.
-	computedID digest.Digest
 }
 
 // Schema2FromManifest creates a Schema2 manifest instance from a manifest blob.
@@ -230,7 +223,7 @@ func (m *Schema2) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*t
 	}
 	i := &types.ImageInspectInfo{
 		Tag:           "",
-		Created:       s2.Created,
+		Created:       &s2.Created,
 		DockerVersion: s2.DockerVersion,
 		Architecture:  s2.Architecture,
 		Os:            s2.OS,

--- a/vendor/github.com/containers/image/manifest/oci.go
+++ b/vendor/github.com/containers/image/manifest/oci.go
@@ -2,7 +2,6 @@ package manifest
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
@@ -95,13 +94,9 @@ func (m *OCI1) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*type
 	}
 	d1 := &Schema2V1Image{}
 	json.Unmarshal(config, d1)
-	created := time.Time{}
-	if v1.Created != nil {
-		created = *v1.Created
-	}
 	i := &types.ImageInspectInfo{
 		Tag:           "",
-		Created:       created,
+		Created:       v1.Created,
 		DockerVersion: d1.DockerVersion,
 		Labels:        v1.Config.Labels,
 		Architecture:  v1.Architecture,

--- a/vendor/github.com/containers/image/oci/archive/oci_dest.go
+++ b/vendor/github.com/containers/image/oci/archive/oci_dest.go
@@ -54,9 +54,8 @@ func (d *ociArchiveImageDestination) SupportsSignatures() error {
 	return d.unpackedDest.SupportsSignatures()
 }
 
-// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination
-func (d *ociArchiveImageDestination) ShouldCompressLayers() bool {
-	return d.unpackedDest.ShouldCompressLayers()
+func (d *ociArchiveImageDestination) DesiredLayerCompression() types.LayerCompression {
+	return d.unpackedDest.DesiredLayerCompression()
 }
 
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
@@ -73,8 +72,8 @@ func (d *ociArchiveImageDestination) MustMatchRuntimeOS() bool {
 // PutBlob writes contents of stream and returns data representing the result (with all data filled in).
 // inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 // inputInfo.Size is the expected length of stream, if known.
-func (d *ociArchiveImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types.BlobInfo, error) {
-	return d.unpackedDest.PutBlob(stream, inputInfo)
+func (d *ociArchiveImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+	return d.unpackedDest.PutBlob(stream, inputInfo, isConfig)
 }
 
 // HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob

--- a/vendor/github.com/containers/image/oci/layout/oci_dest.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_dest.go
@@ -84,9 +84,8 @@ func (d *ociImageDestination) SupportsSignatures() error {
 	return errors.Errorf("Pushing signatures for OCI images is not supported")
 }
 
-// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.
-func (d *ociImageDestination) ShouldCompressLayers() bool {
-	return true
+func (d *ociImageDestination) DesiredLayerCompression() types.LayerCompression {
+	return types.Compress
 }
 
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
@@ -106,7 +105,7 @@ func (d *ociImageDestination) MustMatchRuntimeOS() bool {
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *ociImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types.BlobInfo, error) {
+func (d *ociImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	blobFile, err := ioutil.TempFile(d.ref.dir, "oci-put-blob")
 	if err != nil {
 		return types.BlobInfo{}, err

--- a/vendor/github.com/containers/image/openshift/openshift.go
+++ b/vendor/github.com/containers/image/openshift/openshift.go
@@ -354,9 +354,8 @@ func (d *openshiftImageDestination) SupportsSignatures() error {
 	return nil
 }
 
-// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.
-func (d *openshiftImageDestination) ShouldCompressLayers() bool {
-	return true
+func (d *openshiftImageDestination) DesiredLayerCompression() types.LayerCompression {
+	return types.Compress
 }
 
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
@@ -376,8 +375,8 @@ func (d *openshiftImageDestination) MustMatchRuntimeOS() bool {
 // WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-func (d *openshiftImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types.BlobInfo, error) {
-	return d.docker.PutBlob(stream, inputInfo)
+func (d *openshiftImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+	return d.docker.PutBlob(stream, inputInfo, isConfig)
 }
 
 // HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob.

--- a/vendor/github.com/containers/image/ostree/ostree_dest.go
+++ b/vendor/github.com/containers/image/ostree/ostree_dest.go
@@ -108,8 +108,8 @@ func (d *ostreeImageDestination) SupportsSignatures() error {
 }
 
 // ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.
-func (d *ostreeImageDestination) ShouldCompressLayers() bool {
-	return false
+func (d *ostreeImageDestination) DesiredLayerCompression() types.LayerCompression {
+	return types.PreserveOriginal
 }
 
 // AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
@@ -123,7 +123,7 @@ func (d *ostreeImageDestination) MustMatchRuntimeOS() bool {
 	return true
 }
 
-func (d *ostreeImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types.BlobInfo, error) {
+func (d *ostreeImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	tmpDir, err := ioutil.TempDir(d.tmpDirPath, "blob")
 	if err != nil {
 		return types.BlobInfo{}, err

--- a/vendor/github.com/containers/image/pkg/sysregistries/system_registries.go
+++ b/vendor/github.com/containers/image/pkg/sysregistries/system_registries.go
@@ -1,6 +1,8 @@
 package sysregistries
 
 import (
+	"strings"
+
 	"github.com/BurntSushi/toml"
 	"github.com/containers/image/types"
 	"io/ioutil"
@@ -27,6 +29,14 @@ type tomlConfig struct {
 		Insecure registries `toml:"insecure"`
 		Block    registries `toml:"block"`
 	} `toml:"registries"`
+}
+
+// normalizeRegistries removes trailing slashes from registries, which is a
+// common pitfall when configuring registries (e.g., "docker.io/library/).
+func normalizeRegistries(regs *registries) {
+	for i := range regs.Registries {
+		regs.Registries[i] = strings.TrimRight(regs.Registries[i], "/")
+	}
 }
 
 // Reads the global registry file from the filesystem. Returns
@@ -58,6 +68,9 @@ func loadRegistryConf(ctx *types.SystemContext) (*tomlConfig, error) {
 	}
 
 	err = toml.Unmarshal(configBytes, &config)
+	normalizeRegistries(&config.Registries.Search)
+	normalizeRegistries(&config.Registries.Insecure)
+	normalizeRegistries(&config.Registries.Block)
 	return config, err
 }
 

--- a/vendor/github.com/containers/image/storage/storage_image.go
+++ b/vendor/github.com/containers/image/storage/storage_image.go
@@ -44,15 +44,13 @@ var (
 
 type storageImageSource struct {
 	imageRef       storageReference
-	ID             string
+	image          *storage.Image
 	layerPosition  map[digest.Digest]int // Where we are in reading a blob's layers
 	cachedManifest []byte                // A cached copy of the manifest, if already known, or nil
 	SignatureSizes []int                 `json:"signature-sizes,omitempty"` // List of sizes of each signature slice
 }
 
 type storageImageDestination struct {
-	image          types.ImageCloser
-	systemContext  *types.SystemContext
 	imageRef       storageReference                // The reference we'll use to name the image
 	publicRef      storageReference                // The reference we return when asked about the name we'll give to the image
 	directory      string                          // Temporary directory where we store blobs until Commit() time
@@ -81,7 +79,7 @@ func newImageSource(imageRef storageReference) (*storageImageSource, error) {
 	// Build the reader object.
 	image := &storageImageSource{
 		imageRef:       imageRef,
-		ID:             img.ID,
+		image:          img,
 		layerPosition:  make(map[digest.Digest]int),
 		SignatureSizes: []int{},
 	}
@@ -124,7 +122,7 @@ func (s *storageImageSource) getBlobAndLayerID(info types.BlobInfo) (rc io.ReadC
 	layers, err := s.imageRef.transport.store.LayersByUncompressedDigest(info.Digest)
 	// If it's not a layer, then it must be a data item.
 	if len(layers) == 0 {
-		b, err := s.imageRef.transport.store.ImageBigData(s.ID, info.Digest.String())
+		b, err := s.imageRef.transport.store.ImageBigData(s.image.ID, info.Digest.String())
 		if err != nil {
 			return nil, -1, "", err
 		}
@@ -166,7 +164,7 @@ func (s *storageImageSource) GetManifest(instanceDigest *digest.Digest) (manifes
 	}
 	if len(s.cachedManifest) == 0 {
 		// We stored the manifest as an item named after storage.ImageDigestBigDataKey.
-		cachedBlob, err := s.imageRef.transport.store.ImageBigData(s.ID, storage.ImageDigestBigDataKey)
+		cachedBlob, err := s.imageRef.transport.store.ImageBigData(s.image.ID, storage.ImageDigestBigDataKey)
 		if err != nil {
 			return nil, "", err
 		}
@@ -178,15 +176,10 @@ func (s *storageImageSource) GetManifest(instanceDigest *digest.Digest) (manifes
 // LayerInfosForCopy() returns the list of layer blobs that make up the root filesystem of
 // the image, after they've been decompressed.
 func (s *storageImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
-	simg, err := s.imageRef.transport.store.Image(s.ID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error reading image %q", s.ID)
-	}
 	updatedBlobInfos := []types.BlobInfo{}
-	layerID := simg.TopLayer
 	_, manifestType, err := s.GetManifest(nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error reading image manifest for %q", s.ID)
+		return nil, errors.Wrapf(err, "error reading image manifest for %q", s.image.ID)
 	}
 	uncompressedLayerType := ""
 	switch manifestType {
@@ -196,10 +189,11 @@ func (s *storageImageSource) LayerInfosForCopy() ([]types.BlobInfo, error) {
 		// This is actually a compressed type, but there's no uncompressed type defined
 		uncompressedLayerType = manifest.DockerV2Schema2LayerMediaType
 	}
+	layerID := s.image.TopLayer
 	for layerID != "" {
 		layer, err := s.imageRef.transport.store.Layer(layerID)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error reading layer %q in image %q", layerID, s.ID)
+			return nil, errors.Wrapf(err, "error reading layer %q in image %q", layerID, s.image.ID)
 		}
 		if layer.UncompressedDigest == "" {
 			return nil, errors.Errorf("uncompressed digest for layer %q is unknown", layerID)
@@ -227,9 +221,9 @@ func (s *storageImageSource) GetSignatures(ctx context.Context, instanceDigest *
 	sigslice := [][]byte{}
 	signature := []byte{}
 	if len(s.SignatureSizes) > 0 {
-		signatureBlob, err := s.imageRef.transport.store.ImageBigData(s.ID, "signatures")
+		signatureBlob, err := s.imageRef.transport.store.ImageBigData(s.image.ID, "signatures")
 		if err != nil {
-			return nil, errors.Wrapf(err, "error looking up signatures data for image %q", s.ID)
+			return nil, errors.Wrapf(err, "error looking up signatures data for image %q", s.image.ID)
 		}
 		signature = signatureBlob
 	}
@@ -257,7 +251,6 @@ func newImageDestination(ctx *types.SystemContext, imageRef storageReference) (*
 	publicRef := imageRef
 	publicRef.name = nil
 	image := &storageImageDestination{
-		systemContext:  ctx,
 		imageRef:       imageRef,
 		publicRef:      publicRef,
 		directory:      directory,
@@ -281,17 +274,16 @@ func (s *storageImageDestination) Close() error {
 	return os.RemoveAll(s.directory)
 }
 
-// ShouldCompressLayers indicates whether or not a caller should compress not-already-compressed
-// data when handing it to us.
-func (s storageImageDestination) ShouldCompressLayers() bool {
-	// We ultimately have to decompress layers to populate trees on disk, so callers shouldn't
-	// bother compressing them before handing them to us, if they're not already compressed.
-	return false
+func (s storageImageDestination) DesiredLayerCompression() types.LayerCompression {
+	// We ultimately have to decompress layers to populate trees on disk,
+	// so callers shouldn't bother compressing them before handing them to
+	// us, if they're not already compressed.
+	return types.PreserveOriginal
 }
 
 // PutBlob stores a layer or data blob in our temporary directory, checking that any information
 // in the blobinfo matches the incoming data.
-func (s *storageImageDestination) PutBlob(stream io.Reader, blobinfo types.BlobInfo) (types.BlobInfo, error) {
+func (s *storageImageDestination) PutBlob(stream io.Reader, blobinfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
 	errorBlobInfo := types.BlobInfo{
 		Digest: "",
 		Size:   -1,
@@ -412,17 +404,11 @@ func (s *storageImageDestination) computeID(m manifest.Manifest) string {
 	// fill in the DiffIDs.  It's expected (but not enforced by us) that the number of
 	// diffIDs corresponds to the number of non-EmptyLayer entries in the history.
 	var diffIDs []digest.Digest
-	switch m.(type) {
+	switch m := m.(type) {
 	case *manifest.Schema1:
 		// Build a list of the diffIDs we've generated for the non-throwaway FS layers,
 		// in reverse of the order in which they were originally listed.
-		s1, ok := m.(*manifest.Schema1)
-		if !ok {
-			// Shouldn't happen
-			logrus.Debugf("internal error reading schema 1 manifest")
-			return ""
-		}
-		for i, history := range s1.History {
+		for i, history := range m.History {
 			compat := manifest.Schema1V1Compatibility{}
 			if err := json.Unmarshal([]byte(history.V1Compatibility), &compat); err != nil {
 				logrus.Debugf("internal error reading schema 1 history: %v", err)
@@ -431,7 +417,7 @@ func (s *storageImageDestination) computeID(m manifest.Manifest) string {
 			if compat.ThrowAway {
 				continue
 			}
-			blobSum := s1.FSLayers[i].BlobSum
+			blobSum := m.FSLayers[i].BlobSum
 			diffID, ok := s.blobDiffIDs[blobSum]
 			if !ok {
 				logrus.Infof("error looking up diffID for layer %q", blobSum.String())
@@ -442,6 +428,8 @@ func (s *storageImageDestination) computeID(m manifest.Manifest) string {
 	case *manifest.Schema2, *manifest.OCI1:
 		// We know the ID calculation for these formats doesn't actually use the diffIDs,
 		// so we don't need to populate the diffID list.
+	default:
+		return ""
 	}
 	id, err := m.ImageID(diffIDs)
 	if err != nil {
@@ -566,9 +554,9 @@ func (s *storageImageDestination) Commit() error {
 	// If one of those blobs was a configuration blob, then we can try to dig out the date when the image
 	// was originally created, in case we're just copying it.  If not, no harm done.
 	options := &storage.ImageOptions{}
-	if inspect, err := man.Inspect(s.getConfigBlob); err == nil {
+	if inspect, err := man.Inspect(s.getConfigBlob); err == nil && inspect.Created != nil {
 		logrus.Debugf("setting image creation date to %s", inspect.Created)
-		options.CreationDate = inspect.Created
+		options.CreationDate = *inspect.Created
 	}
 	if manifestDigest, err := manifest.Digest(s.manifest); err == nil {
 		options.Digest = manifestDigest
@@ -735,14 +723,14 @@ func (s *storageImageDestination) PutSignatures(signatures [][]byte) error {
 func (s *storageImageSource) getSize() (int64, error) {
 	var sum int64
 	// Size up the data blobs.
-	dataNames, err := s.imageRef.transport.store.ListImageBigData(s.ID)
+	dataNames, err := s.imageRef.transport.store.ListImageBigData(s.image.ID)
 	if err != nil {
-		return -1, errors.Wrapf(err, "error reading image %q", s.ID)
+		return -1, errors.Wrapf(err, "error reading image %q", s.image.ID)
 	}
 	for _, dataName := range dataNames {
-		bigSize, err := s.imageRef.transport.store.ImageBigDataSize(s.ID, dataName)
+		bigSize, err := s.imageRef.transport.store.ImageBigDataSize(s.image.ID, dataName)
 		if err != nil {
-			return -1, errors.Wrapf(err, "error reading data blob size %q for %q", dataName, s.ID)
+			return -1, errors.Wrapf(err, "error reading data blob size %q for %q", dataName, s.image.ID)
 		}
 		sum += bigSize
 	}
@@ -750,13 +738,8 @@ func (s *storageImageSource) getSize() (int64, error) {
 	for _, sigSize := range s.SignatureSizes {
 		sum += int64(sigSize)
 	}
-	// Prepare to walk the layer list.
-	img, err := s.imageRef.transport.store.Image(s.ID)
-	if err != nil {
-		return -1, errors.Wrapf(err, "error reading image info %q", s.ID)
-	}
 	// Walk the layer list.
-	layerID := img.TopLayer
+	layerID := s.image.TopLayer
 	for layerID != "" {
 		layer, err := s.imageRef.transport.store.Layer(layerID)
 		if err != nil {

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -132,6 +132,19 @@ type ImageSource interface {
 	LayerInfosForCopy() ([]BlobInfo, error)
 }
 
+// LayerCompression indicates if layers must be compressed, decompressed or preserved
+type LayerCompression int
+
+const (
+	// PreserveOriginal indicates the layer must be preserved, ie
+	// no compression or decompression.
+	PreserveOriginal LayerCompression = iota
+	// Decompress indicates the layer must be decompressed
+	Decompress
+	// Compress indicates the layer must be compressed
+	Compress
+)
+
 // ImageDestination is a service, possibly remote (= slow), to store components of a single image.
 //
 // There is a specific required order for some of the calls:
@@ -154,8 +167,8 @@ type ImageDestination interface {
 	// SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.
 	// Note: It is still possible for PutSignatures to fail if SupportsSignatures returns nil.
 	SupportsSignatures() error
-	// ShouldCompressLayers returns true iff it is desirable to compress layer blobs written to this destination.
-	ShouldCompressLayers() bool
+	// DesiredLayerCompression indicates the kind of compression to apply on layers
+	DesiredLayerCompression() LayerCompression
 	// AcceptsForeignLayerURLs returns false iff foreign layers in manifest should be actually
 	// uploaded to the image destination, true otherwise.
 	AcceptsForeignLayerURLs() bool
@@ -168,7 +181,7 @@ type ImageDestination interface {
 	// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 	// to any other readers for download using the supplied digest.
 	// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
-	PutBlob(stream io.Reader, inputInfo BlobInfo) (BlobInfo, error)
+	PutBlob(stream io.Reader, inputInfo BlobInfo, isConfig bool) (BlobInfo, error)
 	// HasBlob returns true iff the image destination already contains a blob with the matching digest which can be reapplied using ReapplyBlob.
 	// Unlike PutBlob, the digest can not be empty.  If HasBlob returns true, the size of the blob must also be returned.
 	// If the destination does not contain the blob, or it is unknown, HasBlob ordinarily returns (false, -1, nil);
@@ -215,10 +228,6 @@ type UnparsedImage interface {
 	Manifest() ([]byte, string, error)
 	// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
 	Signatures(ctx context.Context) ([][]byte, error)
-	// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer blobsums that are listed in the image's manifest.
-	// The Digest field is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
-	// WARNING: The list may contain duplicates, and they are semantically relevant.
-	LayerInfosForCopy() ([]BlobInfo, error)
 }
 
 // Image is the primary API for inspecting properties of images.
@@ -242,6 +251,10 @@ type Image interface {
 	// The Digest field is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
 	LayerInfos() []BlobInfo
+	// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer blobsums that are listed in the image's manifest.
+	// The Digest field is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
+	// WARNING: The list may contain duplicates, and they are semantically relevant.
+	LayerInfosForCopy() ([]BlobInfo, error)
 	// EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
 	// It returns false if the manifest does not embed a Docker reference.
 	// (This embedding unfortunately happens for Docker schema1, please do not add support for this in any new formats.)
@@ -292,7 +305,7 @@ type ManifestUpdateInformation struct {
 // for other manifest types.
 type ImageInspectInfo struct {
 	Tag           string
-	Created       time.Time
+	Created       *time.Time
 	DockerVersion string
 	Labels        map[string]string
 	Architecture  string


### PR DESCRIPTION
Some more features.
docker-archive generates docker legacy compatible images
Do not create $DiffID subdirectories for layers with no configs
Ensure the layer IDs in legacy docker/tarfile metadata are unique
docker-archive: repeated layers are symlinked in the tar file
sysregistries: remove all trailing slashes
Improve docker/* error messages
Fix failure to make auth directory
Create a new slice in Schema1.UpdateLayerInfos
Drop unused storageImageDestination.{image,systemContext}
Load a *storage.Image only once in storageImageSource
Support gzip for docker-archive files
Remove .tar extension from blob and config file names
ostree, src: support copy of compressed layers
ostree: re-pull layer if it misses uncompressed_digest|uncompressed_size
image: fix docker schema v1 -> OCI conversion
Add /etc/containers/certs.d as default certs directory

Signed-off-by: Daniel J Walsh dwalsh@redhat.com