### PR TITLE
buildah push/from can push and pull images with no reference

### DIFF
--- a/pull.go
+++ b/pull.go
@@ -60,10 +60,15 @@ func localImageNameForReference(ctx context.Context, store storage.Store, srcRef
 		if err != nil {
 			return "", errors.Wrapf(err, "error loading manifest for %q", srcRef)
 		}
+		// if index.json has no reference name, compute the image digest instead
 		if manifest.Annotations == nil || manifest.Annotations["org.opencontainers.image.ref.name"] == "" {
-			return "", errors.Errorf("error, archive doesn't have a name annotation. Cannot store image with no name")
+			name, err = getImageDigest(ctx, srcRef, nil)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			name = manifest.Annotations["org.opencontainers.image.ref.name"]
 		}
-		name = manifest.Annotations["org.opencontainers.image.ref.name"]
 	case util.DirTransport:
 		// supports pull from a directory
 		name = split[1]

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -156,6 +156,26 @@ load helpers
   rm -rf alp-dir
 }
 
+@test "from the following transports: docker-archive and oci-archive with no image reference" {
+  cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah rm $cid
+  buildah push --signature-policy ${TESTSDIR}/policy.json alpine docker-archive:docker-alp.tar
+  buildah push --signature-policy ${TESTSDIR}/policy.json alpine oci-archive:oci-alp.tar
+  buildah rmi alpine
+
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json docker-archive:docker-alp.tar)
+  [ "$cid" == docker-archive-working-container ]
+  buildah rm ${cid}
+  buildah rmi -a
+  rm -f docker-alp.tar
+
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json oci-archive:oci-alp.tar)
+  [ "$cid" == oci-archive-working-container ]
+  buildah rm ${cid}
+  buildah rmi -a
+  rm -f oci-alp.tar
+}
+
 @test "from cpu-period test" {
   cid=$(buildah from --cpu-period=5000 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   run buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_period_us

--- a/vendor/github.com/containers/image/docker/archive/dest.go
+++ b/vendor/github.com/containers/image/docker/archive/dest.go
@@ -16,11 +16,7 @@ type archiveImageDestination struct {
 	writer               io.Closer
 }
 
-func newImageDestination(ref archiveReference) (types.ImageDestination, error) {
-	if ref.destinationRef == nil {
-		return nil, errors.Errorf("docker-archive: destination reference not supplied (must be of form <path>:<reference:tag>)")
-	}
-
+func newImageDestination(sys *types.SystemContext, ref archiveReference) (types.ImageDestination, error) {
 	// ref.path can be either a pipe or a regular file
 	// in the case of a pipe, we require that we can open it for write
 	// in the case of a regular file, we don't want to overwrite any pre-existing file
@@ -40,8 +36,12 @@ func newImageDestination(ref archiveReference) (types.ImageDestination, error) {
 		return nil, errors.New("docker-archive doesn't support modifying existing images")
 	}
 
+	tarDest := tarfile.NewDestination(fh, ref.destinationRef)
+	if sys != nil && sys.DockerArchiveAdditionalTags != nil {
+		tarDest.AddRepoTags(sys.DockerArchiveAdditionalTags)
+	}
 	return &archiveImageDestination{
-		Destination: tarfile.NewDestination(fh, ref.destinationRef),
+		Destination: tarDest,
 		ref:         ref,
 		writer:      fh,
 	}, nil

--- a/vendor/github.com/containers/image/docker/archive/transport.go
+++ b/vendor/github.com/containers/image/docker/archive/transport.go
@@ -41,7 +41,9 @@ func (t archiveTransport) ValidatePolicyConfigurationScope(scope string) error {
 
 // archiveReference is an ImageReference for Docker images.
 type archiveReference struct {
-	destinationRef reference.NamedTagged // only used for destinations
+	// only used for destinations
+	// archiveReference.destinationRef is optional and can be nil for destinations as well.
+	destinationRef reference.NamedTagged
 	path           string
 }
 
@@ -148,7 +150,7 @@ func (ref archiveReference) NewImageSource(ctx context.Context, sys *types.Syste
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref archiveReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(ref)
+	return newImageDestination(sys, ref)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.

--- a/vendor/github.com/containers/image/docker/tarfile/dest.go
+++ b/vendor/github.com/containers/image/docker/tarfile/dest.go
@@ -23,9 +23,9 @@ import (
 
 // Destination is a partial implementation of types.ImageDestination for writing to an io.Writer.
 type Destination struct {
-	writer    io.Writer
-	tar       *tar.Writer
-	reference reference.NamedTagged
+	writer   io.Writer
+	tar      *tar.Writer
+	repoTags []reference.NamedTagged
 	// Other state.
 	blobs  map[digest.Digest]types.BlobInfo // list of already-sent blobs
 	config []byte
@@ -33,12 +33,21 @@ type Destination struct {
 
 // NewDestination returns a tarfile.Destination for the specified io.Writer.
 func NewDestination(dest io.Writer, ref reference.NamedTagged) *Destination {
-	return &Destination{
-		writer:    dest,
-		tar:       tar.NewWriter(dest),
-		reference: ref,
-		blobs:     make(map[digest.Digest]types.BlobInfo),
+	repoTags := []reference.NamedTagged{}
+	if ref != nil {
+		repoTags = append(repoTags, ref)
 	}
+	return &Destination{
+		writer:   dest,
+		tar:      tar.NewWriter(dest),
+		repoTags: repoTags,
+		blobs:    make(map[digest.Digest]types.BlobInfo),
+	}
+}
+
+// AddRepoTags adds the specified tags to the destination's repoTags.
+func (d *Destination) AddRepoTags(tags []reference.NamedTagged) {
+	d.repoTags = append(d.repoTags, tags...)
 }
 
 // SupportedManifestMIMETypes tells which manifest mime types the destination supports
@@ -161,8 +170,15 @@ func (d *Destination) ReapplyBlob(ctx context.Context, info types.BlobInfo) (typ
 }
 
 func (d *Destination) createRepositoriesFile(rootLayerID string) error {
-	repositories := map[string]map[string]string{
-		d.reference.Name(): {d.reference.Tag(): rootLayerID}}
+	repositories := map[string]map[string]string{}
+	for _, repoTag := range d.repoTags {
+		if val, ok := repositories[repoTag.Name()]; ok {
+			val[repoTag.Tag()] = rootLayerID
+		} else {
+			repositories[repoTag.Name()] = map[string]string{repoTag.Tag(): rootLayerID}
+		}
+	}
+
 	b, err := json.Marshal(repositories)
 	if err != nil {
 		return errors.Wrap(err, "Error marshaling repositories")
@@ -199,26 +215,31 @@ func (d *Destination) PutManifest(ctx context.Context, m []byte) error {
 		}
 	}
 
-	// For github.com/docker/docker consumers, this works just as well as
-	//   refString := ref.String()
-	// because when reading the RepoTags strings, github.com/docker/docker/reference
-	// normalizes both of them to the same value.
-	//
-	// Doing it this way to include the normalized-out `docker.io[/library]` does make
-	// a difference for github.com/projectatomic/docker consumers, with the
-	// “Add --add-registry and --block-registry options to docker daemon” patch.
-	// These consumers treat reference strings which include a hostname and reference
-	// strings without a hostname differently.
-	//
-	// Using the host name here is more explicit about the intent, and it has the same
-	// effect as (docker pull) in projectatomic/docker, which tags the result using
-	// a hostname-qualified reference.
-	// See https://github.com/containers/image/issues/72 for a more detailed
-	// analysis and explanation.
-	refString := fmt.Sprintf("%s:%s", d.reference.Name(), d.reference.Tag())
+	repoTags := []string{}
+	for _, tag := range d.repoTags {
+		// For github.com/docker/docker consumers, this works just as well as
+		//   refString := ref.String()
+		// because when reading the RepoTags strings, github.com/docker/docker/reference
+		// normalizes both of them to the same value.
+		//
+		// Doing it this way to include the normalized-out `docker.io[/library]` does make
+		// a difference for github.com/projectatomic/docker consumers, with the
+		// “Add --add-registry and --block-registry options to docker daemon” patch.
+		// These consumers treat reference strings which include a hostname and reference
+		// strings without a hostname differently.
+		//
+		// Using the host name here is more explicit about the intent, and it has the same
+		// effect as (docker pull) in projectatomic/docker, which tags the result using
+		// a hostname-qualified reference.
+		// See https://github.com/containers/image/issues/72 for a more detailed
+		// analysis and explanation.
+		refString := fmt.Sprintf("%s:%s", tag.Name(), tag.Tag())
+		repoTags = append(repoTags, refString)
+	}
+
 	items := []ManifestItem{{
 		Config:       man.ConfigDescriptor.Digest.Hex() + ".json",
-		RepoTags:     []string{refString},
+		RepoTags:     repoTags,
 		Layers:       layerPaths,
 		Parent:       "",
 		LayerSources: nil,

--- a/vendor/github.com/containers/image/internal/tmpdir/tmpdir.go
+++ b/vendor/github.com/containers/image/internal/tmpdir/tmpdir.go
@@ -5,6 +5,16 @@ import (
 	"runtime"
 )
 
+// unixTempDirForBigFiles is the directory path to store big files on non Windows systems.
+// You can override this at build time with
+// -ldflags '-X github.com/containers/image/internal/tmpdir.unixTempDirForBigFiles=$your_path'
+var unixTempDirForBigFiles = builtinUnixTempDirForBigFiles
+
+// builtinUnixTempDirForBigFiles is the directory path to store big files.
+// Do not use the system default of os.TempDir(), usually /tmp, because with systemd it could be a tmpfs.
+// DO NOT change this, instead see unixTempDirForBigFiles above.
+const builtinUnixTempDirForBigFiles = "/var/tmp"
+
 // TemporaryDirectoryForBigFiles returns a directory for temporary (big) files.
 // On non Windows systems it avoids the use of os.TempDir(), because the default temporary directory usually falls under /tmp
 // which on systemd based systems could be the unsuitable tmpfs filesystem.
@@ -13,7 +23,7 @@ func TemporaryDirectoryForBigFiles() string {
 	if runtime.GOOS == "windows" {
 		temporaryDirectoryForBigFiles = os.TempDir()
 	} else {
-		temporaryDirectoryForBigFiles = "/var/tmp"
+		temporaryDirectoryForBigFiles = unixTempDirForBigFiles
 	}
 	return temporaryDirectoryForBigFiles
 }

--- a/vendor/github.com/containers/image/oci/layout/oci_dest.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_dest.go
@@ -25,10 +25,6 @@ type ociImageDestination struct {
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
 func newImageDestination(sys *types.SystemContext, ref ociReference) (types.ImageDestination, error) {
-	if ref.image == "" {
-		return nil, errors.Errorf("cannot save image with empty reference name (syntax must be of form <transport>:<path>:<reference>)")
-	}
-
 	var index *imgspecv1.Index
 	if indexExists(ref) {
 		var err error
@@ -217,13 +213,11 @@ func (d *ociImageDestination) PutManifest(ctx context.Context, m []byte) error {
 		return err
 	}
 
-	if d.ref.image == "" {
-		return errors.Errorf("cannot save image with empyt image.ref.name")
+	if d.ref.image != "" {
+		annotations := make(map[string]string)
+		annotations["org.opencontainers.image.ref.name"] = d.ref.image
+		desc.Annotations = annotations
 	}
-
-	annotations := make(map[string]string)
-	annotations["org.opencontainers.image.ref.name"] = d.ref.image
-	desc.Annotations = annotations
 	desc.Platform = &imgspecv1.Platform{
 		Architecture: runtime.GOARCH,
 		OS:           runtime.GOOS,

--- a/vendor/github.com/containers/image/oci/layout/oci_transport.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_transport.go
@@ -55,7 +55,9 @@ type ociReference struct {
 	// (But in general, we make no attempt to be completely safe against concurrent hostile filesystem modifications.)
 	dir         string // As specified by the user. May be relative, contain symlinks, etc.
 	resolvedDir string // Absolute path with no symlinks, at least at the time of its creation. Primarily used for policy namespaces.
-	image       string // If image=="", it means the only image in the index.json is used
+	// If image=="", it means the "only image" in the index.json is used in the case it is a source
+	// for destinations, the image name annotation "image.ref.name" is not added to the index.json
+	image string
 }
 
 // ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an OCI ImageReference.

--- a/vendor/github.com/containers/image/storage/storage_image.go
+++ b/vendor/github.com/containers/image/storage/storage_image.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 
 	"github.com/containers/image/image"
+	"github.com/containers/image/internal/tmpdir"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
@@ -24,8 +25,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
-
-const temporaryDirectoryForBigFiles = "/var/tmp" // Do not use the system default of os.TempDir(), usually /tmp, because with systemd it could be a tmpfs.
 
 var (
 	// ErrBlobDigestMismatch is returned when PutBlob() is given a blob
@@ -240,7 +239,7 @@ func (s *storageImageSource) GetSignatures(ctx context.Context, instanceDigest *
 // newImageDestination sets us up to write a new image, caching blobs in a temporary directory until
 // it's time to Commit() the image
 func newImageDestination(imageRef storageReference) (*storageImageDestination, error) {
-	directory, err := ioutil.TempDir(temporaryDirectoryForBigFiles, "storage")
+	directory, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(), "storage")
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating a temporary directory")
 	}

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -347,6 +347,9 @@ type SystemContext struct {
 	// If not "", overrides the use of platform.GOOS when choosing an image or verifying OS match.
 	OSChoice string
 
+	// Additional tags when creating or copying a docker-archive.
+	DockerArchiveAdditionalTags []reference.NamedTagged
+
 	// === OCI.Transport overrides ===
 	// If not "", a directory containing a CA certificate (ending with ".crt"),
 	// a client certificate (ending with ".cert") and a client ceritificate key


### PR DESCRIPTION
pushing with format <transport>:<path> is valid now.
Add support to pull images from oci-archive that have no image ref name.

Signed-off-by: umohnani8 <umohnani@redhat.com>
