### PR TITLE
Remove requires for ostree-lib in rpm spec file

### DIFF
--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -49,7 +49,6 @@ BuildRequires:  make
 Requires:       runc >= 1.0.0-6
 Requires:       container-selinux
 Requires:       skopeo-containers
-Requires:       ostree-libs
 Provides:       %{repo} = %{version}-%{release}
 
 %description


### PR DESCRIPTION
I stupidly added this in a previous patch. rpm figures this
out for you so no need to specify.  On RHEL systems ostree-libs
does not exist.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>