### PR TITLE
Add Files section with registries.conf to pertinent man pages

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -337,5 +337,11 @@ buildah bud --security-opt label=level:s0:c100,c200 --cgroup-parent /path/to/cgr
 
 buildah bud --volume /home/test:/myvol:ro,Z -t imageName .
 
+## Files
+
+**registries.conf** (`/etc/containers/registries.conf`)
+
+registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
+
 ## SEE ALSO
-buildah(1), podman-login(1), docker-login(1)
+buildah(1), podman-login(1), docker-login(1), policy.json(5), registries.conf(5)

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -87,5 +87,11 @@ This example commits the container to the image on the local registry using cred
 This example commits the container to the image on the local registry using credentials from the /tmp/auths/myauths.json file and certificates for authentication.
  `buildah commit --authfile /tmp/auths/myauths.json --cert-dir ~/auth  --tls-verify=true --creds=username:password containerID docker://localhost:5000/imageName`
 
+## Files
+
+**registries.conf** (`/etc/containers/registries.conf`)
+
+registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
+
 ## SEE ALSO
-buildah(1)
+buildah(1), policy.json(5), registries.conf(5)

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -299,5 +299,11 @@ buildah from --ulimit nofile=1024:1028 --cgroup-parent /path/to/cgroup/parent my
 
 buildah from --volume /home/test:/myvol:ro,Z myregistry/myrepository/imagename:imagetag
 
+## Files
+
+**registries.conf** (`/etc/containers/registries.conf`)
+
+registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
+
 ## SEE ALSO
-buildah(1), podman-login(1), docker-login(1)
+buildah(1), podman-login(1), docker-login(1), policy.json(5), registries.conf(5)

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -114,5 +114,11 @@ This example extracts the imageID image and puts it into the registry on the loc
 This example extracts the imageID image and puts it into the registry on the localhost using credentials and certificates for authentication.
  `# buildah push --cert-dir ~/auth --tls-verify=true --creds=username:password imageID docker://localhost:5000/my-imageID`
 
+## Files
+
+**registries.conf** (`/etc/containers/registries.conf`)
+
+registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
+
 ## SEE ALSO
-buildah(1), podman-login(1), docker-login(1)
+buildah(1), podman-login(1), docker-login(1), policy.json(5), registries.conf(5)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Adds a "Files" section to the four man pages that make use of registries.conf and adds an entry for registries.conf to each.  No code changes, just man page updates.