### PR TITLE
buildah-image: add validation to 'format'

### DIFF
--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -240,8 +240,7 @@ func outputContainers(store storage.Store, opts containerOptions, params *contai
 }
 
 func containerOutputUsingTemplate(format string, params containerOutputParams) error {
-	matched, err := regexp.MatchString("{{.*}}", format)
-	if err != nil {
+	if matched, err := regexp.MatchString("{{.*}}", format); err != nil {
 		return errors.Wrapf(err, "error validating format provided: %s", format)
 	} else if !matched {
 		return errors.Errorf("error invalid format provided: %s", format)

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -373,6 +374,12 @@ func formattedSize(size int64) string {
 }
 
 func outputUsingTemplate(format string, params imageOutputParams) error {
+	if matched, err := regexp.MatchString("{{.*}}", format); err != nil {
+		return errors.Wrapf(err, "error validating format provided: %s", format)
+	} else if !matched {
+		return errors.Errorf("error invalid format provided: %s", format)
+	}
+
 	tmpl, err := template.New("image").Parse(format)
 	if err != nil {
 		return errors.Wrapf(err, "Template parsing error")

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -13,22 +13,6 @@ import (
 	"github.com/containers/storage"
 )
 
-func TestTemplateOutputBlankTemplate(t *testing.T) {
-	params := imageOutputParams{
-		ID:        "0123456789abcdef",
-		Name:      "test/image:latest",
-		Digest:    "sha256:012345789abcdef012345789abcdef012345789abcdef012345789abcdef",
-		CreatedAt: "Jan 01 2016 10:45",
-		Size:      "97 KB",
-	}
-
-	err := outputUsingTemplate("", params)
-	//Output: Words
-	if err != nil {
-		t.Error(err)
-	}
-}
-
 func TestTemplateOutputValidTemplate(t *testing.T) {
 	params := imageOutputParams{
 		ID:        "0123456789abcdef",
@@ -47,6 +31,23 @@ func TestTemplateOutputValidTemplate(t *testing.T) {
 		t.Error(err)
 	} else if strings.TrimSpace(output) != strings.TrimSpace(params.ID) {
 		t.Errorf("Error with template output:\nExpected: %s\nReceived: %s\n", params.ID, output)
+	}
+}
+
+func TestTemplateOutputInvalidFormat(t *testing.T) {
+	params := imageOutputParams{
+		ID:        "0123456789abcdef",
+		Name:      "test/image:latest",
+		Digest:    "sha256:012345789abcdef012345789abcdef012345789abcdef012345789abcdef",
+		CreatedAt: "Jan 01 2016 10:45",
+		Size:      "97 KB",
+	}
+
+	formatString := "ID"
+
+	err := outputUsingTemplate(formatString, params)
+	if err == nil || err.Error() != "error invalid format provided: ID" {
+		t.Fatalf("expected error invalid format")
 	}
 }
 

--- a/docs/buildah-images.md
+++ b/docs/buildah-images.md
@@ -53,5 +53,7 @@ buildah images -q --noheading --notruncate
 
 buildah images --filter dangling=true
 
+buildah images --format "ImageID: {{.ID}}"
+
 ## SEE ALSO
 buildah(1)


### PR DESCRIPTION
Same as #589.

Duplicate function name `TestTemplateOutputInvalidFormat` was modified in #604.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>