### PR TITLE
Add /bin/sh -c to entrypoint in config

### DIFF
--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -135,13 +135,16 @@ func updateConfig(builder *buildah.Builder, c *cli.Context) {
 		}
 	}
 	if c.IsSet("entrypoint") {
-		entrypointSpec, err := shellwords.Parse(c.String("entrypoint"))
-		if err != nil {
-			logrus.Errorf("error parsing --entrypoint %q: %v", c.String("entrypoint"), err)
+		entrypointSpec := make([]string, 3)
+		entrypointSpec[0] = "/bin/sh"
+		entrypointSpec[1] = "-c"
+		entrypointSpec[2] = c.String("entrypoint")
+		if len(strings.TrimSpace(c.String("entrypoint"))) == 0 {
+			builder.SetEntrypoint(nil)
 		} else {
 			builder.SetEntrypoint(entrypointSpec)
-			builder.SetCmd(nil)
 		}
+		builder.SetCmd(nil)
 	}
 	// cmd should always run after entrypoint; setting entrypoint clears cmd
 	if c.IsSet("cmd") {

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -125,3 +125,11 @@ load helpers
   buildah --debug=false inspect --type=image --format '{{.ImageAnnotations}}' scratch-image-oci | grep ANNOTATION:VALUE
   buildah --debug=false inspect --type=image --format '{{.ImageAnnotations}}' scratch-image-oci | grep ANNOTATION:VALUE
 }
+
+@test "config with entrypoint" {
+  ctr=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah config --workingdir /tmp $ctr
+  buildah config --entrypoint /bin/sh $ctr
+  buildah commit --signature-policy ${TESTSDIR}/policy.json $ctr test1
+  buildah inspect --format '{{.Docker.Config.Entrypoint}}' test1 | grep '/bin/sh -c /bin/sh'
+}

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -77,30 +77,21 @@ load helpers
 	[ "$status" -eq 0 ]
 	[ "$output" = /tmp ]
 
-	buildah config --entrypoint echo --cmd pwd $cid
-	run buildah --debug=false run $cid
-	[ "$status" -eq 0 ]
-	[ "$output" = pwd ]
-
+	buildah config --entrypoint pwd $cid
 	buildah config --cmd "" $cid
 	run buildah --debug=false run $cid
 	[ "$status" -eq 0 ]
-	[ "$output" = "" ]
+	[ "$output" = /tmp ]
 
-	buildah config --entrypoint "" $cid
-	run buildah --debug=false run $cid echo that-other-thing
+	buildah config --entrypoint pwd $cid
+	run buildah --debug=false run $cid
 	[ "$status" -eq 0 ]
-	[ "$output" = that-other-thing ]
+	[ "$output" = /tmp ]
 
-	buildah config --cmd echo $cid
-	run buildah --debug=false run $cid echo that-other-thing
+	buildah config --entrypoint "ls -lha" $cid
+	buildah config --cmd "/tmp" $cid
+	run buildah --debug=false run $cid
 	[ "$status" -eq 0 ]
-	[ "$output" = that-other-thing ]
-
-	buildah config --entrypoint echo $cid
-	run buildah --debug=false run $cid that-other-thing
-	[ "$status" -eq 0 ]
-	[ "$output" = that-other-thing ]
 
 	buildah rm $cid
 }


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Prepend ''/bin/sh -c" to the entrypoint value given by the user for the `buildah config` command.  This addresses #593 

Tests:
```
# ctr=$(buildah from centos:7)
# buildah config --workingdir /tmp $ctr
# buildah config --entrypoint /bin/bash $ctr

# buildah commit $ctr test1
Getting image source signatures
Skipping fetch of repeat blob sha256:43e653f84b79ba52711b0f726ff5a7fd1162ae9df4be76ca1de8370b8bbf9bb0
Skipping fetch of repeat blob sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
Copying config sha256:ae0382211cbf19f667ef1b3bbcc97b4195ebc1d5119813ca90cdad78eba83371
 1.24 KiB / 1.24 KiB [======================================================] 0s
Writing manifest to image destination
Storing signatures

# buildah from test1
test1-working-container

# buildah run test1-working-container
[root@mrsdalloway tmp]# 
```