### PR TITLE
buildah-from: add effective value to mount propagation

### DIFF
--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -210,7 +210,7 @@ Ulimit options
 
    * [rw|ro]
    * [z|Z]
-   * [`[r]shared`|`[r]slave`|`[r]private`]
+   * [`[r]shared`|`[r]slave`|`[r]private`|`[r]unbindable`]
 
 The `CONTAINER-DIR` must be an absolute path such as `/src/docs`. The `HOST-DIR`
 must be an absolute path as well. Buildah bind-mounts the `HOST-DIR` to the
@@ -247,7 +247,7 @@ the container on that volume will be visible to both the host and container. Whe
 the mount propagation policy is set to `slave`, one way mount propagation is enabled
 and any mounts completed on the host for that volume will be visible only inside of the container.
 To control the mount propagation property of the volume use the `:[r]shared`,
-`:[r]slave` or `:[r]private` propagation flag. The propagation property can
+`:[r]slave`, `[r]private` or `[r]unbindable`propagation flag. The propagation property can
 be specified only for bind mounted volumes and not for internal volumes or
 named volumes. For mount propagation to work on the source mount point (the mount point
 where source dir is mounted on) it has to have the right propagation properties. For

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -180,9 +180,9 @@ func validateVolumeOpts(option string) error {
 				return errors.Errorf("invalid options %q, can only specify 1 'z' or 'Z' option", option)
 			}
 			foundLabelChange++
-		case "private", "rprivate", "shared", "rshared", "slave", "rslave":
+		case "private", "rprivate", "shared", "rshared", "slave", "rslave", "unbindable", "runbindable":
 			if foundRootPropagation > 1 {
-				return errors.Errorf("invalid options %q, can only specify 1 '[r]shared', '[r]private' or '[r]slave' option", option)
+				return errors.Errorf("invalid options %q, can only specify 1 '[r]shared', '[r]private', '[r]slave' or '[r]unbindable' option", option)
 			}
 			foundRootPropagation++
 		default:


### PR DESCRIPTION
According to the [kernel documentation.](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt)

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>