### PR TITLE
Buildah Docker compatibility demo

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -10,6 +10,10 @@
 
 **[Tutorials](../docs/tutorials/README.md)**
 
+**[Useful blogs by ipbabble](https://www.projectatomic.io/blog/author/ipbabble/)**
+
+**[Useful blogs by Tom Sweeney](http://www.projectatomic.io/blog/author/tsweeney/)**
+
 # Buildah Demos
 
 The purpose of these demonstrations is twofold:
@@ -17,9 +21,11 @@ The purpose of these demonstrations is twofold:
 1. To help automate some of the tutorial material so that Buildah newcomers can walk through some of the concepts.
 2. For Buildah enthusiasts and practitioners to use for demos at educational presentations - college classes, Meetups etc.
 
-It is assumed that you have installed Buildah and Podman on your  machine.
+It is assumed that you have installed Buildah and Podman on your machine. 
 
     $ sudo yum -y install podman buildah
+
+Replace `yum` with `dnf` if required.
 
 ## Building from scratch demo 
 
@@ -34,12 +40,22 @@ Please make sure you have installed Buildah and Podman. Also this demo uses Quay
 There are several variables you will want to set that are listed at the top of the script. The name for the container image, your quay.io username, your name, and the Fedora release number:
 
     demoimg=myshdemo
-    quayuser=ipbabble
+    quayuser=UserNameHere
     myname=YourNameHere
-    fedorarelease=28
+    distrorelease=28
+    pkgmgr=dnf   # switch to yum if using yum 
 
 ## Buildah and Docker compatibility demo
 
-Coming soon.
+filename: [`buildah-scratch-demo.sh`](https://github.com/projectatomic/buildah/demos/docker-compatibility-demo.sh)
 
+This demo builds an nginx container image using Buildah. It modifies the home page and commits the image. The contianer is tested using `podman run` and then stopped. The Docker dameon is then started and the image is pushed over to the Docker repository. The container is started using `docker run` and tested. 
 
+There are several variables you will want to set that are listed at the top of the script. The name for the container image, your quay.io username, your name, and the Fedora release number:
+
+    demoimg=dockercompatibilitydemo
+    quayuser=UsernameHere  
+    myname=YourNameHear
+    distro=fedora
+    distrorelease=28
+    pkgmgr=dnf   # switch to yum if using yum 

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,45 @@
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
+
+# Useful Buildah links
+
+**[Changelog](../CHANGELOG.md)**
+
+**[Installation notes](../install.md)**
+
+**[Troubleshooting Guide](../troubleshooting.md)**
+
+**[Tutorials](../docs/tutorials/README.md)**
+
+# Buildah Demos
+
+The purpose of these demonstrations is twofold:
+
+1. To help automate some of the tutorial material so that Buildah newcomers can walk through some of the concepts.
+2. For Buildah enthusiasts and practitioners to use for demos at educational presentations - college classes, Meetups etc.
+
+It is assumed that you have installed Buildah and Podman on your  machine.
+
+    $ sudo yum -y install podman buildah
+
+## Building from scratch demo 
+
+filename: [`buildah-scratch-demo.sh`](https://github.com/projectatomic/buildah/demos/buildah-scratch-demo.sh)
+
+This demo builds a container image from scratch. The container is going to inject a bash shell script and therefore requires the installation of coreutils and bash.
+
+Please make sure you have installed Buildah and Podman. Also this demo uses Quay.io to push the image to that registry when it is completed. If you are not logged in then it will fail at that step and finish. If you wish to login to Quay.io before running the demo, then it will push to your repository successfully.
+
+    $ sudo podman login quay.io
+
+There are several variables you will want to set that are listed at the top of the script. The name for the container image, your quay.io username, your name, and the Fedora release number:
+
+    demoimg=myshdemo
+    quayuser=ipbabble
+    myname=YourNameHere
+    fedorarelease=28
+
+## Buildah and Docker compatibility demo
+
+Coming soon.
+
+

--- a/demos/buildah-scratch-demo.sh
+++ b/demos/buildah-scratch-demo.sh
@@ -1,0 +1,84 @@
+#!/bin/bash 
+
+# author : ipbabble
+# Assumptions install buildah and podman
+# login to Quay.io using podman if you want to see the image push
+#   otherwise it will just fail the last step and no biggy.
+#   podman login quay.io
+# Set some of the variables below
+
+demoimg=myshdemo
+quayuser=ipbabble
+myname=WilliamHenry
+distrorelease=28
+pkgmgr=dnf   # switch to yum if using yum 
+
+#Setting up some colors for helping read the demo output
+bold=$(tput bold)
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+yellow=$(tput setaf 3)
+blue=$(tput setaf 4)
+cyan=$(tput setaf 6)
+reset=$(tput sgr0)
+
+echo -e "Using ${green}GREEN${reset} to introduce Buildah steps"
+echo -e "Using ${yellow}YELLOW${reset} to introduce code"
+echo -e "Using ${blue}BLUE${reset} to introduce Podman steps"
+echo -e "Using ${cyan}CYAN${reset} to introduce bash commands"
+echo -e "Building an image called ${demoimg}"
+read -p "${green}Start of the script${reset}"
+
+set -x
+read -p "${green}Create a new container on disk from scratch${reset}"
+newcontainer=$(buildah from scratch)
+read -p "${green}Mount the root directory of the new scratch container${reset}"
+scratchmnt=$(buildah mount $newcontainer)
+read -p "${cyan}Lets see what is in scratchmnt${reset}"
+ls $scratchmnt
+echo -e "${red}Note that the root of the scratch container is EMPTY!${reset}"
+read -p "${cyan}Time to install some basic bash capabilities: coreutils and bash packages${reset}"
+if [ "$pkgmgr" == "dnf" ]; then
+	$pkgmgr install --installroot $scratchmnt --release ${distrorelease} bash coreutils --setopt install_weak_deps=false -y
+elif [ "$pkgmgr" == "yum" ]; then
+	$pkgmgr install --installroot $scratchmnt --release ${distrorelease} bash coreutils  -y
+else
+	echo -e "${red}[Error] Unknown package manager ${pkgmgr}${reset}"
+fi
+
+read -p "${cyan}Clean up the packages${reset}"
+$pkgmgr clean --installroot $scratchmnt --release ${distrorelease} all
+read -p "${green}Run the shell and see what is inside. When your done, type ${red}exit${green} and return.${reset}"
+buildah run $newcontainer bash
+read -p "${cyan}Let's look at the program${yellow}"
+FILE=./runecho.sh
+/bin/cat <<EOM >$FILE
+#!/bin/bash
+for i in {1..9};
+do
+    echo "This is a new cloud native container using Buildah [" \$i "]"
+done
+EOM
+chmod +x $FILE
+cat $FILE
+read -p "${green}Copy program into the container and run ls to see it is there${reset}"
+buildah copy $newcontainer $FILE /usr/bin
+ls -al $scratchmnt/usr/bin/*.sh
+read -p "${green}Run the container using Buildah${reset}"
+buildah run $newcontainer /usr/bin/runecho.sh
+read -p "${green}Make the container run the program by default when container is run${reset}"
+buildah config --entrypoint /usr/bin/runecho.sh $newcontainer
+read -p "${green}Set some config information for the container image${reset}"
+buildah config --author "${myname}" --created-by "${quayuser}" --label name=${demoimg} $newcontainer
+read -p "${green}Inspect the meta data${yellow}"
+buildah inspect $newcontainer
+read -p "${green}Unmount the container and commit to an image called ${demoimg}.${reset}"
+buildah unmount $newcontainer
+buildah commit $newcontainer $demoimg
+read -p "${green}List the images we have.${reset}"
+buildah images
+read -p "${blue}Run the container using Podman.${reset}"
+podman run $demoimg
+read -p "${green}Make sure you are already logged into your account on Quay.io. Or use Quay creds.${reset}"
+buildah push $demoimg docker://quay.io/$quayuser/$demoimg
+echo -e "${red}We are done!${reset}"

--- a/demos/docker-compatibility-demo.sh
+++ b/demos/docker-compatibility-demo.sh
@@ -1,0 +1,83 @@
+#!/bin/bash 
+
+# author : ipbabble
+# Assumptions install buildah, podman & docker
+# Do NOT start the docker deamon
+# Set some of the variables below
+
+demoimg=dockercompatibilitydemo
+quayuser=ipbabble
+myname="William Henry"
+distro=fedora
+distrorelease=28
+pkgmgr=dnf   # switch to yum if using yum 
+
+#Setting up some colors for helping read the demo output
+bold=$(tput bold)
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+yellow=$(tput setaf 3)
+blue=$(tput setaf 4)
+cyan=$(tput setaf 6)
+reset=$(tput sgr0)
+
+echo -e "Using ${green}GREEN${reset} to introduce Buildah steps"
+echo -e "Using ${yellow}YELLOW${reset} to introduce code"
+echo -e "Using ${blue}BLUE${reset} to introduce Podman steps"
+echo -e "Using ${cyan}CYAN${reset} to introduce bash commands"
+echo -e "Using ${red}RED${reset} to introduce Docker commands"
+
+echo -e "Building an image called ${demoimg}"
+read -p "${green}Start of the script${reset}"
+
+set -x
+read -p "${green}Create a new container on disk from ${distro}${reset}"
+newcontainer=$(buildah from ${distro})
+read -p "${green}Update packages and clean all ${reset}"
+buildah run $newcontainer -- ${pkgmgr} -y update && ${pkgmgr} -y clean all
+read -p "${green}Install nginx${reset}"
+buildah run $newcontainer -- ${pkgmgr} -y install nginx && ${pkgmgr} -y clean all 
+#read -p "${green}Run the container bash shell and see what is inside. When your done, type ${red}exit${green} and return.${reset}"
+#buildah run $newcontainer bash
+read -p "${green}Make some nginx config and home page changes ${reset}"
+buildah run $newcontainer bash -c 'echo "daemon off;" >> /etc/nginx/nginx.conf'
+buildah run $newcontainer bash -c 'echo "nginx on OCI Fedora image, built using Buildah" > /usr/share/nginx/html/index.html'
+read -p "${green}Use buildah config to expose the port and set the entrypoint${reset}"
+buildah config --port 80 --entrypoint /usr/sbin/nginx $newcontainer
+read -p "${green}Set other meta data using buildah config${reset}"
+buildah config --created-by "${quayuser}"  $newcontainer
+buildah config --author "${myname} @${quayuser}" --label name=$demoimg $newcontainer
+read -p "${green}Inspect the container image meta data${yellow}"
+buildah inspect $newcontainer
+read -p "${green}Commit the container to an OCI image called ${demoimg}.${reset}"
+buildah commit $newcontainer $demoimg
+read -p "${green}List the images we have.${reset}"
+buildah images
+read -p "${blue}Run the container using Podman. Check ${bold}http://localhost${reset}"
+containernum=$(podman run -d -p 80:80 $demoimg) 
+read -p "$cyan}Check that nginx is up and running with our new page${reset}"
+curl localhost
+read -p "${blue}Stop the container and rm it${reset}"
+podman ps                                                                                   
+podman stop $containernum                                                                            
+podman rm $containernum                                                                              
+read -p "${cyan}Check that nginx is down${reset}"
+curl localhost
+read -p "${cyan}Start the Docker daemon${reset}"
+systemctl start docker
+read -p "${red}List the Docker images in the repository - should be empty${reset}"
+docker images                                                                          
+read -p "${blue}Push the image to the local Docker repository using docker-daemon${reset}"
+podman push $demoimg docker-daemon:$quayuser/dockercompatibilitydemo:latest       
+read -p "${red}List the Docker images in the repository${reset}"
+docker images                                                                          
+read -p "${red}Start the container from the new Docker repo image${reset}"
+dockercontainer=$(docker run -d -p 80:80 $quayuser/$demoimg)
+read -p "$cyan}Check that nginx is up and running with our new page${reset}"
+curl localhost
+read -p "${red}Stop the container and rm it${reset}"
+docker rm $dockercontainer                                                                            
+docker rm $dockercontainer
+read -p "$cyan}Stop Docker${reset}"
+systemctl stop docker
+echo -e "${red}We are done!${reset}"


### PR DESCRIPTION
Added a demo that builds an nginx container image using Buildah. It modifies the home page and commits the image. The container is tested using `podman run` and then stopped. The Docker dameon is then started and the image is pushed over to the Docker repository. The container is started using `docker run` and tested. 