### PR TITLE
Change entrypoint parameter behaviour to match docker

### DIFF
--- a/run.go
+++ b/run.go
@@ -328,18 +328,18 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		return err
 	}
 
+	entrypoint := b.Entrypoint()
+	if len(options.Entrypoint) > 0 {
+		entrypoint = options.Entrypoint
+	}
 	if len(command) > 0 {
-		g.SetProcessArgs(command)
+		g.SetProcessArgs(append(entrypoint, command...))
 	} else {
 		cmd := b.Cmd()
 		if len(options.Cmd) > 0 {
 			cmd = options.Cmd
 		}
-		ep := b.Entrypoint()
-		if len(options.Entrypoint) > 0 {
-			ep = options.Entrypoint
-		}
-		g.SetProcessArgs(append(ep, cmd...))
+		g.SetProcessArgs(append(entrypoint, cmd...))
 	}
 	if options.WorkingDir != "" {
 		g.SetProcessCwd(options.WorkingDir)

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -98,7 +98,7 @@ load helpers
 	[ "$output" = that-other-thing ]
 
 	buildah config --entrypoint echo $cid
-	run buildah --debug=false run $cid echo that-other-thing
+	run buildah --debug=false run $cid that-other-thing
 	[ "$status" -eq 0 ]
 	[ "$output" = that-other-thing ]
 


### PR DESCRIPTION
Fixes #564

Behaviour updated to match docker:
1. container entrypoint is no longer overwritten by user command and command is instead passed as parameter to entrypoint
2. container cmd is overwritten by user command (existing behaviour)

Signed-off-by: pixdrift <support@pixeldrift.net>