### PR TITLE
Remove buildah run cmd and entrypoint execution

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -69,9 +69,9 @@ func runCmd(c *cli.Context) error {
 		args = args[1:]
 	}
 
-        if len(args) == 0 {
-                return errors.Errorf("command must be specified")
-        }
+	if len(args) == 0 {
+		return errors.Errorf("command must be specified")
+	}
 
 	store, err := getStore(c)
 	if err != nil {

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -69,6 +69,10 @@ func runCmd(c *cli.Context) error {
 		args = args[1:]
 	}
 
+        if len(args) == 0 {
+                return errors.Errorf("command must be specified")
+        }
+
 	store, err := getStore(c)
 	if err != nil {
 		return err

--- a/run.go
+++ b/run.go
@@ -326,15 +326,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	if len(command) > 0 {
 		g.SetProcessArgs(command)
 	} else {
-		cmd := b.Cmd()
-		if len(options.Cmd) > 0 {
-			cmd = options.Cmd
-		}
-		entrypoint := b.Entrypoint()
-		if len(options.Entrypoint) > 0 {
-			entrypoint = options.Entrypoint
-		}
-		g.SetProcessArgs(append(entrypoint, cmd...))
+		g.SetProcessArgs(nil)
 	}
 	if options.WorkingDir != "" {
 		g.SetProcessCwd(options.WorkingDir)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -443,3 +443,20 @@ load helpers
   [[ "$output" =~ "error building at step" ]]
   [ "$status" -eq 1 ]
 }
+
+@test "bud with ENTRYPOINT, CMD and RUN" {
+  target=alpine-image
+  run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-cmd-run
+  [[ "$output" =~ "unique.test.string" ]]
+  [ "$status" -eq 0 ]
+  cid=$(buildah from ${target})
+  buildah rm ${cid}
+  buildah rmi ${target}
+}
+
+@test "bud with ENTRYPOINT, CMD and empty RUN" {
+  target=alpine-image
+  run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-cmd-empty-run
+  [[ "$output" =~ "error building at step" ]]
+  [ "$status" -eq 1 ]
+}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -409,3 +409,37 @@ load helpers
   run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/symlink/Dockerfile.symlink-points-to-itself
   [ "$status" -ne 0 ]
 }
+
+@test "bud with ENTRYPOINT and RUN" {
+  target=alpine-image
+  run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-run
+  [[ "$output" =~ "unique.test.string" ]]
+  [ "$status" -eq 0 ]
+  cid=$(buildah from ${target})
+  buildah rm ${cid}
+  buildah rmi ${target}
+}
+
+@test "bud with ENTRYPOINT and empty RUN" {
+  target=alpine-image
+  run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-empty-run
+  [[ "$output" =~ "error building at step" ]]
+  [ "$status" -eq 1 ]
+}
+
+@test "bud with CMD and RUN" {
+  target=alpine-image
+  run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.cmd-run
+  [[ "$output" =~ "unique.test.string" ]]
+  [ "$status" -eq 0 ]
+  cid=$(buildah from ${target})
+  buildah rm ${cid}
+  buildah rmi ${target}
+}
+
+@test "bud with CMD and empty RUN" {
+  target=alpine-image
+  run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.cmd-empty-run
+  [[ "$output" =~ "error building at step" ]]
+  [ "$status" -eq 1 ]
+}

--- a/tests/bud/run-scenarios/Dockerfile.cmd-empty-run
+++ b/tests/bud/run-scenarios/Dockerfile.cmd-empty-run
@@ -1,0 +1,3 @@
+FROM alpine
+CMD [ "pwd" ]
+RUN

--- a/tests/bud/run-scenarios/Dockerfile.cmd-run
+++ b/tests/bud/run-scenarios/Dockerfile.cmd-run
@@ -1,0 +1,3 @@
+FROM alpine
+CMD [ "/invalid/cmd" ]
+RUN echo "unique.test.string"

--- a/tests/bud/run-scenarios/Dockerfile.entrypoint-cmd-empty-run
+++ b/tests/bud/run-scenarios/Dockerfile.entrypoint-cmd-empty-run
@@ -1,0 +1,4 @@
+FROM alpine
+ENTRYPOINT [ "pwd" ]
+CMD [ "whoami" ]
+RUN

--- a/tests/bud/run-scenarios/Dockerfile.entrypoint-cmd-run
+++ b/tests/bud/run-scenarios/Dockerfile.entrypoint-cmd-run
@@ -1,0 +1,4 @@
+FROM alpine
+ENTRYPOINT [ "/invalid/entrypoint" ]
+CMD [ "/invalid/cmd" ]
+RUN echo "unique.test.string"

--- a/tests/bud/run-scenarios/Dockerfile.entrypoint-empty-run
+++ b/tests/bud/run-scenarios/Dockerfile.entrypoint-empty-run
@@ -1,0 +1,3 @@
+FROM alpine
+ENTRYPOINT [ "pwd" ]
+RUN

--- a/tests/bud/run-scenarios/Dockerfile.entrypoint-run
+++ b/tests/bud/run-scenarios/Dockerfile.entrypoint-run
@@ -1,0 +1,3 @@
+FROM alpine
+ENTRYPOINT [ "/invalid/entrypoint" ]
+RUN echo "unique.test.string"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -80,6 +80,13 @@ load helpers
 	run buildah --debug=false run $cid
 	[ "$status" -eq 1 ]
 	[ "$output" = "command must be specified" ]
+	
+	# empty entrypoint, configured cmd, empty run arguments, end parsing option
+	buildah config --entrypoint "" $cid
+	buildah config --cmd pwd $cid
+	run buildah --debug=false run $cid --
+	[ "$status" -eq 1 ]
+	[ "$output" = "command must be specified" ]
 
 	# configured entrypoint, empty cmd, empty run arguments
 	buildah config --entrypoint pwd $cid
@@ -87,10 +94,23 @@ load helpers
 	run buildah --debug=false run $cid
 	[ "$status" -eq 1 ]
 	[ "$output" = "command must be specified" ]
+	
+	# configured entrypoint, empty cmd, empty run arguments, end parsing option
+	buildah config --entrypoint pwd $cid
+	buildah config --cmd "" $cid
+	run buildah --debug=false run $cid --
+	[ "$status" -eq 1 ]
+	[ "$output" = "command must be specified" ]
 
 	# configured entrypoint only, empty run arguments
 	buildah config --entrypoint pwd $cid
 	run buildah --debug=false run $cid
+	[ "$status" -eq 1 ]
+	[ "$output" = "command must be specified" ]
+	
+	# configured entrypoint only, empty run arguments, end parsing option
+	buildah config --entrypoint pwd $cid
+	run buildah --debug=false run $cid --
 	[ "$status" -eq 1 ]
 	[ "$output" = "command must be specified" ]
 
@@ -100,10 +120,23 @@ load helpers
 	[ "$status" -eq 1 ]
 	[ "$output" = "command must be specified" ]
 
+	# cofigured cmd only, empty run arguments, end parsing option
+	buildah config --cmd pwd $cid
+	run buildah --debug=false run $cid --
+	[ "$status" -eq 1 ]
+	[ "$output" = "command must be specified" ]
+
 	# configured entrypoint, configured cmd, empty run arguments
 	buildah config --entrypoint "pwd" $cid
 	buildah config --cmd "whoami" $cid
 	run buildah --debug=false run $cid
+	[ "$status" -eq 1 ]
+	[ "$output" = "command must be specified" ]
+	
+	# configured entrypoint, configured cmd, empty run arguments, end parsing option
+	buildah config --entrypoint "pwd" $cid
+	buildah config --cmd "whoami" $cid
+	run buildah --debug=false run $cid --
 	[ "$status" -eq 1 ]
 	[ "$output" = "command must be specified" ]
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -71,27 +71,39 @@ load helpers
 	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
 	buildah config --workingdir /tmp $cid
 
+	# Configured entrypoint/cmd shouldn't modify behaviour of run with no command
+	# empty entrypoint, configured cmd
 	buildah config --entrypoint "" $cid
 	buildah config --cmd pwd $cid
 	run buildah --debug=false run $cid
-	[ "$status" -eq 0 ]
-	[ "$output" = /tmp ]
+	[ "$status" -eq 1 ]
+	[ "$output" = "args must not be empty" ]
 
+	# configured entrypoint, empty cmd
 	buildah config --entrypoint pwd $cid
 	buildah config --cmd "" $cid
 	run buildah --debug=false run $cid
-	[ "$status" -eq 0 ]
-	[ "$output" = /tmp ]
+	[ "$status" -eq 1 ]
+	[ "$output" = "args must not be empty" ]
 
+	# configured entrypoint only
 	buildah config --entrypoint pwd $cid
 	run buildah --debug=false run $cid
-	[ "$status" -eq 0 ]
-	[ "$output" = /tmp ]
+	[ "$status" -eq 1 ]
+	[ "$output" = "args must not be empty" ]
 
-	buildah config --entrypoint "ls -lha" $cid
-	buildah config --cmd "/tmp" $cid
+	# cofigured cmd only
+	buildah config --cmd pwd $cid
 	run buildah --debug=false run $cid
-	[ "$status" -eq 0 ]
+	[ "$status" -eq 1 ]
+	[ "$output" = "args must not be empty" ]
+
+	# configured entrypoint, configured cmd
+	buildah config --entrypoint "pwd" $cid
+	buildah config --cmd "whoami" $cid
+	run buildah --debug=false run $cid
+	[ "$status" -eq 1 ]
+	[ "$output" = "args must not be empty" ]
 
 	buildah rm $cid
 }

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -71,39 +71,78 @@ load helpers
 	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
 	buildah config --workingdir /tmp $cid
 
