### PR TITLE
Add support for buildah bud --label

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -187,6 +187,7 @@ func budCmd(c *cli.Context) error {
 		CommonBuildOpts:       commonOpts,
 		DefaultMountsFilePath: c.GlobalString("default-mounts-file"),
 		IIDFile:               c.String("iidfile"),
+		Labels:                c.StringSlice("label"),
 	}
 
 	if !c.Bool("quiet") {

--- a/commit.go
+++ b/commit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strings"
 	"time"
 
 	cp "github.com/containers/image/copy"
@@ -49,6 +50,8 @@ type CommitOptions struct {
 	SystemContext *types.SystemContext
 	// IIDFile tells the builder to write the image ID to the specified file
 	IIDFile string
+	// Labels metadata for an image
+	Labels []string
 }
 
 // PushOptions can be used to alter how an image is copied somewhere.
@@ -82,6 +85,15 @@ type PushOptions struct {
 // if commit was successful and the image destination was local
 func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options CommitOptions) (string, error) {
 	var imgID string
+
+	for _, labelSpec := range options.Labels {
+		label := strings.SplitN(labelSpec, "=", 2)
+		if len(label) > 1 {
+			b.SetLabel(label[0], label[1])
+		} else {
+			b.SetLabel(label[0], "")
+		}
+	}
 
 	systemContext := getSystemContext(options.SystemContext, options.SignaturePolicyPath)
 	policy, err := signature.DefaultPolicy(systemContext)

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -378,6 +378,7 @@ return 1
      --file
      --format
      --iidfile
+     --label
      -m
      --memory
      --memory-swap

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -157,6 +157,10 @@ Buildah is not currently supported on Windows, and does not have a daemon.
 If you want to override the container isolation you can choose a different
 OCI Runtime, using the --runtime flag.
 
+**--label** *label*
+
+Add an image *label* (e.g. label=*value*) to the image metadata. Can be used multiple times.
+
 **--memory, -m**=""
 
 Memory limit (format: <number>[<unit>], where unit = b, k, m or g)

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -113,6 +113,8 @@ type BuildOptions struct {
 	DefaultMountsFilePath string
 	// IIDFile tells the builder to write the image ID to the specified file
 	IIDFile string
+	// Labels metadata for an image
+	Labels []string
 }
 
 // Executor is a buildah-based implementation of the imagebuilder.Executor
@@ -150,6 +152,7 @@ type Executor struct {
 	commonBuildOptions             *buildah.CommonBuildOptions
 	defaultMountsFilePath          string
 	iidfile                        string
+	labels                         []string
 }
 
 // withName creates a new child executor that will be used whenever a COPY statement uses --from=NAME.
@@ -482,6 +485,7 @@ func NewExecutor(store storage.Store, options BuildOptions) (*Executor, error) {
 		commonBuildOptions:    options.CommonBuildOpts,
 		defaultMountsFilePath: options.DefaultMountsFilePath,
 		iidfile:               options.IIDFile,
+		labels:                options.Labels,
 	}
 	if exec.err == nil {
 		exec.err = os.Stderr
@@ -692,6 +696,7 @@ func (b *Executor) Commit(ctx context.Context, ib *imagebuilder.Builder) (err er
 		ReportWriter:          b.reportWriter,
 		PreferredManifestType: b.outputFormat,
 		IIDFile:               b.iidfile,
+		Labels:                b.labels,
 	}
 	imgID, err := b.builder.Commit(ctx, imageRef, options)
 	if err != nil {

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -53,6 +53,10 @@ var (
 			Name:  "iidfile",
 			Usage: "Write the image ID to the file",
 		},
+		cli.StringSliceFlag{
+			Name:  "label",
+			Usage: "Set metadata for an image (default [])",
+		},
 		cli.BoolFlag{
 			Name:  "no-cache",
 			Usage: "Do not use caching for the container build. Buildah does not currently support caching so this is a NOOP.",

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -25,6 +25,15 @@ load helpers
   [ "$output" = "" ]
 }
 
+@test "bud-from-scratch-label" {
+  target=scratch-image
+  buildah bud --label "test=label" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run buildah --debug=false inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
+  [ "$status" -eq 0 ]
+  [ "$output" = 'map["test":"label"]' ]
+  buildah rmi ${target}
+}
+
 @test "bud-from-multiple-files-one-from" {
   target=scratch-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.nofrom


### PR DESCRIPTION
We want to be able to add labels when building a container image.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>