### PR TITLE
Force "localhost" as a default registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,5 +61,5 @@ script:
     # Setting up  Docker Registry is complete, let's do Buildah testing! 
     - make install.tools install.libseccomp.sudo all runc validate TAGS="apparmor seccomp containers_image_ostree_stub"
     - go test -c -tags "apparmor seccomp `./btrfs_tag.sh` `./libdm_tag.sh` `./ostree_tag.sh` `./selinux_tag.sh`" ./cmd/buildah
-    - tmp=`mktemp -d`; mkdir $tmp/root $tmp/runroot; sudo PATH="$PATH" ./buildah.test -test.v -root $tmp/root -runroot $tmp/runroot -storage-driver vfs -signature-policy `pwd`/tests/policy.json
+    - tmp=`mktemp -d`; mkdir $tmp/root $tmp/runroot; sudo PATH="$PATH" ./buildah.test -test.v -root $tmp/root -runroot $tmp/runroot -storage-driver vfs -signature-policy `pwd`/tests/policy.json -registries-conf `pwd`/tests/registries.conf
     - cd tests; sudo PATH="$PATH" ./test_runner.sh

--- a/Makefile
+++ b/Makefile
@@ -93,4 +93,4 @@ test-unit:
 	$(GO) test -v -race $(shell go list ./... | grep -v vendor | grep -v tests | grep -v cmd)
 	tmp=$(shell mktemp -d) ; \
 	mkdir -p $$tmp/root $$tmp/runroot; \
-	$(GO) test -v -tags "$(AUTOTAGS) $(TAGS)" ./cmd/buildah -args -root $$tmp/root -runroot $$tmp/runroot -storage-driver vfs -signature-policy $(shell pwd)/tests/policy.json
+	$(GO) test -v -tags "$(AUTOTAGS) $(TAGS)" ./cmd/buildah -args -root $$tmp/root -runroot $$tmp/runroot -storage-driver vfs -signature-policy $(shell pwd)/tests/policy.json -registries-conf $(shell pwd)/tests/registries.conf

--- a/cmd/buildah/common_test.go
+++ b/cmd/buildah/common_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	is "github.com/containers/image/storage"
+	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	"github.com/projectatomic/buildah"
 	"github.com/sirupsen/logrus"
