### PR TITLE
Display imageId after commit

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -117,6 +117,11 @@ func (b *Builder) Commit(dest types.ImageReference, options CommitOptions) error
 			logrus.Warnf("don't know how to add tags to images stored in %q transport", dest.Transport().Name())
 		}
 	}
+
+	img, err := is.Transport.GetStoreImage(b.store, dest)
+	if err == nil {
+		fmt.Printf("%s\n", img.ID)
+	}
 	return nil
 }
 

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -10,6 +10,9 @@ buildah commit - Create an image from a working container.
 Writes a new image using the specified container's read-write layer and if it
 is based on an image, the layers of that image.
 
+## RETURN VALUE
+The image ID of the image that was created.  On error, 1 is returned and errno is returned.
+
 ## OPTIONS
 
 **--authfile** *path*
@@ -60,7 +63,7 @@ Require HTTPS and verify certificates when talking to container registries (defa
 ## EXAMPLE
 
 This example saves an image based on the container.
- `buildah commit containerID`
+ `buildah commit containerID newImageName`
 
 This example saves an image named newImageName based on the container.
  `buildah commit --rm containerID newImageName`

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -32,7 +32,7 @@ Multiple transports are supported:
   An image in local OSTree repository.  _/absolute/repo/path_ defaults to _/ostree/repo_.
 
 ## RETURN VALUE
-The container ID of the container that was created.  On error, -1 is returned and errno is returned.
+The container ID of the container that was created.  On error, 1 is returned and errno is returned.
 
 ## OPTIONS
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

When `buildah commit` completes, display the id of the newly committed image.  Addresses #565.

Test Results:
```
# buildah commit alpine-working-container tom
Getting image source signatures
Skipping fetch of repeat blob sha256:cd7100a72410606589a54b932cabd804a17f9ae5b42a1882bd56d263e02b6215
Skipping fetch of repeat blob sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
Copying config sha256:9c2464847df085d1b1895f6c6b6bbf8138d3eb082792b6c49ad80641adf0f49f
 719 B / 719 B [============================================================] 0s
Writing manifest to image destination
Storing signatures
9c2464847df085d1b1895f6c6b6bbf8138d3eb082792b6c49ad80641adf0f49f

# buildah commit -q alpine-working-container tom
1bcb308ef095820f1db45946cc52fd0c7167f43a1ffd1c01f0a46e211d20bacd

```