### PR TITLE
Add cpu-shares short flag (-c) and cpu-shares CI tests

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -65,7 +65,7 @@ Limit the container's CPU usage. By default, containers run with the full
 CPU resource. This flag tell the kernel to restrict the container's CPU usage
 to the quota you specify.
 
-**--cpu-shares**=*0*
+**-c, --cpu-shares**=*0*
 
 CPU shares (relative weight)
 

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -118,7 +118,7 @@ var (
 			Usage: "limit the CPU CFS (Completely Fair Scheduler) quota",
 		},
 		cli.Uint64Flag{
-			Name:  "cpu-shares",
+			Name:  "cpu-shares, c",
 			Usage: "CPU shares (relative weight)",
 		},
 		cli.StringFlag{

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -515,3 +515,47 @@ load helpers
   buildah rm ${cid}
   buildah rmi ${target}
 }
+
+@test "bud with --cpu-shares flag, no argument" {
+  target=bud-flag
+  run buildah bud --cpu-shares --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile
+  [ "$status" -ne 0 ]
+}
+
+@test "bud with --cpu-shares flag, invalid argument" {
+  target=bud-flag
+  run buildah bud --cpu-shares bogus --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "invalid value \"bogus\" for flag" ]]
+}
+
+@test "bud with --cpu-shares flag, valid argument" {
+  target=bud-flag
+  run buildah bud --cpu-shares 2 --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile
+  [ "$status" -eq 0 ]
+  cid=$(buildah from ${target})
+  buildah rm ${cid}
+  buildah rmi ${target}
+}
+
+@test "bud with --cpu-shares short flag (-c), no argument" {
+  target=bud-flag
+  run buildah bud -c --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile
+  [ "$status" -ne 0 ]
+}
+
+@test "bud with --cpu-shares short flag (-c), invalid argument" {
+  target=bud-flag
+  run buildah bud -c bogus --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "invalid value \"bogus\" for flag" ]]
+}
+
+@test "bud with --cpu-shares short flag (-c), valid argument" {
+  target=bud-flag
+  run buildah bud -c 2 --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile
+  [ "$status" -eq 0 ]
+  cid=$(buildah from ${target})
+  buildah rm ${cid}
+  buildah rmi ${target}
+}


### PR DESCRIPTION
Short flag `-c` was missing for `--cpu-shares` in `buildah bud`, this adds the flag to improve compatibility with `docker build`. CI tests included for flag options.
Signed-off-by: pixdrift <support@pixeldrift.net>