### PR TITLE
Set BUILD_INFO to zero if unset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ GO := go
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 BUILD_INFO := $(shell date +%s)
 
+ifndef BUILD_INFO
+    $(warning Warning! NO value set for BUILD_INFO, date command failed.)
+    BUILD_INFO := 0
+endif
+
 RUNC_COMMIT := c5ec25487693612aed95673800863e134785f946
 LIBSECCOMP_COMMIT := release-2.3
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

In some rare cases, the BUILD_INFO value in the Makefile was not being set in users sandboxes.  This caused the `buildah version` to error as noted in #612.

This fix will print a warning message to the user during make and will set the build date to the epoch.

Addresses #612

Tests:
```
# make
Makefile:14: Warning! NO value set for BUILD_INFO, date command failed.
go build -ldflags '-X main.gitCommit=ec2f209 -X main.buildInfo=0' -o buildah -tags "   selinux seccomp" ./cmd/buildah
go build -ldflags '-X main.gitCommit=ec2f209 -X main.buildInfo=0' -o imgtype -tags "   selinux seccomp" ./tests/imgtype/imgtype.go
make -C docs
make[1]: Entering directory '/root/tsweeney/workspaces/buildah/src/github.com/projectatomic/buildah/docs'
make[1]: Nothing to be done for 'docs'.
make[1]: Leaving directory '/root/tsweeney/workspaces/buildah/src/github.com/projectatomic/buildah/docs'

# ./buildah version
Version:       0.16
Go Version:    go1.9.4
Image Spec:    1.0.0
Runtime Spec:  1.0.0
Git Commit:    ec2f209
Built:         Wed Dec 31 19:00:00 1969
OS/Arch:       linux/amd64
```