### PR TITLE
Clarify the use of buildah config options

### DIFF
--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -20,7 +20,7 @@ var (
 	configFlags = []cli.Flag{
 		cli.StringSliceFlag{
 			Name:  "annotation, a",
-			Usage: "add `annotation` e.g. annotation=value, for the target image",
+			Usage: "add `annotation` e.g. annotation=value, for the target image (default [])",
 		},
 		cli.StringFlag{
 			Name:  "arch",
@@ -32,11 +32,11 @@ var (
 		},
 		cli.StringFlag{
 			Name:  "cmd",
-			Usage: "sets the default `command` to run for containers based on the image",
+			Usage: "set the default `command` to run for containers based on the image",
 		},
 		cli.StringFlag{
 			Name:  "created-by",
-			Usage: "add `description` of how the image was created",
+			Usage: "set `description` of how the image was created",
 			Value: DefaultCreatedBy,
 		},
 		cli.StringFlag{
@@ -45,7 +45,7 @@ var (
 		},
 		cli.StringSliceFlag{
 			Name:  "env, e",
-			Usage: "add `environment variable` to be set when running containers based on image",
+			Usage: "add `environment variable` to be set when running containers based on image (default [])",
 		},
 		cli.StringSliceFlag{
 			Name:  "label, l",
@@ -57,7 +57,7 @@ var (
 		},
 		cli.StringSliceFlag{
 			Name:  "port, p",
-			Usage: "add `port` to expose when running containers based on image",
+			Usage: "add `port` to expose when running containers based on image (default [])",
 		},
 		cli.StringFlag{
 			Name:  "shell",
@@ -73,7 +73,7 @@ var (
 		},
 		cli.StringSliceFlag{
 			Name:  "volume, v",
-			Usage: "add default `volume` path to be created for containers based on image",
+			Usage: "add default `volume` path to be created for containers based on image (default [])",
 		},
 		cli.StringFlag{
 			Name:  "workingdir",

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -13,24 +13,24 @@ Updates one or more of the settings kept for a container.
 
 **--annotation** *annotation*
 
-Adds an image *annotation* (e.g. annotation=*annotation*) to the image manifest
-of any images which will be built using the specified container.
+Add an image *annotation* (e.g. annotation=*annotation*) to the image manifest
+of any images which will be built using the specified container. Can be used multiple times.
 
 **--arch** *architecture*
 
-Specify the target *architecture* for any images which will be built using the
+Set the target *architecture* for any images which will be built using the
 specified container.  By default, if the container was based on an image, that
 image's target architecture is kept, otherwise the host's architecture is
 recorded.
 
 **--author** *author*
 
-Sets contact information for the *author* for any images which will be built
+Set contact information for the *author* for any images which will be built
 using the specified container.
 
 **--cmd** *command*
 
-Sets the default *command* to run for containers based on any images which will
+Set the default *command* to run for containers based on any images which will
 be built using the specified container.  When used in combination with an
 *entry point*, this specifies the default parameters for the *entry point*.
 
@@ -41,33 +41,33 @@ edits") in any images which will be created using the specified container.
 
 **--entrypoint** *entry*
 
-Sets the *entry point* for containers based on any images which will be built
+Set the *entry point* for containers based on any images which will be built
 using the specified container.
 
 **--env** *var=value*
 
-Adds a value (e.g. name=*value*) to the environment for containers based on any
-images which will be built using the specified container.
+Add a value (e.g. name=*value*) to the environment for containers based on any
+images which will be built using the specified container. Can be used multiple times.
 
 **--label** *label*
 
-Adds an image *label* (e.g. label=*value*) to the image configuration of any
-images which will be built using the specified container.
+Add an image *label* (e.g. label=*value*) to the image configuration of any
+images which will be built using the specified container. Can be used multiple times.
 
 **--os** *operating system*
 
-Specify the target *operating system* for any images which will be built using
+Set the target *operating system* for any images which will be built using
 the specified container.  By default, if the container was based on an image,
 its OS is kept, otherwise the host's OS's name is recorded.
 
 **--port** *port*
 
-Specifies a *port* to expose when running containers based on any images which
-will be built using the specified container.
+Add a *port* to expose when running containers based on any images which
+will be built using the specified container. Can be used multiple times.
 
 **--shell** *shell*
 
-Specify the *shell* to run inside of the container image
+Set the default *shell* to run inside of the container image.
 The shell instruction allows the default shell used for the shell form of commands to be overridden. The default shell for Linux containers is "/bin/sh -c".
 
 Note: this setting is not present in the OCIv1 image format, so it is discarded when writing images using OCIv1 formats.
@@ -78,25 +78,28 @@ Set default *stop signal* for container. This signal will be sent when container
 
 **--user** *user*
 
-Specify the *user* as whom containers based on images which will be built using
-the specified container should run.  The user can be specified as a user name
+Set the default *user* to be used when running containers based on this image.
+The user can be specified as a user name
 or UID, optionally followed by a group name or GID, separated by a colon (':').
 If names are used, the container should include entries for those names in its
 */etc/passwd* and */etc/group* files.
 
 **--volume** *volume*
 
-Specifies a location in the directory tree which should be marked as a *volume*
-in any images which will be built using the specified container.
+Add a location in the directory tree which should be marked as a *volume* in any images which will be built using the specified container. Can be used multiple times.
 
 **--workingdir** *directory*
 
-Sets the initial working *directory* for containers based on images which will
+Set the initial working *directory* for containers based on images which will
 be built using the specified container.
 
 ## EXAMPLE
 
 buildah config --author='Jane Austen' --workingdir='/etc/mycontainers' containerID
+
+buildah config --env foo=bar PATH=$PATH containerID
+
+buildah config --label Name=Mycontainer --label  Version=1.0 containerID
 
 ## SEE ALSO
 buildah(1)


### PR DESCRIPTION
Make it clearer to the user which options can be executed
multiple times, versus those that can only used once.

Cleanup some documentation issues

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>