### PR TITLE
Fix secrets patch

### DIFF
--- a/secrets.go
+++ b/secrets.go
@@ -3,6 +3,7 @@ package buildah
 import (
 	"bufio"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,6 +22,82 @@ var (
 	// "host_path:container_path" overriden by the user
 	OverrideMountsFile = "/etc/containers/mounts.conf"
 )
+
+// secretData stores the name of the file and the content read from it
+type secretData struct {
+	name string
+	data []byte
+}
+
+// saveTo saves secret data to given directory
+func (s secretData) saveTo(dir string) error {
+	path := filepath.Join(dir, s.name)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil && !os.IsExist(err) {
+		return err
+	}
+	return ioutil.WriteFile(path, s.data, 0700)
+}
+
+func readAll(root, prefix string) ([]secretData, error) {
+	path := filepath.Join(root, prefix)
+
+	data := []secretData{}
+
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return data, nil
+		}
+
+		return nil, err
+	}
+
+	for _, f := range files {
+		fileData, err := readFile(root, filepath.Join(prefix, f.Name()))
+		if err != nil {
+			// If the file did not exist, might be a dangling symlink
+			// Ignore the error
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		data = append(data, fileData...)
+	}
+
+	return data, nil
+}
+
+func readFile(root, name string) ([]secretData, error) {
+	path := filepath.Join(root, name)
+
+	s, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.IsDir() {
+		dirData, err := readAll(root, name)
+		if err != nil {
+			return nil, err
+		}
+		return dirData, nil
+	}
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return []secretData{{name: name, data: bytes}}, nil
+}
+
+func getHostSecretData(hostDir string) ([]secretData, error) {
+	var allSecrets []secretData
+	hostSecrets, err := readAll(hostDir, "")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read secrets from %q", hostDir)
+	}
+	return append(allSecrets, hostSecrets...), nil
+}
 
 func getMounts(filePath string) []string {
 	file, err := os.Open(filePath)
@@ -80,8 +157,14 @@ func secretMounts(filePath, mountLabel, containerWorkingDir string) ([]rspec.Mou
 			return nil, err
 		}
 
-		if err = copyWithTar(hostDir, ctrDirOnHost); err != nil && !os.IsNotExist(err) {
-			return nil, errors.Wrapf(err, "error getting host secret data")
+		data, err := getHostSecretData(hostDir)
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting host secret data failed")
+		}
+		for _, s := range data {
+			if err := s.saveTo(ctrDirOnHost); err != nil {
+				return nil, errors.Wrapf(err, "error saving data to container filesystem on host %q", ctrDirOnHost)
+			}
 		}
 
 		err = label.Relabel(ctrDirOnHost, mountLabel, false)

--- a/tests/secrets.bats
+++ b/tests/secrets.bats
@@ -4,14 +4,16 @@ load helpers
 
 function setup() {
     mkdir $TESTSDIR/containers
-    touch $TESTSDIR/mounts.conf
+    touch $TESTSDIR/containers/mounts.conf
     MOUNTS_PATH=$TESTSDIR/containers/mounts.conf
     echo "$TESTSDIR/rhel/secrets:/run/secrets" > $MOUNTS_PATH
 
-    mkdir $TESTSDIR/rhel
-    mkdir $TESTSDIR/rhel/secrets
+    mkdir -p $TESTSDIR/rhel/secrets
     touch $TESTSDIR/rhel/secrets/test.txt
     echo "Testing secrets mounts. I am mounted!" > $TESTSDIR/rhel/secrets/test.txt
+    mkdir -p $TESTSDIR/symlink/target
+    touch $TESTSDIR/symlink/target/key.pem
+    ln -s $TESTSDIR/symlink/target $TESTSDIR/rhel/secrets/mysymlink
 }
 
 @test "bind secrets mounts to container" {
@@ -20,14 +22,16 @@ function setup() {
     fi
     runc --version
     cid=$(buildah --default-mounts-file "$MOUNTS_PATH" --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-    run buildah --debug=false run $cid ls /run
+    run buildah --debug=false run $cid ls /run/secrets
     echo "$output"
     [ "$status" -eq 0 ]
-    mounts="$output"
-    run grep "secrets" <<< "$mounts"
+    [[ "$output" =~ "test.txt" ]]
+    run buildah --debug run $cid ls /run/secrets/mysymlink
     echo "$output"
     [ "$status" -eq 0 ]
+    [[ "$output" =~ "key.pem" ]]
     buildah rm $cid
     rm -rf $TESTSDIR/containers
     rm -rf $TESTSDIR/rhel
+    rm -rf $TESTSDIR/symlink
 }


### PR DESCRIPTION
The secrets code was just tarring and copying the contents of the secrets directory on host as is.
This meant it was not accounting for any symlinks inside the directory, leading up to the contents
not being copied over.

Signed-off-by: umohnani8 <umohnani@redhat.com>