### PR TITLE
Modify man pages so they compile correctly in mandb

### DIFF
--- a/docs/buildah-add.md
+++ b/docs/buildah-add.md
@@ -1,7 +1,7 @@
 # buildah-add "1" "March 2017" "buildah"
 
 ## NAME
-buildah add - Add the contents of a file, URL, or a directory to a container.
+buildah\-add - Add the contents of a file, URL, or a directory to a container.
 
 ## SYNOPSIS
 **buildah** **add** **containerID** **SRC** [[...] **DEST**]

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -1,7 +1,7 @@
 # buildah-bud "1" "April 2017" "buildah"
 
 ## NAME
-buildah bud - Build an image using instructions from Dockerfiles.
+buildah\-bud - Build an image using instructions from Dockerfiles.
 
 ## SYNOPSIS
 **buildah** **bud | build-using-dockerfile** [*options* [...]] [**context**]

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -1,7 +1,7 @@
 # buildah-commit "1" "March 2017" "buildah"
 
 ## NAME
-buildah commit - Create an image from a working container.
+buildah\-commit - Create an image from a working container.
 
 ## SYNOPSIS
 **buildah** **commit** [*options* [...]] **containerID** **imageName**

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -1,7 +1,7 @@
 # buildah-config "1" "March 2017" "buildah"
 
 ## NAME
-buildah config - Update image configuration settings.
+buildah\-config - Update image configuration settings.
 
 ## SYNOPSIS
 **buildah** **config** [*options* [...]] **containerID**

--- a/docs/buildah-containers.md
+++ b/docs/buildah-containers.md
@@ -1,7 +1,7 @@
 # buildah-containers "1" "March 2017" "buildah"
 
 ## NAME
-buildah containers - List the working containers and their base images.
+buildah\-containers - List the working containers and their base images.
 
 ## SYNOPSIS
 **buildah** **containers** [*options* [...]]

--- a/docs/buildah-copy.md
+++ b/docs/buildah-copy.md
@@ -1,7 +1,7 @@
 # buildah-copy "1" "March 2017" "buildah"
 
 ## NAME
-buildah copy - Copies the contents of a file, URL, or directory into a container's working directory.
+buildah\-copy - Copies the contents of a file, URL, or directory into a container's working directory.
 
 ## SYNOPSIS
 **buildah** **copy** containerID **SRC** [[...] **DEST**]

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -1,7 +1,7 @@
 # buildah-from "1" "March 2017" "buildah"
 
 ## NAME
-buildah from - Creates a new working container, either from scratch or using a specified image as a starting point.
+buildah\-from - Creates a new working container, either from scratch or using a specified image as a starting point.
 
 ## SYNOPSIS
 **buildah** **from** [*options* [...]] *imageName*

--- a/docs/buildah-images.md
+++ b/docs/buildah-images.md
@@ -1,7 +1,7 @@
 # buildah-images "1" "March 2017" "buildah"
 
 ## NAME
-buildah images - List images in local storage.
+buildah\-images - List images in local storage.
 
 ## SYNOPSIS
 **buildah** **images** [*options* [...]]

--- a/docs/buildah-inspect.md
+++ b/docs/buildah-inspect.md
@@ -1,7 +1,7 @@
 # buildah-inspect "1" "May 2017" "buildah"
 
 ## NAME
-buildah inspect - Display information about working containers or images.
+buildah\-inspect - Display information about working containers or images.
 
 ## SYNOPSIS
 **buildah** **inspect** [*options* [...] --] **ID**

--- a/docs/buildah-mount.md
+++ b/docs/buildah-mount.md
@@ -1,7 +1,7 @@
 # buildah-mount "1" "March 2017" "buildah"
 
 ## NAME
-buildah mount - Mount a working container's root filesystem.
+buildah\-mount - Mount a working container's root filesystem.
 
 ## SYNOPSIS
 **buildah** **mount**

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -1,7 +1,7 @@
 # buildah-push"1" "June 2017" "buildah"
 
 ## NAME
-buildah push - Push an image from local storage to elsewhere.
+buildah\-push - Push an image from local storage to elsewhere.
 
 ## SYNOPSIS
 **buildah** **push** [*options* [...]] **imageID** [**destination**]

--- a/docs/buildah-rm.md
+++ b/docs/buildah-rm.md
@@ -1,7 +1,7 @@
 # buildah-rm "1" "March 2017" "buildah"
 
 ## NAME
-buildah rm - Removes one or more working containers.
+buildah\-rm - Removes one or more working containers.
 
 ## SYNOPSIS
 **buildah** **rm** **containerID [...]**

--- a/docs/buildah-rmi.md
+++ b/docs/buildah-rmi.md
@@ -1,7 +1,7 @@
 # buildah-rmi "1" "March 2017" "buildah"
 
 ## NAME
-buildah rmi - Removes one or more images.
+buildah\-rmi - Removes one or more images.
 
 ## SYNOPSIS
 **buildah** **rmi** **imageID [...]**

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -1,7 +1,7 @@
 # buildah-run "1" "March 2017" "buildah"
 
 ## NAME
-buildah run - Run a command inside of the container.
+buildah\-run - Run a command inside of the container.
 
 ## SYNOPSIS
 **buildah** **run** [*options* [...] --] **containerID** **command**

--- a/docs/buildah-tag.md
+++ b/docs/buildah-tag.md
@@ -1,7 +1,7 @@
 # buildah-tag "1" "May 2017" "buildah"
 
 ## NAME
-buildah tag - Add additional names to local images.
+buildah\-tag - Add additional names to local images.
 
 ## SYNOPSIS
 **buildah** **tag** **name** **new-name** [...]

--- a/docs/buildah-umount.md
+++ b/docs/buildah-umount.md
@@ -1,7 +1,7 @@
 # buildah-umount "1" "March 2017" "buildah"
 
 ## NAME
-buildah umount - Unmount the root file system on the specified working containers.
+buildah\-umount - Unmount the root file system on the specified working containers.
 
 ## SYNOPSIS
 **buildah** **umount** **containerID [...]**

--- a/docs/buildah-version.md
+++ b/docs/buildah-version.md
@@ -1,7 +1,7 @@
 # buildah-version "1" "June 2017" "Buildah"
 
 ## NAME
-buildah version - Display the Buildah Version Information.
+buildah\-version - Display the Buildah Version Information.
 
 ## SYNOPSIS
 **buildah version**

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -1,7 +1,7 @@
 # buildah "1" "March 2017" "buildah"
 
 ## NAME
-Buildah - A command line tool to facilitate working with containers and using them to build images.
+Buildah - A command line tool that facilitates building OCI container images.
 
 ## SYNOPSIS
 buildah [OPTIONS] COMMAND [ARG...]


### PR DESCRIPTION
This fixes an issue where if you did
man -k buildah-bud

buildah-bud (1)    - (unknown subject)

Now you will see

man -k buildah-bud
buildah-bud (1)      - Build an image using instructions from Dockerfiles.

More importantly
man -k Dockerfile
buildah-bud (1)      - Build an image using instructions from Dockerfiles.
docker-build (1)     - Build an image from a Dockerfile
docker-image-build (1) - Build an image from a Dockerfile
Dockerfile (5)       - automate the steps of creating a Docker image
podman-build (1)     - Build a container image using a Dockerfile.

Will now list buildah-d

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>