### PR TITLE
Revert update of entrypoint behaviour to match docker

### DIFF
--- a/run.go
+++ b/run.go
@@ -328,16 +328,16 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		return err
 	}
 
-	entrypoint := b.Entrypoint()
-	if len(options.Entrypoint) > 0 {
-		entrypoint = options.Entrypoint
-	}
 	if len(command) > 0 {
-		g.SetProcessArgs(append(entrypoint, command...))
+		g.SetProcessArgs(command)
 	} else {
 		cmd := b.Cmd()
 		if len(options.Cmd) > 0 {
 			cmd = options.Cmd
+		}
+		entrypoint := b.Entrypoint()
+		if len(options.Entrypoint) > 0 {
+			entrypoint = options.Entrypoint
 		}
 		g.SetProcessArgs(append(entrypoint, cmd...))
 	}


### PR DESCRIPTION
Signed-off-by: pixdrift <support@pixeldrift.net>

The original commit changed entrypoint behaviour in `buildah run` to match `docker run`. This breaks the desired state of `buildah run` command line behaviour matching `buildah bud RUN` (Dockerfile) behaviour.

To achieve `docker run` entrypoint behaviour, `podman run` should be used.

Fixes #607 