### PR TITLE
Revert "Update entrypoint behaviour to match docker"

### DIFF
--- a/run.go
+++ b/run.go
@@ -328,18 +328,18 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		return err
 	}
 
-	entrypoint := b.Entrypoint()
-	if len(options.Entrypoint) > 0 {
-		entrypoint = options.Entrypoint
-	}
 	if len(command) > 0 {
-		g.SetProcessArgs(append(entrypoint, command...))
+		g.SetProcessArgs(command)
 	} else {
 		cmd := b.Cmd()
 		if len(options.Cmd) > 0 {
 			cmd = options.Cmd
 		}
-		g.SetProcessArgs(append(entrypoint, cmd...))
+		ep := b.Entrypoint()
+		if len(options.Entrypoint) > 0 {
+			ep = options.Entrypoint
+		}
+		g.SetProcessArgs(append(ep, cmd...))
 	}
 	if options.WorkingDir != "" {
 		g.SetProcessCwd(options.WorkingDir)

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -98,7 +98,7 @@ load helpers
 	[ "$output" = that-other-thing ]
 
 	buildah config --entrypoint echo $cid
-	run buildah --debug=false run $cid that-other-thing
+	run buildah --debug=false run $cid echo that-other-thing
 	[ "$status" -eq 0 ]
 	[ "$output" = that-other-thing ]
 


### PR DESCRIPTION
This reverts commit 15e1054820a0442ce179ca44ddd870b8ff56fa8c.

The original commit changed entrypoint behaviour in `buildah run` to match `docker run`. This breaks the desired state of `buildah run` command line behaviour matching `buildah bud RUN` (Dockerfile) behaviour.

To achieve `docker run` entrypoint behaviour, `podman run` should be used.

Fixes #607

Signed-off-by: pixdrift <support@pixeldrift.net>