### PR TITLE
CI tests and minor fix for cache related noop flags

### DIFF
--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -19,7 +19,7 @@ var (
 			Name:  "build-arg",
 			Usage: "`argument=value` to supply to the builder",
 		},
-		cli.BoolFlag{
+		cli.StringFlag{
 			Name:  "cache-from",
 			Usage: "Images to utilise as potential cache sources. Buildah does not currently support caching so this is a NOOP.",
 		},

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -460,3 +460,58 @@ load helpers
   [[ "$output" =~ "error building at step" ]]
   [ "$status" -eq 1 ]
 }
+
+# Following flags are configured to result in noop but should not affect buildiah bud behavior
+@test "bud with --cache-from noop flag" {
+  target=noop-image
+  run buildah bud --cache-from=invalidimage --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.noop-flags
+  [ "$status" -eq 0 ]
+  cid=$(buildah from ${target})
+  buildah rm ${cid}
+  buildah rmi ${target}
+}
+
+@test "bud with --compress noop flag" {
+  target=noop-image
+  run buildah bud --compress --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.noop-flags
+  [ "$status" -eq 0 ]
+  cid=$(buildah from ${target})
+  buildah rm ${cid}
+  buildah rmi ${target}
+}
+
+@test "bud with --force-rm noop flag" {
+  target=noop-image
+  run buildah bud --force-rm --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.noop-flags
+  [ "$status" -eq 0 ]
+  cid=$(buildah from ${target})
+  buildah rm ${cid}
+  buildah rmi ${target}
+}
+
+@test "bud with --no-cache noop flag" {
+  target=noop-image
+  run buildah bud --no-cache --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.noop-flags
+  [ "$status" -eq 0 ]
+  cid=$(buildah from ${target})
+  buildah rm ${cid}
+  buildah rmi ${target}
+}
+
+@test "bud with --rm noop flag" {
+  target=noop-image
+  run buildah bud --rm --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.noop-flags
+  [ "$status" -eq 0 ]
+  cid=$(buildah from ${target})
+  buildah rm ${cid}
+  buildah rmi ${target}
+}
+
+@test "bud with --squash noop flag" {
+  target=noop-image
+  run buildah bud --squash --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.noop-flags
+  [ "$status" -eq 0 ]
+  cid=$(buildah from ${target})
+  buildah rm ${cid}
+  buildah rmi ${target}
+}

--- a/tests/bud/run-scenarios/Dockerfile.noop-flags
+++ b/tests/bud/run-scenarios/Dockerfile.noop-flags
@@ -1,0 +1,1 @@
+FROM scratch


### PR DESCRIPTION
Tests to ensure that the cache related flags currently configured for noop are consumed by buildah bud but don't change its behaviour.

Minor fix for option --cache-from noop behaviour
Signed-off-by: <pixdrift support@pixeldrift.net>