### PR TITLE
buildah-containers: add validation to 'format'

### DIFF
--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -239,6 +240,13 @@ func outputContainers(store storage.Store, opts containerOptions, params *contai
 }
 
 func containerOutputUsingTemplate(format string, params containerOutputParams) error {
+	matched, err := regexp.MatchString("{{.*}}", format)
+	if err != nil {
+		return errors.Wrapf(err, "error validating format provided %s", format)
+	} else if !matched {
+		return errors.Errorf("error invalid format provided: %s", format)
+	}
+
 	tmpl, err := template.New("container").Parse(format)
 	if err != nil {
 		return errors.Wrapf(err, "Template parsing error")

--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -242,7 +242,7 @@ func outputContainers(store storage.Store, opts containerOptions, params *contai
 func containerOutputUsingTemplate(format string, params containerOutputParams) error {
 	matched, err := regexp.MatchString("{{.*}}", format)
 	if err != nil {
-		return errors.Wrapf(err, "error validating format provided %s", format)
+		return errors.Wrapf(err, "error validating format provided: %s", format)
 	} else if !matched {
 		return errors.Errorf("error invalid format provided: %s", format)
 	}

--- a/cmd/buildah/containers_test.go
+++ b/cmd/buildah/containers_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTemplateOutputValidFormat(t *testing.T) {
+	params := containerOutputParams{
+		ContainerID:   "e477836657bb",
+		Builder:       " ",
+		ImageID:       "f975c5035748",
+		ImageName:     "test/image:latest",
+		ContainerName: "test-container",
+	}
+
+	formatString := "Container ID: {{.ContainerID}}"
+	expectedString := "Container ID: " + params.ContainerID
+
+	output, err := captureOutputWithError(func() error {
+		return containerOutputUsingTemplate(formatString, params)
+	})
+	if err != nil {
+		t.Error(err)
+	} else if strings.TrimSpace(output) != expectedString {
+		t.Errorf("Errorf with template output:\nExpected: %s\nReceived: %s\n", expectedString, output)
+	}
+}
+
+func TestTemplateOutputInvalidFormat(t *testing.T) {
+	params := containerOutputParams{
+		ContainerID:   "e477836657bb",
+		Builder:       " ",
+		ImageID:       "f975c5035748",
+		ImageName:     "test/image:latest",
+		ContainerName: "test-container",
+	}
+
+	formatString := "ContainerID"
+
+	err := containerOutputUsingTemplate(formatString, params)
+	if err == nil || err.Error() != "error invalid format provided: ContainerID" {
+		t.Fatalf("expected error invalid format")
+	}
+}

--- a/docs/buildah-containers.md
+++ b/docs/buildah-containers.md
@@ -107,6 +107,12 @@ buildah containers --format "{{.ContainerID}} {{.ContainerName}}"
 fbfd3505376ee639c3ed50f9d32b78445cd59198a1dfcacf2e7958cda2516d5c ubuntu-working-container
 ```
 
+buildah containers --format "Container ID: {{.ContainerID}}"
+```
+Container ID: 3fbeaa87e583ee7a3e6787b2d3af961ef21946a0c01a08938e4f52d53cce4c04
+Container ID: fbfd3505376ee639c3ed50f9d32b78445cd59198a1dfcacf2e7958cda2516d5c
+```
+
 buildah containers --filter ancestor=ubuntu
 ```
 CONTAINER ID  BUILDER  IMAGE ID     IMAGE NAME                       CONTAINER NAME


### PR DESCRIPTION
Avoid the following situations：

```
➜  buildah git:(containers-format) sudo buildah containers --format zz
zz
zz
zz
zz
zz
zz
zz
zz
zz
```

After change:
```
➜  buildah git:(containers-format) sudo ./buildah containers --format zz
error format: zz
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>