-	# Configured entrypoint/cmd shouldn't modify behaviour of run with no command
-	# empty entrypoint, configured cmd
+
+	# Configured entrypoint/cmd shouldn't modify behaviour of run with no arguments
+
+	# empty entrypoint, configured cmd, empty run arguments
 	buildah config --entrypoint "" $cid
 	buildah config --cmd pwd $cid
 	run buildah --debug=false run $cid
 	[ "$status" -eq 1 ]
 	[ "$output" = "args must not be empty" ]
 
-	# configured entrypoint, empty cmd
+	# configured entrypoint, empty cmd, empty run arguments
 	buildah config --entrypoint pwd $cid
 	buildah config --cmd "" $cid
 	run buildah --debug=false run $cid
 	[ "$status" -eq 1 ]
 	[ "$output" = "args must not be empty" ]
 
-	# configured entrypoint only
+	# configured entrypoint only, empty run arguments
 	buildah config --entrypoint pwd $cid
 	run buildah --debug=false run $cid
 	[ "$status" -eq 1 ]
 	[ "$output" = "args must not be empty" ]
 
-	# cofigured cmd only
+	# cofigured cmd only, empty run arguments
 	buildah config --cmd pwd $cid
 	run buildah --debug=false run $cid
 	[ "$status" -eq 1 ]
 	[ "$output" = "args must not be empty" ]
 
