### PR TITLE
Update buildah scratch demo to support el7

### DIFF
--- a/demos/buildah-scratch-demo.sh
+++ b/demos/buildah-scratch-demo.sh
@@ -41,13 +41,13 @@ read -p "${cyan}Time to install some basic bash capabilities: coreutils and bash
 if [ "$pkgmgr" == "dnf" ]; then
 	$pkgmgr install --installroot $scratchmnt --release ${distrorelease} bash coreutils --setopt install_weak_deps=false -y
 elif [ "$pkgmgr" == "yum" ]; then
-	$pkgmgr install --installroot $scratchmnt --release ${distrorelease} bash coreutils  -y
+	$pkgmgr install --installroot $scratchmnt --releasever ${distrorelease} bash coreutils  -y
 else
 	echo -e "${red}[Error] Unknown package manager ${pkgmgr}${reset}"
 fi
 
 read -p "${cyan}Clean up the packages${reset}"
-$pkgmgr clean --installroot $scratchmnt --release ${distrorelease} all
+$pkgmgr clean --installroot $scratchmnt all
 read -p "${green}Run the shell and see what is inside. When your done, type ${red}exit${green} and return.${reset}"
 buildah run $newcontainer bash
 read -p "${cyan}Let's look at the program${yellow}"


### PR DESCRIPTION
Minor fix to demo script to support el7. Tested on CentOS 7.4.
Signed-off-by: pixdrift <support@pixeldrift.net>