### PR TITLE
If a user specifies --entrypoint it should clear the cmd field

### DIFF
--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -140,8 +140,10 @@ func updateConfig(builder *buildah.Builder, c *cli.Context) {
 			logrus.Errorf("error parsing --entrypoint %q: %v", c.String("entrypoint"), err)
 		} else {
 			builder.SetEntrypoint(entrypointSpec)
+			builder.SetCmd(nil)
 		}
 	}
+	// cmd should always run after entrypoint; setting entrypoint clears cmd
 	if c.IsSet("cmd") {
 		cmdSpec, err := shellwords.Parse(c.String("cmd"))
 		if err != nil {

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -44,6 +44,8 @@ edits") in any images which will be created using the specified container.
 Set the *entry point* for containers based on any images which will be built
 using the specified container.
 
+Note: Setting the entrypoint without setting the --cmd, clears the cmd field in the container.
+
 **--env** *var=value*
 
 Add a value (e.g. name=*value*) to the environment for containers based on any

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -2,6 +2,46 @@
 
 load helpers
 
+@test "config entrypoint" {
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah config \
+   --entrypoint /ENTRYPOINT \
+   --cmd COMMAND-OR-ARGS \
+  $cid
+  buildah commit --format dockerv2 --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  buildah commit --format ociv1 --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Cmd}}' scratch-image-docker | grep COMMAND-OR-ARGS
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Cmd}}' scratch-image-docker | grep COMMAND-OR-ARGS
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Cmd}}' scratch-image-oci | grep COMMAND-OR-ARGS
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Cmd}}' scratch-image-oci | grep COMMAND-OR-ARGS
+
+  buildah config \
+   --entrypoint /ENTRYPOINT \
+  $cid
+
+  buildah commit --format dockerv2 --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  buildah commit --format ociv1 --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  # Cmd should now be nil
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Cmd}}' scratch-image-docker | grep '\[\]'
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Cmd}}' scratch-image-docker | grep '\[\]'
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Cmd}}' scratch-image-oci | grep '\[\]'
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Cmd}}' scratch-image-oci | grep '\[\]'
+
+  buildah config \
+   --entrypoint /ENTRYPOINT \
+   --cmd COMMAND-OR-ARGS \
+  $cid
+
+  buildah commit --format dockerv2 --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  buildah commit --format ociv1 --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Cmd}}' scratch-image-docker | grep COMMAND-OR-ARGS
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Cmd}}' scratch-image-docker | grep COMMAND-OR-ARGS
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Cmd}}' scratch-image-oci | grep COMMAND-OR-ARGS
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Cmd}}' scratch-image-oci | grep COMMAND-OR-ARGS
+
+}
+
 @test "config" {
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah config \

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -77,7 +77,7 @@ load helpers
 	[ "$status" -eq 0 ]
 	[ "$output" = /tmp ]
 
-	buildah config --entrypoint echo $cid
+	buildah config --entrypoint echo --cmd pwd $cid
 	run buildah --debug=false run $cid
 	[ "$status" -eq 0 ]
 	[ "$output" = pwd ]


### PR DESCRIPTION
This matches the way that docker build and buildah bud works.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>