-	# configured entrypoint, configured cmd
+	# configured entrypoint, configured cmd, empty run arguments
 	buildah config --entrypoint "pwd" $cid
 	buildah config --cmd "whoami" $cid
 	run buildah --debug=false run $cid
 	[ "$status" -eq 1 ]
 	[ "$output" = "args must not be empty" ]
+
+
+	# Configured entrypoint/cmd shouldn't modify behaviour of run with argument
+	# Note: entrypoint and cmd can be invalid in below tests as they should never execute
+
+	# empty entrypoint, configured cmd, configured run arguments
+	buildah config --entrypoint "" $cid
+	buildah config --cmd "/invalid/cmd" $cid
+	run buildah --debug=false run $cid -- pwd
+	[ "$status" -eq 0 ]
+	[ "$output" = "/tmp" ]
+
+        # configured entrypoint, empty cmd, configured run arguments
+        buildah config --entrypoint "/invalid/entrypoint" $cid
+        buildah config --cmd "" $cid
+        run buildah --debug=false run $cid -- pwd
+        [ "$status" -eq 0 ]
+        [ "$output" = "/tmp" ]
+
+        # configured entrypoint only, configured run arguments
+        buildah config --entrypoint "/invalid/entrypoint" $cid
+        run buildah --debug=false run $cid -- pwd
+        [ "$status" -eq 0 ]
+        [ "$output" = "/tmp" ]
+
+        # cofigured cmd only, configured run arguments
+        buildah config --cmd "/invalid/cmd" $cid
+        run buildah --debug=false run $cid -- pwd
+        [ "$status" -eq 0 ]
+        [ "$output" = "/tmp" ]
+
+        # configured entrypoint, configured cmd, configured run arguments
+        buildah config --entrypoint "/invalid/entrypoint" $cid
+        buildah config --cmd "/invalid/cmd" $cid
+        run buildah --debug=false run $cid -- pwd
+        [ "$status" -eq 0 ]
+        [ "$output" = "/tmp" ]
 
 	buildah rm $cid
 }

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -79,33 +79,33 @@ load helpers
 	buildah config --cmd pwd $cid
 	run buildah --debug=false run $cid
 	[ "$status" -eq 1 ]
-	[ "$output" = "args must not be empty" ]
+	[ "$output" = "command must be specified" ]
 
 	# configured entrypoint, empty cmd, empty run arguments
 	buildah config --entrypoint pwd $cid
 	buildah config --cmd "" $cid
 	run buildah --debug=false run $cid
 	[ "$status" -eq 1 ]
-	[ "$output" = "args must not be empty" ]
+	[ "$output" = "command must be specified" ]
 
 	# configured entrypoint only, empty run arguments
 	buildah config --entrypoint pwd $cid
 	run buildah --debug=false run $cid
 	[ "$status" -eq 1 ]
-	[ "$output" = "args must not be empty" ]
+	[ "$output" = "command must be specified" ]
 
 	# cofigured cmd only, empty run arguments
 	buildah config --cmd pwd $cid
 	run buildah --debug=false run $cid
 	[ "$status" -eq 1 ]
-	[ "$output" = "args must not be empty" ]
+	[ "$output" = "command must be specified" ]
 
 	# configured entrypoint, configured cmd, empty run arguments
 	buildah config --entrypoint "pwd" $cid
 	buildah config --cmd "whoami" $cid
 	run buildah --debug=false run $cid
 	[ "$status" -eq 1 ]
-	[ "$output" = "args must not be empty" ]
+	[ "$output" = "command must be specified" ]
 
 
 	# Configured entrypoint/cmd shouldn't modify behaviour of run with argument


### PR DESCRIPTION
Fixes #607 

Remove the `cmd` and `entrypoint` behaviour when `buildah run` is executed with no arguments, so `buildah run` matches `Dockerfile RUN` behaviour.

Signed-off-by: pixdrift <support@pixeldrift.net>