### PR TITLE
Allow umount to have multi-containers

### DIFF
--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah/util"
 	"github.com/urfave/cli"
 )
 
@@ -29,14 +29,6 @@ var (
 	}
 )
 
-// writeError writes `lastError` into `w` if not nil and return the next error `err`
-func writeError(w io.Writer, err error, lastError error) error {
-	if lastError != nil {
-		fmt.Fprintln(w, lastError)
-	}
-	return err
-}
-
 func rmCmd(c *cli.Context) error {
 	delContainerErrStr := "error removing container"
 	args := c.Args()
@@ -58,7 +50,7 @@ func rmCmd(c *cli.Context) error {
 		for _, builder := range builders {
 			id := builder.ContainerID
 			if err = builder.Delete(); err != nil {
-				lastError = writeError(os.Stderr, errors.Wrapf(err, "%s %q", delContainerErrStr, builder.Container), lastError)
+				lastError = util.WriteError(os.Stderr, errors.Wrapf(err, "%s %q", delContainerErrStr, builder.Container), lastError)
 				continue
 			}
 			fmt.Printf("%s\n", id)
@@ -67,12 +59,12 @@ func rmCmd(c *cli.Context) error {
 		for _, name := range args {
 			builder, err := openBuilder(store, name)
 			if err != nil {
-				lastError = writeError(os.Stderr, errors.Wrapf(err, "%s %q", delContainerErrStr, name), lastError)
+				lastError = util.WriteError(os.Stderr, errors.Wrapf(err, "%s %q", delContainerErrStr, name), lastError)
 				continue
 			}
 			id := builder.ContainerID
 			if err = builder.Delete(); err != nil {
-				lastError = writeError(os.Stderr, errors.Wrapf(err, "%s %q", delContainerErrStr, name), lastError)
+				lastError = util.WriteError(os.Stderr, errors.Wrapf(err, "%s %q", delContainerErrStr, name), lastError)
 				continue
 			}
 			fmt.Printf("%s\n", id)

--- a/docs/buildah-umount.md
+++ b/docs/buildah-umount.md
@@ -1,17 +1,19 @@
 # buildah-umount "1" "March 2017" "buildah"
 
 ## NAME
-buildah umount - Unmount a working container's root file system.
+buildah umount - Unmount the root file system on the specified working containers.
 
 ## SYNOPSIS
-**buildah** **umount** **containerID**
+**buildah** **umount** **containerID [...]**
 
 ## DESCRIPTION
-Unmounts the specified container's root file system.
+Unmounts the root file system on the specified working containers.
 
 ## EXAMPLE
 
 buildah umount containerID
+
+buildah umount containerID1 containerID2 containerID3
 
 ## SEE ALSO
 buildah(1)

--- a/tests/umount.bats
+++ b/tests/umount.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "umount one image" {
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah mount "$cid"
+  run buildah umount "$cid"
+  [ "${status}" -eq 0 ]
+  buildah rm --all
+}
+
+@test "umount bad image" {
+  run buildah umount badcontainer 
+  [ "${status}" -ne 0 ]
+  buildah rm --all
+}
+
+@test "umount multi images" {
+  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah mount "$cid1"
+  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah mount "$cid2"
+  cid3=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah mount "$cid3"
+  run buildah umount "$cid1" "$cid2" "$cid3"
+  [ "${status}" -eq 0 ]
+  buildah rm --all
+}
+
+@test "umount multi images one bad" {
+  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah mount "$cid1"
+  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah mount "$cid2"
+  cid3=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah mount "$cid3"
+  run buildah umount "$cid1" badcontainer "$cid2" "$cid3"
+  [ "${status}" -ne 0 ]
+  buildah rm --all
+}

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+	"io"
 	"net/url"
 	"path"
 	"strings"
@@ -208,4 +210,12 @@ func GetLocalTime(localTime time.Time) time.Time {
 	_, offset := t.Local().Zone()
 	localTime = localTime.Add(time.Second * time.Duration(offset))
 	return localTime
+}
+
+// WriteError writes `lastError` into `w` if not nil and return the next error `err`
+func WriteError(w io.Writer, err error, lastError error) error {
+	if lastError != nil {
+		fmt.Fprintln(w, lastError)
+	}
+	return err
 }


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Similar to `buildah rm`, umount multiple containers if more than one container ID is given as an argument.   Addresses #548.

Testing:
```
# buildah mount alpine-working-container
/var/lib/containers/storage/overlay/14d096b196149d388f0e435f4b4afb8ce3c499669496edf728efd971d7d16ec0/merged

# buildah umount alpine-working-container
0a7efbcceb43ba9374e2d960c6888f8bad1fc60b6c12dd2796f91334ed84af33

# buildah mount alpine-working-container
/var/lib/containers/storage/overlay/14d096b196149d388f0e435f4b4afb8ce3c499669496edf728efd971d7d16ec0/merged

# buildah mount alpine-working-container-2
/var/lib/containers/storage/overlay/908b8f1d8d7f13fecf80b061c63517a285920dbf42cb07cf9973d16a2baf0a27/merged

# buildah umount alpine-working-container badcontainer alpine-working-container-2
0a7efbcceb43ba9374e2d960c6888f8bad1fc60b6c12dd2796f91334ed84af33
5224a321e3733beede8a0db8952777a0d0e364a98e30b5baa99015d8b5859195
error unmounting container badcontainer: error reading build container: container not known
```