### PR TITLE
Add golang 1.10 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 go: 
     - 1.8
     - 1.9.x
+    - 1.10.x
     - tip
 
 matrix:


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add golang 1.10 to the build mix.  I'm not 100% sure how it will go, so a bit of an experiment.