### PR TITLE
Re-enable existing, and add new rpm .spec CI tests

### DIFF
--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -259,13 +259,13 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 - Turn on --enable-gc when running gometalinter
 - rmi: handle truncated image IDs
 
-* Tue Aug 15 2017 Josh Boyer <jwboyer@redhat.com> - 0.3-5.gitb9b2a8a
+* Tue Aug 15 2017 Josh Boyer <jwboyer@redhat.com> 0.3-5.gitb9b2a8a
 - Build for s390x as well
 
-* Wed Aug 02 2017 Fedora Release Engineering <releng@fedoraproject.org> - 0.3-4.gitb9b2a8a
+* Wed Aug 02 2017 Fedora Release Engineering <releng@fedoraproject.org> 0.3-4.gitb9b2a8a
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Binutils_Mass_Rebuild
 
-* Wed Jul 26 2017 Fedora Release Engineering <releng@fedoraproject.org> - 0.3-3.gitb9b2a8a
+* Wed Jul 26 2017 Fedora Release Engineering <releng@fedoraproject.org> 0.3-3.gitb9b2a8a
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Mass_Rebuild
 
 * Thu Jul 20 2017 Dan Walsh <dwalsh@redhat.com> 0.3-2.gitb9b2a8a7e

--- a/tests/rpm.bats
+++ b/tests/rpm.bats
@@ -2,7 +2,68 @@
 
 load helpers
 
