### PR TITLE
Drop util.GetLocalTime()

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/storage"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah/pkg/parse"
-	"github.com/projectatomic/buildah/util"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"golang.org/x/crypto/ssh/terminal"
@@ -233,7 +232,7 @@ func outputImages(ctx context.Context, images []storage.Image, format string, st
 				createdTime = inspectedTime
 			}
 		}
-		createdTime = util.GetLocalTime(createdTime)
+		createdTime = createdTime.Local()
 
 		names := []string{}
 		if len(image.Names) > 0 {

--- a/util/util.go
+++ b/util/util.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"path"
 	"strings"
-	"time"
 
 	"github.com/containers/image/directory"
 	dockerarchive "github.com/containers/image/docker/archive"
@@ -201,15 +200,6 @@ func GetFailureCause(err, defaultError error) error {
 	default:
 		return defaultError
 	}
-}
-
-// GetLocalTime discover the UTC offset and then add that to the
-// passed in time to arrive at the local time.
-func GetLocalTime(localTime time.Time) time.Time {
-	t := time.Now()
-	_, offset := t.Local().Zone()
-	localTime = localTime.Add(time.Second * time.Duration(offset))
-	return localTime
 }
 
 // WriteError writes `lastError` into `w` if not nil and return the next error `err`


### PR DESCRIPTION
util.GetLocalTime() duplicates time.Time.Local(), so drop it.