@@ -16,6 +17,7 @@ import (
 var (
 	signaturePolicyPath = ""
 	storeOptions        = storage.DefaultStoreOptions
+	testSystemContext   = types.SystemContext{}
 )
 
 func TestMain(m *testing.M) {
@@ -25,6 +27,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&options.GraphRoot, "root", "", "storage root dir")
 	flag.StringVar(&options.RunRoot, "runroot", "", "storage state dir")
 	flag.StringVar(&options.GraphDriverName, "storage-driver", "", "storage driver")
+	flag.StringVar(&testSystemContext.SystemRegistriesConfPath, "registries-conf", "", "registries list")
 	flag.BoolVar(&debug, "debug", false, "turn on debug logging")
 	flag.Parse()
 	if options.GraphRoot != "" || options.RunRoot != "" || options.GraphDriverName != "" {
@@ -112,6 +115,7 @@ func pullTestImage(t *testing.T, imageName string) (string, error) {
 		FromImage:           imageName,
 		SignaturePolicyPath: signaturePolicyPath,
 		CommonBuildOpts:     commonOpts,
+		SystemContext:       &testSystemContext,
 	}
 
 	b, err := buildah.NewBuilder(getContext(), store, options)

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -11,6 +11,7 @@ import (
 
 	is "github.com/containers/image/storage"
 	"github.com/containers/storage"
+	"github.com/projectatomic/buildah/util"
 )
 
 func TestTemplateOutputValidTemplate(t *testing.T) {
@@ -428,9 +429,9 @@ func TestParseFilterAllParams(t *testing.T) {
 		t.Fatalf("error parsing filter: %v", err)
 	}
 
-	ref, err := is.Transport.ParseStoreReference(store, "busybox:latest")
+	ref, _, err := util.FindImage(store, "", &testSystemContext, "busybox:latest")
 	if err != nil {
-		t.Fatalf("error parsing store reference: %v", err)
+		t.Fatalf("error finding local copy of image: %v", err)
 	}
 	img, err := ref.NewImage(getContext(), nil)
 	if err != nil {

--- a/cmd/buildah/rmi_test.go
+++ b/cmd/buildah/rmi_test.go
@@ -52,7 +52,7 @@ func TestStorageImageRefTrue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not pull image to remove: %v", err)
 	}
-	imgRef, err := storageImageRef(getContext(), store, "busybox")
+	imgRef, err := storageImageRef(getContext(), &testSystemContext, store, "busybox")
 	if err != nil {
 		t.Errorf("could not match image: %v", err)
 	} else if imgRef == nil {
@@ -76,7 +76,7 @@ func TestStorageImageRefFalse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not pull image to remove: %v", err)
 	}
-	imgRef, _ := storageImageRef(getContext(), store, "")
+	imgRef, _ := storageImageRef(getContext(), &testSystemContext, store, "")
 	if imgRef != nil {
 		t.Error("should not have found an Image Reference")
 	}

--- a/cmd/buildah/tag.go
+++ b/cmd/buildah/tag.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah/pkg/parse"
 	"github.com/projectatomic/buildah/util"
 	"github.com/urfave/cli"
 )
@@ -27,11 +28,15 @@ func tagCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	img, err := util.FindImage(store, args[0])
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return errors.Wrapf(err, "error building system context")
+	}
+	_, img, err := util.FindImage(store, "", systemContext, args[0])
 	if err != nil {
 		return errors.Wrapf(err, "error finding local image %q", args[0])
 	}
-	err = util.AddImageNames(store, img, args[1:])
+	err = util.AddImageNames(store, "", systemContext, img, args[1:])
 	if err != nil {
 		return errors.Wrapf(err, "error adding names %v to image %q", args[1:], args[0])
 	}

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -22,7 +22,7 @@ Add a line to /etc/hosts. The format is hostname:ip. The **--add-host** option c
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--build-arg** *arg=value*
@@ -34,7 +34,7 @@ resulting image's configuration.
 
 **--cert-dir** *path*
 
-Use certificates at *path* (*.crt, *.cert, *.key) to connect to the registry.
+Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
 Default certificates directory is _/etc/containers/certs.d_.
 
 **--cgroup-parent**=""
@@ -234,6 +234,7 @@ Squash newly built layers into a single new layer.  Buildah does not currently s
 
 Specifies the name which will be assigned to the resulting image if the build
 process completes successfully.
+If _imageName_ does not include a registry name, the registry name *localhost* will be prepended to the image name.
 
 **--tls-verify** *bool-value*
 

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -8,7 +8,8 @@ buildah\-commit - Create an image from a working container.
 
 ## DESCRIPTION
 Writes a new image using the specified container's read-write layer and if it
-is based on an image, the layers of that image.
+is based on an image, the layers of that image.  If *imageName* does not begin
+with a registry name component, *localhost* will be added to the name.
 
 ## RETURN VALUE
 The image ID of the image that was created.  On error, 1 is returned and errno is returned.
@@ -17,12 +18,12 @@ The image ID of the image that was created.  On error, 1 is returned and errno i
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--cert-dir** *path*
 
-Use certificates at *path* (*.crt, *.cert, *.key) to connect to the registry.
+Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
 Default certificates directory is _/etc/containers/certs.d_.
 
 **--creds** *creds*
@@ -34,7 +35,6 @@ value can be entered.  The password is entered without echo.
 **--disable-compression, -D**
 
 Don't compress filesystem layers when building the image.
-
 
 **--format**
 
@@ -72,7 +72,6 @@ This example saves an image based on the container.
 This example saves an image named newImageName based on the container.
  `buildah commit --rm containerID newImageName`
 
-
 This example saves an image based on the container disabling compression.
  `buildah commit --disable-compression containerID`
 
@@ -86,7 +85,7 @@ This example commits the container to the image on the local registry using cred
  `buildah commit --cert-dir ~/auth  --tls-verify=true --creds=username:password containerID docker://localhost:5000/imageId`
 
 This example commits the container to the image on the local registry using credentials from the /tmp/auths/myauths.json file and certificates for authentication.
- `buildah commit --authfile /tmp/auths/myauths.json --cert-dir ~/auth  --tls-verify=true --creds=username:password containerID docker://localhost:5000/imageId`
+ `buildah commit --authfile /tmp/auths/myauths.json --cert-dir ~/auth  --tls-verify=true --creds=username:password containerID docker://localhost:5000/imageName`
 
 ## SEE ALSO
 buildah(1)

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -17,7 +17,8 @@ Multiple transports are supported:
   An existing local directory _path_ retrieving the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
   **docker://**_docker-reference_ (Default)
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set using `(podman login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG\_RUNTIME\_DIR/containers/auth.json`, which is set using `(podman login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
+  If _docker-reference_ does not include a registry name, *localhost* will be consulted first, followed by any registries named in the registries configuration.
 
   **docker-archive:**_path_
   An image is retrieved as a `docker load` formatted file.
@@ -44,7 +45,7 @@ Add a line to /etc/hosts. The format is hostname:ip. The **--add-host** option c
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--cert-dir** *path*

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -24,7 +24,8 @@ Image stored in local container/storage
   An existing local directory _path_ storing the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
   **docker://**_docker-reference_
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set using `(podman login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG\_RUNTIME\_DIR/containers/auth.json`, which is set using `(podman login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
+  If _docker-reference_ does not include a registry name, the image will be pushed to a registry running on *localhost*.
 
   **docker-archive:**_path_[**:**_docker-reference_]
   An image is stored in the `docker save` formatted file.  _docker-reference_ is only used when creating such a file, and it must not contain a digest.
@@ -45,12 +46,12 @@ Image stored in local container/storage
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--cert-dir** *path*
 
-Use certificates at *path* (*.crt, *.cert, *.key) to connect to the registry.
+Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
 Default certificates directory is _/etc/containers/certs.d_.
 
 **--creds** *creds*

--- a/docs/buildah-rmi.md
+++ b/docs/buildah-rmi.md
@@ -13,6 +13,7 @@ Removes one or more locally stored images.
 If the image was pushed to a directory path using the 'dir:' transport
 the rmi command can not remove the image.  Instead standard file system
 commands should be used.
+If _imageID_ is a name, but does not include a registry name, buildah will attempt to find and remove an image named using the registry name *localhost*, if no such image is found, it will search for the intended image by attempting to expand the given name using the names of registries provided in the system's registries configuration.
 
 ## OPTIONS
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/imagebuilder"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
+	"github.com/projectatomic/buildah/util"
 	"github.com/sirupsen/logrus"
 )
 
@@ -623,22 +624,25 @@ func (b *Executor) Execute(ib *imagebuilder.Builder, node *parser.Node) error {
 // the name if there is one, generating a unique ID-based one otherwise.
 func (b *Executor) Commit(ctx context.Context, ib *imagebuilder.Builder) (err error) {
 	var imageRef types.ImageReference
+
 	if b.output != "" {
 		imageRef, err = alltransports.ParseImageName(b.output)
 		if err != nil {
-			imageRef2, err2 := is.Transport.ParseStoreReference(b.store, b.output)
-			if err2 == nil {
-				imageRef = imageRef2
-				err = nil
-			} else {
-				err = err2
+			candidates := util.ResolveName(b.output, "", b.systemContext, b.store)
+			if len(candidates) == 0 {
+				return errors.Errorf("error parsing target image name %q", b.output)
 			}
+			imageRef2, err2 := is.Transport.ParseStoreReference(b.store, candidates[0])
+			if err2 != nil {
+				return errors.Wrapf(err, "error parsing target image name %q", b.output)
+			}
+			imageRef = imageRef2
 		}
 	} else {
 		imageRef, err = is.Transport.ParseStoreReference(b.store, "@"+stringid.GenerateRandomID())
-	}
-	if err != nil {
-		return errors.Wrapf(err, "error parsing reference for image to be written")
+		if err != nil {
+			return errors.Wrapf(err, "error parsing reference for image to be written")
+		}
 	}
 	if ib.Author != "" {
 		b.builder.SetMaintainer(ib.Author)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -240,7 +240,7 @@ load helpers
   target=scratch-image
   target2=another-scratch-image
   target3=so-many-scratch-images
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -t ${target2} -t ${target3} ${TESTSDIR}/bud/from-scratch
+  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -t docker.io/${target2} -t ${target3} ${TESTSDIR}/bud/from-scratch
   run buildah --debug=false images
   [ "$status" -eq 0 ]
   cid=$(buildah from ${target})

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -123,7 +123,7 @@ load helpers
   cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm $cid
   buildah tag alpine alpine2
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json docker.io/alpine2)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json localhost/alpine2)
   [ "$cid" == alpine2-working-container ]
   buildah rm ${cid}
   buildah rmi alpine alpine2

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -45,5 +45,5 @@ function buildah() {
 }
 
 function imgtype() {
-        ${IMGTYPE_BINARY} -root ${TESTDIR}/root -runroot ${TESTDIR}/runroot -storage-driver ${STORAGE_DRIVER} "$@"
+        ${IMGTYPE_BINARY} -debug -root ${TESTDIR}/root -runroot ${TESTDIR}/runroot -storage-driver ${STORAGE_DRIVER} "$@"
 }

--- a/tests/imgtype/imgtype.go
+++ b/tests/imgtype/imgtype.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/projectatomic/buildah"
 	"github.com/projectatomic/buildah/docker"
+	"github.com/projectatomic/buildah/util"
 	"github.com/sirupsen/logrus"
 )
 
@@ -101,11 +102,11 @@ func main() {
 		manifestType := ""
 		configType := ""
 
-		ref, err := is.Transport.ParseStoreReference(store, image)
+		ref, _, err := util.FindImage(store, "", systemContext, image)
 		if err != nil {
 			ref2, err2 := alltransports.ParseImageName(image)
 			if err2 != nil {
-				logrus.Errorf("error parsing reference %q: %v", image, err)
+				logrus.Errorf("error parsing reference %q to an image: %v", image, err)
 				errors = true
 				continue
 			}

--- a/util/util.go
+++ b/util/util.go
@@ -54,8 +54,9 @@ var (
 	TarballTransport = tarball.Transport.Name()
 )
 
-// ResolveName checks if name is a valid image name, and if that name doesn't include a domain
-// portion, returns a list of the names which it might correspond to in the registries.
+// ResolveName checks if name is a valid image name, and if that name doesn't
+// include a domain portion, returns a list of the names which it might
+// correspond to in the set of configured registries.
 func ResolveName(name string, firstRegistry string, sc *types.SystemContext, store storage.Store) []string {
 	if name == "" {
 		return nil
@@ -101,8 +102,8 @@ func ResolveName(name string, firstRegistry string, sc *types.SystemContext, sto
 	// Figure out the list of registries.
 	registries, err := sysregistries.GetRegistries(sc)
 	if err != nil {
-		logrus.Debugf("unable to complete image name %q: %v", name, err)
-		return []string{name}
+		logrus.Debugf("unable to read configured registries to complete %q: %v", name, err)
+		registries = []string{}
 	}
 	if sc.DockerInsecureSkipTLSVerify {
 		if unverifiedRegistries, err := sysregistries.GetInsecureRegistries(sc); err == nil {
@@ -111,10 +112,14 @@ func ResolveName(name string, firstRegistry string, sc *types.SystemContext, sto
 	}
 
 	// Create all of the combinations.  Some registries need an additional component added, so
-	// use our lookaside map to keep track of them.  If there are no configured registries, at
-	// least return the name as it was passed to us.
+	// use our lookaside map to keep track of them.  If there are no configured registries, we'll
+	// return a name using "localhost" as the registry name.
 	candidates := []string{}
-	for _, registry := range append([]string{firstRegistry}, registries...) {
+	initRegistries := []string{"localhost"}
+	if firstRegistry != "" && firstRegistry != "localhost" {
+		initRegistries = append([]string{firstRegistry}, initRegistries...)
+	}
+	for _, registry := range append(initRegistries, registries...) {
 		if registry == "" {
 			continue
 		}
@@ -125,9 +130,6 @@ func ResolveName(name string, firstRegistry string, sc *types.SystemContext, sto
 		candidate := path.Join(registry, middle, name)
 		candidates = append(candidates, candidate)
 	}
-	if len(candidates) == 0 {
-		candidates = append(candidates, name)
-	}
 	return candidates
 }
 
@@ -135,12 +137,23 @@ func ResolveName(name string, firstRegistry string, sc *types.SystemContext, sto
 // the fully expanded result, including a tag.  Names which don't include a registry
 // name will be marked for the most-preferred registry (i.e., the first one in our
 // configuration).
-func ExpandNames(names []string) ([]string, error) {
+func ExpandNames(names []string, firstRegistry string, systemContext *types.SystemContext, store storage.Store) ([]string, error) {
 	expanded := make([]string, 0, len(names))
 	for _, n := range names {
-		name, err := reference.ParseNormalizedNamed(n)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing name %q", n)
+		var name reference.Named
+		nameList := ResolveName(n, firstRegistry, systemContext, store)
+		if len(nameList) == 0 {
+			named, err := reference.ParseNormalizedNamed(n)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error parsing name %q", n)
+			}
+			name = named
+		} else {
+			named, err := reference.ParseNormalizedNamed(nameList[0])
+			if err != nil {
+				return nil, errors.Wrapf(err, "error parsing name %q", nameList[0])
+			}
+			name = named
 		}
 		name = reference.TagNameOnly(name)
 		tag := ""
@@ -157,28 +170,36 @@ func ExpandNames(names []string) ([]string, error) {
 }
 
 // FindImage locates the locally-stored image which corresponds to a given name.
-func FindImage(store storage.Store, image string) (*storage.Image, error) {
+func FindImage(store storage.Store, firstRegistry string, systemContext *types.SystemContext, image string) (types.ImageReference, *storage.Image, error) {
+	var ref types.ImageReference
 	var img *storage.Image
-	ref, err := is.Transport.ParseStoreReference(store, image)
-	if err == nil {
-		img, err = is.Transport.GetStoreImage(store, ref)
-	}
-	if err != nil {
-		img2, err2 := store.Image(image)
-		if err2 != nil {
-			if ref == nil {
-				return nil, errors.Wrapf(err, "error parsing reference to image %q", image)
-			}
-			return nil, errors.Wrapf(err, "unable to locate image %q", image)
+	var err error
+	for _, name := range ResolveName(image, firstRegistry, systemContext, store) {
+		ref, err = is.Transport.ParseStoreReference(store, name)
+		if err != nil {
+			logrus.Debugf("error parsing reference to image %q: %v", name, err)
+			continue
 		}
-		img = img2
+		img, err = is.Transport.GetStoreImage(store, ref)
+		if err != nil {
+			img2, err2 := store.Image(name)
+			if err2 != nil {
+				logrus.Debugf("error locating image %q: %v", name, err2)
+				continue
+			}
+			img = img2
+		}
+		break
 	}
-	return img, nil
+	if ref == nil || img == nil {
+		return nil, nil, errors.Wrapf(err, "error locating image with name %q", image)
+	}
+	return ref, img, nil
 }
 
 // AddImageNames adds the specified names to the specified image.
-func AddImageNames(store storage.Store, image *storage.Image, addNames []string) error {
-	names, err := ExpandNames(addNames)
+func AddImageNames(store storage.Store, firstRegistry string, systemContext *types.SystemContext, image *storage.Image, addNames []string) error {
+	names, err := ExpandNames(addNames, firstRegistry, systemContext, store)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Extend `util.ResolveName()` to prepend "localhost" to the list of registries, and teach `util.FindImage()`, `util.ExpandNames()`, and `util.AddImageNames()` to use `util.ResolveName()`.