-@test "rpm-build" {
+# Ensure that any updated/pushed rpm .spec files don't clobber the commit placeholder
+@test "rpm REPLACEWITHCOMMITID placeholder exists in .spec file" {
+	run grep -q "^%global[ ]\+commit[ ]\+REPLACEWITHCOMMITID$" ${TESTSDIR}/../contrib/rpm/buildah.spec
+	[ "$status" -eq 0 ]
+}
+
+@test "rpm-build CentOS 7" {
+        if ! which runc ; then
+                skip
+        fi
+
+        # Build a container to use for building the binaries.
+        image=registry.centos.org/centos/centos:centos7
+        cid=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+        root=$(buildah --debug=false mount $cid)
+        commit=$(git log --format=%H -n 1)
+        shortcommit=$(echo ${commit} | cut -c-7)
+        mkdir -p ${root}/rpmbuild/{SOURCES,SPECS}
+
+        # Build the tarball.
+        (cd ..; git archive --format tar.gz --prefix=buildah-${commit}/ ${commit}) > ${root}/rpmbuild/SOURCES/buildah-${shortcommit}.tar.gz
+
+        # Update the .spec file with the commit ID.
+        sed s:REPLACEWITHCOMMITID:${commit}:g ${TESTSDIR}/../contrib/rpm/buildah.spec > ${root}/rpmbuild/SPECS/buildah.spec
+
+        # Install build dependencies and build binary packages.
+        buildah --debug=false run $cid -- yum -y install rpm-build yum-utils
+        buildah --debug=false run $cid -- yum-builddep -y rpmbuild/SPECS/buildah.spec
+        buildah --debug=false run $cid -- rpmbuild --define "_topdir /rpmbuild" -ba /rpmbuild/SPECS/buildah.spec
+
+        # Build a second new container.
+        cid2=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+        root2=$(buildah --debug=false mount $cid2)
+
+        # Copy the binary packages from the first container to the second one, and build a list of
+        # their filenames relative to the root of the second container.
+        rpms=
+        mkdir -p ${root2}/packages
+        for rpm in ${root}/rpmbuild/RPMS/*/*.rpm ; do
+                cp $rpm ${root2}/packages/
+                rpms="$rpms "/packages/$(basename $rpm)
+        done
+
+        # Install the binary packages into the second container.
+        buildah --debug=false run $cid2 -- yum -y install $rpms
+
+        # Run the binary package and compare its self-identified version to the one we tried to build.
+        id=$(buildah --debug=false run $cid2 -- buildah version | awk '/^Git Commit:/ { print $NF }')
+        bv=$(buildah --debug=false run $cid2 -- buildah version | awk '/^Version:/ { print $NF }')
+        rv=$(buildah --debug=false run $cid2 -- rpm -q --queryformat '%{version}' buildah)
+        echo "short commit: $shortcommit"
+        echo "id: $id"
+        echo "buildah version: $bv"
+        echo "buildah rpm version: $rv"
+        test $shortcommit = $id
+        test $bv = $rv
+
+        # Clean up.
+        buildah --debug=false rm $cid $cid2
+}
+
+@test "rpm-build Fedora 27" {
 	if ! which runc ; then
 		skip
 	fi
@@ -27,7 +88,7 @@ load helpers
 	buildah --debug=false run $cid -- rpmbuild --define "_topdir /rpmbuild" -ba /rpmbuild/SPECS/buildah.spec
 
 	# Build a second new container.
-	cid2=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json registry.fedoraproject.org/fedora:27)
+	cid2=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
 	root2=$(buildah --debug=false mount $cid2)
 
 	# Copy the binary packages from the first container to the second one, and build a list of
@@ -55,4 +116,59 @@ load helpers
 
 	# Clean up.
 	buildah --debug=false rm $cid $cid2
+}
+
+@test "rpm-build Fedora 28" {
+        if ! which runc ; then
+                skip
+        fi
+
+        # Build a container to use for building the binaries.
+        image=registry.fedoraproject.org/fedora:28
+        cid=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+        root=$(buildah --debug=false mount $cid)
+        commit=$(git log --format=%H -n 1)
+        shortcommit=$(echo ${commit} | cut -c-7)
+        mkdir -p ${root}/rpmbuild/{SOURCES,SPECS}
+
+        # Build the tarball.
+        (cd ..; git archive --format tar.gz --prefix=buildah-${commit}/ ${commit}) > ${root}/rpmbuild/SOURCES/buildah-${shortcommit}.tar.gz
+
+        # Update the .spec file with the commit ID.
+        sed s:REPLACEWITHCOMMITID:${commit}:g ${TESTSDIR}/../contrib/rpm/buildah.spec > ${root}/rpmbuild/SPECS/buildah.spec
+
+        # Install build dependencies and build binary packages.
+        buildah --debug=false run $cid -- dnf -y install 'dnf-command(builddep)' rpm-build
+        buildah --debug=false run $cid -- dnf -y builddep --spec rpmbuild/SPECS/buildah.spec
+        buildah --debug=false run $cid -- rpmbuild --define "_topdir /rpmbuild" -ba /rpmbuild/SPECS/buildah.spec
+
+        # Build a second new container.
+        cid2=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+        root2=$(buildah --debug=false mount $cid2)
+
+        # Copy the binary packages from the first container to the second one, and build a list of
+        # their filenames relative to the root of the second container.
+        rpms=
+        mkdir -p ${root2}/packages
+        for rpm in ${root}/rpmbuild/RPMS/*/*.rpm ; do
+                cp $rpm ${root2}/packages/
+                rpms="$rpms "/packages/$(basename $rpm)
+        done
+
+        # Install the binary packages into the second container.
+        buildah --debug=false run $cid2 -- dnf -y install $rpms
+
+        # Run the binary package and compare its self-identified version to the one we tried to build.
+        id=$(buildah --debug=false run $cid2 -- buildah version | awk '/^Git Commit:/ { print $NF }')
+        bv=$(buildah --debug=false run $cid2 -- buildah version | awk '/^Version:/ { print $NF }')
+        rv=$(buildah --debug=false run $cid2 -- rpm -q --queryformat '%{version}' buildah)
+        echo "short commit: $shortcommit"
+        echo "id: $id"
+        echo "buildah version: $bv"
+        echo "buildah rpm version: $rv"
+        test $shortcommit = $id
+        test $bv = $rv
+
+        # Clean up.
+        buildah --debug=false rm $cid $cid2
 }

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -8,11 +8,15 @@ load helpers
 	[ "$status" -eq 0 ]
 }
 
-@test "buildah version up to date in .spec file" {
-    skip "cni doesnt version the same"
-	run buildah version
-	[ "$status" -eq 0 ]
-	bversion=$(echo "$output" | awk '/^Version:/ { print $NF }')
+@test "buildah version current in .spec file Version" {
+	bversion=$(buildah version | awk '/^Version:/ { print $NF }')
 	rversion=$(cat ${TESTSDIR}/../contrib/rpm/buildah.spec | awk '/^Version:/ { print $NF }')
-	test "$bversion" = "$rversion"
+	run test "${bversion}" = "${rversion}"
+	[ "$status" -eq 0 ]
+}
+
+@test "buildah version current in .spec file changelog" {
+	bversion=$(buildah version | awk '/^Version:/ { print $NF }')
+	run bash -c "grep -A1 ^%changelog ${TESTSDIR}/../contrib/rpm/buildah.spec | grep -q \" ${bversion}-.*$\""
+	[ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Rework rpm .spec version check slightly and re-enable it
Add check for rpm changelog most recent entry version
Fix minor variable issue in rpm-build bats script
Split rpm-build bats script into Fedora 27 / Fedora 28 (can drop 27 in future if required)

Signed-off-by: pixdrift <support@pixeldrift.net>