### PR TITLE
Add a method for setting a comment in to-be-created history items

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -89,6 +89,8 @@ type Builder struct {
 	ImageAnnotations map[string]string `json:"annotations,omitempty"`
 	// ImageCreatedBy is a description of how this container was built.
 	ImageCreatedBy string `json:"created-by,omitempty"`
+	// ImageHistoryComment is a description of how our added layers were built.
+	ImageHistoryComment string `json:"history-comment,omitempty"`
 
 	// Image metadata and runtime settings, in multiple formats.
 	OCIv1  v1.Image       `json:"ociv1,omitempty"`

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -30,8 +30,16 @@ var (
 			Usage: "set the default `command` to run for containers based on the image",
 		},
 		cli.StringFlag{
+			Name:  "comment",
+			Usage: "set a `comment` in the target image",
+		},
+		cli.StringFlag{
 			Name:  "created-by",
 			Usage: "set `description` of how the image was created",
+		},
+		cli.StringFlag{
+			Name:  "domainname",
+			Usage: "set a domain `name` for containers based on image",
 		},
 		cli.StringFlag{
 			Name:  "entrypoint",
@@ -40,6 +48,14 @@ var (
 		cli.StringSliceFlag{
 			Name:  "env, e",
 			Usage: "add `environment variable` to be set when running containers based on image (default [])",
+		},
+		cli.StringFlag{
+			Name:  "history-comment",
+			Usage: "set a `comment` for the history of the target image",
+		},
+		cli.StringFlag{
+			Name:  "hostname",
+			Usage: "set a host`name` for containers based on image",
 		},
 		cli.StringSliceFlag{
 			Name:  "label, l",
@@ -168,6 +184,18 @@ func updateConfig(builder *buildah.Builder, c *cli.Context) {
 	}
 	if c.IsSet("workingdir") {
 		builder.SetWorkDir(c.String("workingdir"))
+	}
+	if c.IsSet("comment") {
+		builder.SetComment(c.String("comment"))
+	}
+	if c.IsSet("history-comment") {
+		builder.SetHistoryComment(c.String("history-comment"))
+	}
+	if c.IsSet("domainname") {
+		builder.SetDomainname(c.String("domainname"))
+	}
+	if c.IsSet("hostname") {
+		builder.SetHostname(c.String("hostname"))
 	}
 	if c.IsSet("annotation") || c.IsSet("a") {
 		for _, annotationSpec := range c.StringSlice("annotation") {

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -11,12 +11,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-const (
-	// DefaultCreatedBy is the default description of how an image layer
-	// was created that we use when adding to an image's history.
-	DefaultCreatedBy = "manual edits"
-)
-
 var (
 	configFlags = []cli.Flag{
 		cli.StringSliceFlag{
@@ -38,7 +32,6 @@ var (
 		cli.StringFlag{
 			Name:  "created-by",
 			Usage: "set `description` of how the image was created",
-			Value: DefaultCreatedBy,
 		},
 		cli.StringFlag{
 			Name:  "entrypoint",

--- a/config.go
+++ b/config.go
@@ -588,12 +588,24 @@ func (b *Builder) Comment() string {
 	return b.Docker.Comment
 }
 
-// SetComment sets the Comment which will be set in the container and in
+// SetComment sets the comment which will be set in the container and in
 // containers built using images built from the container.
 // Note: this setting is not present in the OCIv1 image format, so it is
 // discarded when writing images using OCIv1 formats.
 func (b *Builder) SetComment(comment string) {
 	b.Docker.Comment = comment
+}
+
+// HistoryComment returns the comment which will be used in the history item
+// which will describe the latest layer when we commit an image.
+func (b *Builder) HistoryComment() string {
+	return b.ImageHistoryComment
+}
+
+// SetHistoryComment sets the comment which will be used in the history item
+// which will describe the latest layer when we commit an image.
+func (b *Builder) SetHistoryComment(comment string) {
+	b.ImageHistoryComment = comment
 }
 
 // StopSignal returns the signal which will be set in the container and in

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -268,10 +268,14 @@ return 1
        --arch
        --author
        --cmd
+       --comment
        --created-by
+       --domainname
        --entrypoint
        --env
        -e
+       --history-comment
+       --hostname
        --label
        -l
        --os

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -36,8 +36,8 @@ be built using the specified container.  When used in combination with an
 
 **--created-by** *created*
 
-Set the description of how the read-write layer *created* (default: "manual
-edits") in any images which will be created using the specified container.
+Set the description of how the topmost layer was *created* for any images which
+will be created using the specified container.
 
 **--entrypoint** *entry*
 

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -34,10 +34,24 @@ Set the default *command* to run for containers based on any images which will
 be built using the specified container.  When used in combination with an
 *entry point*, this specifies the default parameters for the *entry point*.
 
+**--comment** *comment*
+
+Set the image-level comment for any images which will be built using the
+specified container.
+
+Note: this setting is not present in the OCIv1 image format, so it is discarded when writing images using OCIv1 formats.
+
 **--created-by** *created*
 
 Set the description of how the topmost layer was *created* for any images which
 will be created using the specified container.
+
+**--domainname** *domain*
+
+Set the domainname to set when running containers based on any images built
+using the specified container.
+
+Note: this setting is not present in the OCIv1 image format, so it is discarded when writing images using OCIv1 formats.
 
 **--entrypoint** *entry*
 
@@ -50,6 +64,18 @@ Note: Setting the entrypoint without setting the --cmd, clears the cmd field in 
 
 Add a value (e.g. name=*value*) to the environment for containers based on any
 images which will be built using the specified container. Can be used multiple times.
+
+**--history-comment** *comment*
+
+Sets a comment on the the topmost layer in any images which will be created
+using the specified container.
+
+**--hostname** *host*
+
+Set the hostname to set when running containers based on any images built using
+the specified container.
+
+Note: this setting is not present in the OCIv1 image format, so it is discarded when writing images using OCIv1 formats.
 
 **--label** *label*
 

--- a/image.go
+++ b/image.go
@@ -46,6 +46,7 @@ type containerImageRef struct {
 	dconfig               []byte
 	created               time.Time
 	createdBy             string
+	historyComment        string
 	annotations           map[string]string
 	preferredManifestType string
 	exporting             bool
@@ -303,6 +304,7 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, sc *types.System
 		Created:    &i.created,
 		CreatedBy:  i.createdBy,
 		Author:     oimage.Author,
+		Comment:    i.historyComment,
 		EmptyLayer: false,
 	}
 	oimage.History = append(oimage.History, onews)
@@ -310,6 +312,7 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, sc *types.System
 		Created:    i.created,
 		CreatedBy:  i.createdBy,
 		Author:     dimage.Author,
+		Comment:    i.historyComment,
 		EmptyLayer: false,
 	}
 	dimage.History = append(dimage.History, dnews)
@@ -521,6 +524,7 @@ func (b *Builder) makeImageRef(manifestType string, exporting bool, compress arc
 		dconfig:               dconfig,
 		created:               created,
 		createdBy:             b.CreatedBy(),
+		historyComment:        b.HistoryComment(),
 		annotations:           b.Annotations(),
 		preferredManifestType: manifestType,
 		exporting:             exporting,


### PR DESCRIPTION
This patch adds `HistoryComment()` and `SetHistoryComment()` methods to the builder structure, which provide a way to manipulate which value we'll use when creating history items for images when we need them.

It stops providing a default for the `buildah config --created-by` option, so that if it's invoked a second time after setting the option, we won't override the previously-supplied value with our default.

It adds tests for --history-comment, --shell, --domainname, --hostname, and --comment.