### PR TITLE
buildah images and podman images are listing different sizes

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -356,16 +356,20 @@ func matchesReference(name, argName string) bool {
 	return strings.HasSuffix(splitName[0], argName)
 }
 
+/*
+According to  https://en.wikipedia.org/wiki/Binary_prefix
+We should be return numbers based on 1000, rather then 1024
+*/
 func formattedSize(size int64) string {
 	suffixes := [5]string{"B", "KB", "MB", "GB", "TB"}
 
 	count := 0
 	formattedSize := float64(size)
-	for formattedSize >= 1024 && count < 4 {
-		formattedSize /= 1024
+	for formattedSize >= 1000 && count < 4 {
+		formattedSize /= 1000
 		count++
 	}
-	return fmt.Sprintf("%.4g %s", formattedSize, suffixes[count])
+	return fmt.Sprintf("%.3g %s", formattedSize, suffixes[count])
 }
 
 func outputUsingTemplate(format string, params imageOutputParams) error {

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -74,14 +74,14 @@ func TestSizeFormatting(t *testing.T) {
 		t.Errorf("Error formatting size: expected '%s' got '%s'", "0 B", size)
 	}
 
-	size = formattedSize(1024)
+	size = formattedSize(1000)
 	if size != "1 KB" {
 		t.Errorf("Error formatting size: expected '%s' got '%s'", "1 KB", size)
 	}
 
-	size = formattedSize(1024 * 1024 * 1024 * 1024 * 1024)
-	if size != "1024 TB" {
-		t.Errorf("Error formatting size: expected '%s' got '%s'", "1024 TB", size)
+	size = formattedSize(1000 * 1000 * 1000 * 1000)
+	if size != "1 TB" {
+		t.Errorf("Error formatting size: expected '%s' got '%s'", "1 TB", size)
 	}
 }
 


### PR DESCRIPTION
After reviewing how the sizes are shown.  It looks like podman was
using docker/units to display size.  Its size is based off of multiples
of 1000, which according to Wikipedia is correct for image sizes.

https://en.wikipedia.org/wiki/Binary_prefix

Buildah was using multiples of 1024.  This patch switches buildah to use the same
multiple and to reduce its accuracy to two decimal points so that buildah
podman will return the same sizes.  This also will match the way that docker
reports image sizes.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>