### PR TITLE
Adding noop for --force-rm to match --rm

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -151,6 +151,10 @@ func budCmd(c *cli.Context) error {
 		logrus.Debugf("--compress option specified but is ignored")
 	}
 
+	if c.IsSet("force-rm") {
+		logrus.Debugf("build caching not enabled so --force-rm flag has no effect")
+	}
+
 	if c.IsSet("rm") {
 		logrus.Debugf("build caching not enabled so --rm flag has no effect")
 	}


### PR DESCRIPTION
This adds noop for the `--force-rm` flag in the same way that noop was added for `--rm` in PR #639 .

This is an intermediate fix for #622 .
Signed-off-by: pixdrift <support@pixeldrift.net>