### PR TITLE
Add support for controlling ID mapping and namespace usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,4 +63,4 @@ script:
     - make install.tools install.libseccomp.sudo all runc validate TAGS="apparmor seccomp containers_image_ostree_stub"
     - go test -c -tags "apparmor seccomp `./btrfs_tag.sh` `./libdm_tag.sh` `./ostree_tag.sh` `./selinux_tag.sh`" ./cmd/buildah
     - tmp=`mktemp -d`; mkdir $tmp/root $tmp/runroot; sudo PATH="$PATH" ./buildah.test -test.v -root $tmp/root -runroot $tmp/runroot -storage-driver vfs -signature-policy `pwd`/tests/policy.json -registries-conf `pwd`/tests/registries.conf
-    - cd tests; travis_wait sudo PATH="$PATH" ./test_runner.sh
+    - cd tests; travis_wait 60 sudo PATH="$PATH" ./test_runner.sh

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,12 @@ GO := go
 
 GIT_COMMIT := $(if $(shell git rev-parse --short HEAD),$(shell git rev-parse --short HEAD),$(error "git failed"))
 BUILD_INFO := $(if $(shell date +%s),$(shell date +%s),$(error "date failed"))
+CNI_COMMIT := $(if $(shell sed -e '\,github.com/containernetworking/cni, !d' -e 's,.* ,,g' vendor.conf),$(shell sed -e '\,github.com/containernetworking/cni, !d' -e 's,.* ,,g' vendor.conf),$(error "sed failed"))
 
 RUNC_COMMIT := c5ec25487693612aed95673800863e134785f946
 LIBSECCOMP_COMMIT := release-2.3
 
-LDFLAGS := -ldflags '-X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_INFO}'
+LDFLAGS := -ldflags '-X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_INFO} -X main.cniVersion=${CNI_COMMIT}'
 
 all: buildah imgtype docs
 

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,12 @@ install.libseccomp.sudo: gopath
 	git clone https://github.com/seccomp/libseccomp ../../seccomp/libseccomp
 	cd ../../seccomp/libseccomp && git checkout $(LIBSECCOMP_COMMIT) && ./autogen.sh && ./configure --prefix=/usr && make all && sudo make install
 
+.PHONY: install.cni.sudo
+install.cni.sudo: gopath
+	rm -rf ../../containernetworking/plugins
+	git clone https://github.com/containernetworking/plugins ../../containernetworking/plugins
+	cd ../../containernetworking/plugins && ./build.sh && mkdir -p /opt/cni/bin && sudo install -v -m755 bin/* /opt/cni/bin/
+
 .PHONY: install
 install:
 	install -D -m0755 buildah $(DESTDIR)/$(BINDIR)/buildah

--- a/add.go
+++ b/add.go
@@ -209,5 +209,16 @@ func (b *Builder) user(mountPoint string, userspec string) (specs.User, error) {
 		GID:      gid,
 		Username: userspec,
 	}
+	if !strings.Contains(userspec, ":") {
+		groups, err2 := chrootuser.GetAdditionalGroupsForUser(mountPoint, uint64(u.UID))
+		if err2 != nil {
+			if errors.Cause(err2) != chrootuser.ErrNoSuchUser && err == nil {
+				err = err2
+			}
+		} else {
+			u.AdditionalGids = groups
+		}
+
+	}
 	return u, err
 }

--- a/add.go
+++ b/add.go
@@ -112,6 +112,9 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	if len(source) > 1 && (destfi == nil || !destfi.IsDir()) {
 		return errors.Errorf("destination %q is not a directory", dest)
 	}
+	copyFileWithTar := b.copyFileWithTar(nil)
+	copyWithTar := b.copyWithTar(nil)
+	untarPath := b.untarPath(nil)
 	for _, src := range source {
 		if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
 			// We assume that source is a file, and we're copying

--- a/add.go
+++ b/add.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/idtools"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/libpod/pkg/chrootuser"
@@ -26,7 +27,7 @@ type AddAndCopyOptions struct {
 // addURL copies the contents of the source URL to the destination.  This is
 // its own function so that deferred closes happen after we're done pulling
 // down each item of potentially many.
-func addURL(destination, srcurl string) error {
+func addURL(destination, srcurl string, owner idtools.IDPair) error {
 	logrus.Debugf("saving %q to %q", srcurl, destination)
 	resp, err := http.Get(srcurl)
 	if err != nil {
@@ -36,6 +37,9 @@ func addURL(destination, srcurl string) error {
 	f, err := os.Create(destination)
 	if err != nil {
 		return errors.Wrapf(err, "error creating %q", destination)
+	}
+	if err = f.Chown(owner.UID, owner.GID); err != nil {
+		return errors.Wrapf(err, "error setting owner of %q", destination)
 	}
 	if last := resp.Header.Get("Last-Modified"); last != "" {
 		if mtime, err2 := time.Parse(time.RFC1123, last); err2 != nil {
@@ -80,11 +84,17 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	if err != nil {
 		return err
 	}
+	containerOwner := idtools.IDPair{UID: int(user.UID), GID: int(user.GID)}
+	hostUID, hostGID, err := getHostIDs(b.IDMappingOptions.UIDMap, b.IDMappingOptions.GIDMap, user.UID, user.GID)
+	if err != nil {
+		return err
+	}
+	hostOwner := idtools.IDPair{UID: int(hostUID), GID: int(hostGID)}
 	dest := mountPoint
 	if destination != "" && filepath.IsAbs(destination) {
 		dest = filepath.Join(dest, destination)
 	} else {
-		if err = ensureDir(filepath.Join(dest, b.WorkDir()), user, 0755); err != nil {
+		if err = idtools.MkdirAllAndChownNew(filepath.Join(dest, b.WorkDir()), 0755, hostOwner); err != nil {
 			return err
 		}
 		dest = filepath.Join(dest, b.WorkDir(), destination)
@@ -93,7 +103,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	// with a '/', create it so that we can be sure that it's a directory,
 	// and any files we're copying will be placed in the directory.
 	if len(destination) > 0 && destination[len(destination)-1] == os.PathSeparator {
-		if err = ensureDir(dest, user, 0755); err != nil {
+		if err = idtools.MkdirAllAndChownNew(dest, 0755, hostOwner); err != nil {
 			return err
 		}
 	}
@@ -112,8 +122,8 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	if len(source) > 1 && (destfi == nil || !destfi.IsDir()) {
 		return errors.Errorf("destination %q is not a directory", dest)
 	}
-	copyFileWithTar := b.copyFileWithTar(nil)
-	copyWithTar := b.copyWithTar(nil)
+	copyFileWithTar := b.copyFileWithTar(&containerOwner)
+	copyWithTar := b.copyWithTar(&containerOwner)
 	untarPath := b.untarPath(nil)
 	for _, src := range source {
 		if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
@@ -130,10 +140,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			if destfi != nil && destfi.IsDir() {
 				d = filepath.Join(dest, path.Base(url.Path))
 			}
-			if err := addURL(d, src); err != nil {
-				return err
-			}
-			if err := setOwner("", d, user); err != nil {
+			if err := addURL(d, src, hostOwner); err != nil {
 				return err
 			}
 			continue
@@ -156,15 +163,12 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 				// the source directory into the target directory.  Try
 				// to create it first, so that if there's a problem,
 				// we'll discover why that won't work.
-				if err = ensureDir(dest, user, 0755); err != nil {
+				if err = idtools.MkdirAllAndChownNew(dest, 0755, hostOwner); err != nil {
 					return err
 				}
 				logrus.Debugf("copying %q to %q", gsrc+string(os.PathSeparator)+"*", dest+string(os.PathSeparator)+"*")
 				if err := copyWithTar(gsrc, dest); err != nil {
 					return errors.Wrapf(err, "error copying %q to %q", gsrc, dest)
-				}
-				if err := setOwner(gsrc, dest, user); err != nil {
-					return err
 				}
 				continue
 			}
@@ -180,9 +184,6 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 				logrus.Debugf("copying %q to %q", gsrc, d)
 				if err := copyFileWithTar(gsrc, d); err != nil {
 					return errors.Wrapf(err, "error copying %q to %q", gsrc, d)
-				}
-				if err := setOwner(gsrc, d, user); err != nil {
-					return err
 				}
 				continue
 			}
@@ -209,48 +210,4 @@ func (b *Builder) user(mountPoint string, userspec string) (specs.User, error) {
 		Username: userspec,
 	}
 	return u, err
-}
-
-// setOwner sets the uid and gid owners of a given path.
-func setOwner(src, dest string, user specs.User) error {
-	fid, err := os.Stat(dest)
-	if err != nil {
-		return errors.Wrapf(err, "error reading %q", dest)
-	}
-	if !fid.IsDir() || src == "" {
-		if err := os.Lchown(dest, int(user.UID), int(user.GID)); err != nil {
-			return errors.Wrapf(err, "error setting ownership of %q", dest)
-		}
-		return nil
-	}
-	err = filepath.Walk(src, func(p string, info os.FileInfo, we error) error {
-		relPath, err2 := filepath.Rel(src, p)
-		if err2 != nil {
-			return errors.Wrapf(err2, "error getting relative path of %q to set ownership on destination", p)
-		}
-		if relPath != "." {
-			absPath := filepath.Join(dest, relPath)
-			if err2 := os.Lchown(absPath, int(user.UID), int(user.GID)); err != nil {
-				return errors.Wrapf(err2, "error setting ownership of %q", absPath)
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return errors.Wrapf(err, "error walking dir %q to set ownership", src)
-	}
-	return nil
-}
-
-// ensureDir creates a directory if it doesn't exist, setting ownership and permissions as passed by user and perm.
-func ensureDir(path string, user specs.User, perm os.FileMode) error {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		if err := os.MkdirAll(path, perm); err != nil {
-			return errors.Wrapf(err, "error ensuring directory %q exists", path)
-		}
-		if err := os.Chown(path, int(user.UID), int(user.GID)); err != nil {
-			return errors.Wrapf(err, "error setting ownership of %q", path)
-		}
-	}
-	return nil
 }

--- a/buildah.go
+++ b/buildah.go
@@ -116,6 +116,11 @@ type Builder struct {
 	// DefaultMountsFilePath is the file path holding the mounts to be mounted in "host-path:container-path" format.
 	DefaultMountsFilePath string `json:"defaultMountsFilePath,omitempty"`
 
+	// NamespaceOptions controls how we set up the namespaces for processes that we run in the container.
+	NamespaceOptions NamespaceOptions
+	// ID mapping options to use when running processes in the container with non-host user namespaces.
+	IDMappingOptions IDMappingOptions
+
 	CommonBuildOpts *CommonBuildOptions
 }
 
@@ -136,6 +141,8 @@ type BuilderInfo struct {
 	OCIv1                 v1.Image
 	Docker                docker.V2Image
 	DefaultMountsFilePath string
+	NamespaceOptions      NamespaceOptions
+	IDMappingOptions      IDMappingOptions
 }
 
 // GetBuildInfo gets a pointer to a Builder object and returns a BuilderInfo object from it.
@@ -156,6 +163,8 @@ func GetBuildInfo(b *Builder) BuilderInfo {
 		OCIv1:                 b.OCIv1,
 		Docker:                b.Docker,
 		DefaultMountsFilePath: b.DefaultMountsFilePath,
+		NamespaceOptions:      b.NamespaceOptions,
+		IDMappingOptions:      b.IDMappingOptions,
 	}
 }
 
@@ -250,7 +259,13 @@ type BuilderOptions struct {
 	// DefaultMountsFilePath is the file path holding the mounts to be
 	// mounted in "host-path:container-path" format
 	DefaultMountsFilePath string
-	CommonBuildOpts       *CommonBuildOptions
+	// NamespaceOptions controls how we set up namespaces for processes that
+	// we might need to run using the container's root filesystem.
+	NamespaceOptions NamespaceOptions
+	// ID mapping options to use if we're setting up our own user namespace.
+	IDMappingOptions *IDMappingOptions
+
+	CommonBuildOpts *CommonBuildOptions
 }
 
 // ImportOptions are used to initialize a Builder from an existing container

--- a/buildah.go
+++ b/buildah.go
@@ -67,6 +67,37 @@ func (p PullPolicy) String() string {
 	return fmt.Sprintf("unrecognized policy %d", p)
 }
 
+// NetworkConfigurationPolicy takes the value NetworkDefault, NetworkDisabled,
+// or NetworkEnabled.
+type NetworkConfigurationPolicy int
+
+const (
+	// NetworkDefault is one of the values that BuilderOptions.ConfigureNetwork
+	// can take, signalling that the default behavior should be used.
+	NetworkDefault NetworkConfigurationPolicy = iota
+	// NetworkDisabled is one of the values that BuilderOptions.ConfigureNetwork
+	// can take, signalling that network interfaces should NOT be configured for
+	// newly-created network namespaces.
+	NetworkDisabled
+	// NetworkEnabled is one of the values that BuilderOptions.ConfigureNetwork
+	// can take, signalling that network interfaces should be configured for
+	// newly-created network namespaces.
+	NetworkEnabled
+)
+
+// String formats a NetworkConfigurationPolicy as a string.
+func (p NetworkConfigurationPolicy) String() string {
+	switch p {
+	case NetworkDefault:
+		return "NetworkDefault"
+	case NetworkDisabled:
+		return "NetworkDisabled"
+	case NetworkEnabled:
+		return "NetworkEnabled"
+	}
+	return fmt.Sprintf("unknown NetworkConfigurationPolicy %d", p)
+}
+
 // Builder objects are used to represent containers which are being used to
 // build images.  They also carry potential updates which will be applied to
 // the image's configuration when the container's contents are used to build an
@@ -118,6 +149,18 @@ type Builder struct {
 
 	// NamespaceOptions controls how we set up the namespaces for processes that we run in the container.
 	NamespaceOptions NamespaceOptions
+	// ConfigureNetwork controls whether or not network interfaces and
+	// routing are configured for a new network namespace (i.e., when not
+	// joining another's namespace and not just using the host's
+	// namespace), effectively deciding whether or not the process has a
+	// usable network.
+	ConfigureNetwork NetworkConfigurationPolicy
+	// CNIPluginPath is the location of CNI plugin helpers, if they should be
+	// run from a location other than the default location.
+	CNIPluginPath string
+	// CNIConfigDir is the location of CNI configuration files, if the files in
+	// the default configuration directory shouldn't be used.
+	CNIConfigDir string
 	// ID mapping options to use when running processes in the container with non-host user namespaces.
 	IDMappingOptions IDMappingOptions
 
@@ -142,6 +185,9 @@ type BuilderInfo struct {
 	Docker                docker.V2Image
 	DefaultMountsFilePath string
 	NamespaceOptions      NamespaceOptions
+	ConfigureNetwork      string
+	CNIPluginPath         string
+	CNIConfigDir          string
 	IDMappingOptions      IDMappingOptions
 }
 
@@ -164,6 +210,9 @@ func GetBuildInfo(b *Builder) BuilderInfo {
 		Docker:                b.Docker,
 		DefaultMountsFilePath: b.DefaultMountsFilePath,
 		NamespaceOptions:      b.NamespaceOptions,
+		ConfigureNetwork:      fmt.Sprintf("%v", b.ConfigureNetwork),
+		CNIPluginPath:         b.CNIPluginPath,
+		CNIConfigDir:          b.CNIConfigDir,
 		IDMappingOptions:      b.IDMappingOptions,
 	}
 }
@@ -262,6 +311,18 @@ type BuilderOptions struct {
 	// NamespaceOptions controls how we set up namespaces for processes that
 	// we might need to run using the container's root filesystem.
 	NamespaceOptions NamespaceOptions
+	// ConfigureNetwork controls whether or not network interfaces and
+	// routing are configured for a new network namespace (i.e., when not
+	// joining another's namespace and not just using the host's
+	// namespace), effectively deciding whether or not the process has a
+	// usable network.
+	ConfigureNetwork NetworkConfigurationPolicy
+	// CNIPluginPath is the location of CNI plugin helpers, if they should be
+	// run from a location other than the default location.
+	CNIPluginPath string
+	// CNIConfigDir is the location of CNI configuration files, if the files in
+	// the default configuration directory shouldn't be used.
+	CNIConfigDir string
 	// ID mapping options to use if we're setting up our own user namespace.
 	IDMappingOptions *IDMappingOptions
 

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -167,6 +167,16 @@ func budCmd(c *cli.Context) error {
 		logrus.Debugf("build caching not enabled so --rm flag has no effect")
 	}
 
+	namespaceOptions, err := parseNamespaceOptions(c)
+	if err != nil {
+		return errors.Wrapf(err, "error parsing namespace-related options")
+	}
+	usernsOption, idmappingOptions, err := parseIDMappingOptions(c)
+	if err != nil {
+		return errors.Wrapf(err, "error parsing ID mapping options")
+	}
+	namespaceOptions.AddOrReplace(usernsOption...)
+
 	options := imagebuildah.BuildOptions{
 		ContextDirectory:      contextDir,
 		PullPolicy:            pullPolicy,
@@ -180,6 +190,8 @@ func budCmd(c *cli.Context) error {
 		RuntimeArgs:           runtimeFlags,
 		OutputFormat:          format,
 		SystemContext:         systemContext,
+		NamespaceOptions:      namespaceOptions,
+		IDMappingOptions:      idmappingOptions,
 		CommonBuildOpts:       commonOpts,
 		DefaultMountsFilePath: c.GlobalString("default-mounts-file"),
 		IIDFile:               c.String("iidfile"),

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -167,7 +167,7 @@ func budCmd(c *cli.Context) error {
 		logrus.Debugf("build caching not enabled so --rm flag has no effect")
 	}
 
-	namespaceOptions, err := parseNamespaceOptions(c)
+	namespaceOptions, networkPolicy, err := parseNamespaceOptions(c)
 	if err != nil {
 		return errors.Wrapf(err, "error parsing namespace-related options")
 	}
@@ -191,6 +191,9 @@ func budCmd(c *cli.Context) error {
 		OutputFormat:          format,
 		SystemContext:         systemContext,
 		NamespaceOptions:      namespaceOptions,
+		ConfigureNetwork:      networkPolicy,
+		CNIPluginPath:         c.String("cni-plugin-path"),
+		CNIConfigDir:          c.String("cni-config-dir"),
 		IDMappingOptions:      idmappingOptions,
 		CommonBuildOpts:       commonOpts,
 		DefaultMountsFilePath: c.GlobalString("default-mounts-file"),

--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -2,15 +2,22 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
+	"unicode"
 
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
-	"github.com/opencontainers/go-digest"
+	"github.com/containers/storage/pkg/idtools"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -117,4 +124,184 @@ func getDateAndDigestAndSize(ctx context.Context, image storage.Image, store sto
 // getContext returns a context.TODO
 func getContext() context.Context {
 	return context.TODO()
+}
+
+var userFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "user",
+		Usage: "`user[:group]` to run the command as",
+	},
+}
+
+func parseUserOptions(c *cli.Context) string {
+	return c.String("user")
+}
+
+func parseNamespaceOptions(c *cli.Context) (namespaceOptions buildah.NamespaceOptions, err error) {
+	options := make(buildah.NamespaceOptions, 0, 7)
+	for _, what := range []string{string(specs.IPCNamespace), "net", string(specs.PIDNamespace), string(specs.UTSNamespace)} {
+		if c.IsSet(what) {
+			how := c.String(what)
+			switch what {
+			case "net", "network":
+				what = string(specs.NetworkNamespace)
+			}
+			switch how {
+			case "", "container":
+				logrus.Debugf("setting %q namespace to %q", what, "")
+				options.AddOrReplace(buildah.NamespaceOption{
+					Name: what,
+				})
+			case "host":
+				logrus.Debugf("setting %q namespace to host", what)
+				options.AddOrReplace(buildah.NamespaceOption{
+					Name: what,
+					Host: true,
+				})
+			default:
+				if _, err := os.Stat(how); err != nil {
+					return nil, errors.Wrapf(err, "error checking for %s namespace at %q", what, how)
+				}
+				logrus.Debugf("setting %q namespace to %q", what, how)
+				options.AddOrReplace(buildah.NamespaceOption{
+					Name: what,
+					Path: how,
+				})
+			}
+		}
+	}
+	return options, nil
+}
+
+func parseIDMappingOptions(c *cli.Context) (usernsOptions buildah.NamespaceOptions, idmapOptions *buildah.IDMappingOptions, err error) {
+	user := c.String("userns-uid-map-user")
+	group := c.String("userns-gid-map-group")
+	// If only the user or group was specified, use the same value for the
+	// other, since we need both in order to initialize the maps using the
+	// names.
+	if user == "" && group != "" {
+		user = group
+	}
+	if group == "" && user != "" {
+		group = user
+	}
+	// Either start with empty maps or the name-based maps.
+	mappings := idtools.NewIDMappingsFromMaps(nil, nil)
+	if user != "" && group != "" {
+		submappings, err := idtools.NewIDMappings(user, group)
+		if err != nil {
+			return nil, nil, err
+		}
+		mappings = submappings
+	}
+	// We'll parse the UID and GID mapping options the same way.
+	buildIDMap := func(basemap []idtools.IDMap, option string) ([]specs.LinuxIDMapping, error) {
+		outmap := make([]specs.LinuxIDMapping, 0, len(basemap))
+		// Start with the name-based map entries.
+		for _, m := range basemap {
+			outmap = append(outmap, specs.LinuxIDMapping{
+				ContainerID: uint32(m.ContainerID),
+				HostID:      uint32(m.HostID),
+				Size:        uint32(m.Size),
+			})
+		}
+		// Parse the flag's value as one or more triples (if it's even
+		// been set), and append them.
+		idmap, err := parseIDMap(c.StringSlice(option))
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range idmap {
+			outmap = append(outmap, specs.LinuxIDMapping{
+				ContainerID: m[0],
+				HostID:      m[1],
+				Size:        m[2],
+			})
+		}
+		return outmap, nil
+	}
+	uidmap, err := buildIDMap(mappings.UIDs(), "userns-uid-map")
+	if err != nil {
+		return nil, nil, err
+	}
+	gidmap, err := buildIDMap(mappings.GIDs(), "userns-gid-map")
+	if err != nil {
+		return nil, nil, err
+	}
+	// If we only have one map or the other populated at this point, then
+	// use the same mapping for both, since we know that no user or group
+	// name was specified, but a specific mapping was for one or the other.
+	if len(uidmap) == 0 && len(gidmap) != 0 {
+		uidmap = gidmap
+	}
+	if len(gidmap) == 0 && len(uidmap) != 0 {
+		gidmap = uidmap
+	}
+	// By default, having mappings configured means we use a user
+	// namespace.  Otherwise, we don't.
+	usernsOption := buildah.NamespaceOption{
+		Name: string(specs.UserNamespace),
+		Host: len(uidmap) == 0 && len(gidmap) == 0,
+	}
+	// If the user specifically requested that we either use or don't use
+	// user namespaces, override that default.
+	if c.IsSet("userns") {
+		how := c.String("userns")
+		switch how {
+		case "", "container":
+			usernsOption.Host = false
+		case "host":
+			usernsOption.Host = true
+		default:
+			if _, err := os.Stat(how); err != nil {
+				return nil, nil, errors.Wrapf(err, "error checking for %s namespace at %q", string(specs.UserNamespace), how)
+			}
+			logrus.Debugf("setting %q namespace to %q", string(specs.UserNamespace), how)
+			usernsOption.Path = how
+		}
+	}
+	usernsOptions = buildah.NamespaceOptions{usernsOption}
+	if !c.IsSet("net") {
+		usernsOptions = append(usernsOptions, buildah.NamespaceOption{
+			Name: string(specs.NetworkNamespace),
+			Host: usernsOption.Host,
+		})
+	}
+	// If the user requested that we use the host namespace, but also that
+	// we use mappings, that's not going to work.
+	if (len(uidmap) != 0 || len(gidmap) != 0) && usernsOption.Host {
+		return nil, nil, errors.Errorf("can not specify ID mappings while using host's user namespace")
+	}
+	return usernsOptions, &buildah.IDMappingOptions{
+		HostUIDMapping: usernsOption.Host,
+		HostGIDMapping: usernsOption.Host,
+		UIDMap:         uidmap,
+		GIDMap:         gidmap,
+	}, nil
+}
+
+func parseIDMap(spec []string) (m [][3]uint32, err error) {
+	for _, s := range spec {
+		args := strings.FieldsFunc(s, func(r rune) bool { return !unicode.IsDigit(r) })
+		if len(args)%3 != 0 {
+			return nil, fmt.Errorf("mapping %q is not in the form containerid:hostid:size[,...]", s)
+		}
+		for len(args) >= 3 {
+			cid, err := strconv.ParseUint(args[0], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing container ID %q from mapping %q as a number: %v", args[0], s, err)
+			}
+			hostid, err := strconv.ParseUint(args[1], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing host ID %q from mapping %q as a number: %v", args[1], s, err)
+			}
+			size, err := strconv.ParseUint(args[2], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing %q from mapping %q as a number: %v", args[2], s, err)
+			}
+			m = append(m, [3]uint32{uint32(cid), uint32(hostid), uint32(size)})
+			args = args[3:]
+		}
+	}
+	return m, nil
 }

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -112,6 +112,16 @@ func fromCmd(c *cli.Context) error {
 		}
 	}
 
+	namespaceOptions, err := parseNamespaceOptions(c)
+	if err != nil {
+		return errors.Wrapf(err, "error parsing namespace-related options")
+	}
+	usernsOption, idmappingOptions, err := parseIDMappingOptions(c)
+	if err != nil {
+		return errors.Wrapf(err, "error parsing ID mapping options")
+	}
+	namespaceOptions.AddOrReplace(usernsOption...)
+
 	options := buildah.BuilderOptions{
 		FromImage:             args[0],
 		Transport:             transport,
@@ -120,6 +130,8 @@ func fromCmd(c *cli.Context) error {
 		SignaturePolicyPath:   signaturePolicy,
 		SystemContext:         systemContext,
 		DefaultMountsFilePath: c.GlobalString("default-mounts-file"),
+		NamespaceOptions:      namespaceOptions,
+		IDMappingOptions:      idmappingOptions,
 		CommonBuildOpts:       commonOpts,
 	}
 

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -112,7 +112,7 @@ func fromCmd(c *cli.Context) error {
 		}
 	}
 
-	namespaceOptions, err := parseNamespaceOptions(c)
+	namespaceOptions, networkPolicy, err := parseNamespaceOptions(c)
 	if err != nil {
 		return errors.Wrapf(err, "error parsing namespace-related options")
 	}
@@ -131,6 +131,9 @@ func fromCmd(c *cli.Context) error {
 		SystemContext:         systemContext,
 		DefaultMountsFilePath: c.GlobalString("default-mounts-file"),
 		NamespaceOptions:      namespaceOptions,
+		ConfigureNetwork:      networkPolicy,
+		CNIPluginPath:         c.String("cni-plugin-path"),
+		CNIConfigDir:          c.String("cni-config-dir"),
 		IDMappingOptions:      idmappingOptions,
 		CommonBuildOpts:       commonOpts,
 	}

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -90,7 +90,7 @@ func runCmd(c *cli.Context) error {
 	}
 
 	user := parseUserOptions(c)
-	namespaceOptions, err := parseNamespaceOptions(c)
+	namespaceOptions, networkPolicy, err := parseNamespaceOptions(c)
 	if err != nil {
 		return errors.Wrapf(err, "error parsing namespace-related options")
 	}
@@ -101,6 +101,9 @@ func runCmd(c *cli.Context) error {
 		Args:             runtimeFlags,
 		User:             user,
 		NamespaceOptions: namespaceOptions,
+		ConfigureNetwork: networkPolicy,
+		CNIPluginPath:    c.String("cni-plugin-path"),
+		CNIConfigDir:     c.String("cni-config-dir"),
 	}
 
 	if c.IsSet("tty") {

--- a/cmd/buildah/version.go
+++ b/cmd/buildah/version.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	cniversion "github.com/containernetworking/cni/pkg/version"
 	ispecs "github.com/opencontainers/image-spec/specs-go"
 	rspecs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/projectatomic/buildah"
@@ -14,8 +15,9 @@ import (
 
 //Overwritten at build time
 var (
-	gitCommit string
-	buildInfo string
+	gitCommit  string
+	buildInfo  string
+	cniVersion string
 )
 
 //Function to get and print info for version command
@@ -27,15 +29,17 @@ func versionCmd(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Println("Version:      ", buildah.Version)
-	fmt.Println("Go Version:   ", runtime.Version())
-	fmt.Println("Image Spec:   ", ispecs.Version)
-	fmt.Println("Runtime Spec: ", rspecs.Version)
-	fmt.Println("Git Commit:   ", gitCommit)
+	fmt.Println("Version:        ", buildah.Version)
+	fmt.Println("Go Version:     ", runtime.Version())
+	fmt.Println("Image Spec:     ", ispecs.Version)
+	fmt.Println("Runtime Spec:   ", rspecs.Version)
+	fmt.Println("CNI Spec:       ", cniversion.Current())
+	fmt.Println("libcni Version: ", cniVersion)
+	fmt.Println("Git Commit:     ", gitCommit)
 
 	//Prints out the build time in readable format
-	fmt.Println("Built:        ", time.Unix(buildTime, 0).Format(time.ANSIC))
-	fmt.Println("OS/Arch:      ", runtime.GOOS+"/"+runtime.GOARCH)
+	fmt.Println("Built:          ", time.Unix(buildTime, 0).Format(time.ANSIC))
+	fmt.Println("OS/Arch:        ", runtime.GOOS+"/"+runtime.GOARCH)
 
 	return nil
 }

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -381,10 +381,14 @@ return 1
      --file
      --format
      --iidfile
+     --ipc
      --label
      -m
      --memory
      --memory-swap
+     --net
+     --network
+     --pid
      --runtime
      --runtime-flag
      --security-opt
@@ -393,6 +397,12 @@ return 1
      -t
      --tag
      --ulimit
+     --userns
+     --userns-uid-map
+     --userns-gid-map
+     --userns-uid-map-user
+     --userns-gid-map-group
+     --uts
      --volume
      -v
   "
@@ -430,9 +440,15 @@ return 1
 
      local options_with_args="
      --hostname
+     --ipc
+     --net
+     --network
+     --pid
      --runtime
      --runtime-flag
      --security-opt
+     --user
+     --uts
      --volume
      -v
   "
@@ -694,14 +710,24 @@ return 1
      --cpuset-cpus
      --cpuset-mems
      --creds
+     --ipc
      -m
      --memory
      --memory-swap
      --name
+     --net
+     --network
+     --pid
      --signature-policy
      --security-opt
      --shm-size
      --ulimit
+     --userns
+     --userns-uid-map
+     --userns-gid-map
+     --userns-uid-map-user
+     --userns-gid-map-group
+     --uts
      --volume
   "
 

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -371,6 +371,8 @@ return 1
      --build-arg
      --cert-dir
      --cgroup-parent
+     --cni-config-dir
+     --cni-plugin-path
      --cpu-period
      --cpu-quota
      --cpu-shares
@@ -439,6 +441,8 @@ return 1
   "
 
      local options_with_args="
+     --cni-config-dir
+     --cni-plugin-path
      --hostname
      --ipc
      --net
@@ -704,6 +708,8 @@ return 1
      --authfile
      --cert-dir
      --cgroup-parent
+     --cni-config-dir
+     --cni-plugin-path
      --cpu-period
      --cpu-quota
      --cpu-shares

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -60,8 +60,20 @@ Path to cgroups under which the cgroup for the container will be created. If the
 **--compress**
 
 This option is added to be aligned with other containers CLIs.
-Buildah doesn't communicate with a daemon or a remote server.
+Buildah doesn't send a copy of the context directory to a daemon or a remote server.
 Thus, compressing the data before sending it is irrelevant to Buildah.
+
+**--cni-config-dir**=*directory*
+
+Location of CNI configuration files which will dictate which plugins will be
+used to configure network interfaces and routing for containers created for
+handling `RUN` instructions, if those containers will be run in their own
+network namespaces, and networking is not disabled.
+
+**--cni-plugin-path**=*directory[:directory[:directory[...]]]*
+
+List of directories in which the CNI plugins which will be used for configuring
+network namespaces can be found.
 
 **--cpu-period**=*0*
 

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -157,6 +157,15 @@ Recognized formats include *oci* (OCI image-spec v1.0, the default) and
 
 Write the image ID to the file.
 
+**--ipc** *how*
+
+Sets the configuration for IPC namespaces when handling `RUN` instructions.
+The configured value can be "" (the empty string) or "container" to indicate
+that a new IPC namespace should be created, or it can be "host" to indicate
+that the IPC namespace in which `buildah` itself is being run should be reused,
+or it can be the path to an IPC namespace which is already in use by
+another process.
+
 **--isolation** [Not Supported]
 
 Buildah is not currently supported on Windows, and does not have a daemon.
@@ -188,9 +197,28 @@ The format of `LIMIT` is `<number>[<unit>]`. Unit can be `b` (bytes),
 `k` (kilobytes), `m` (megabytes), or `g` (gigabytes). If you don't specify a
 unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
+**--net** *how*
+**--network** *how*
+
+Sets the configuration for network namespaces when handling `RUN` instructions.
+The configured value can be "" (the empty string) or "container" to indicate
+that a new network namespace should be created, or it can be "host" to indicate
+that the network namespace in which `buildah` itself is being run should be
+reused, or it can be the path to a network namespace which is already in use by
+another process.
+
 **--no-cache**
 
 Do not use caching for the container build. Buildah does not currently support caching so this is a NOOP.
+
+**--pid** *how*
+
+Sets the configuration for PID namespaces when handling `RUN` instructions.
+The configured value can be "" (the empty string) or "container" to indicate
+that a new PID namespace should be created, or it can be "host" to indicate
+that the PID namespace in which `buildah` itself is being run should be reused,
+or it can be the path to a PID namespace which is already in use by another
+process.
 
 **--pull**
 
@@ -288,6 +316,72 @@ include:
   "rttime": maximum amount of real-time execution between blocking syscalls
   "sigpending": maximum number of pending signals (ulimit -i)
   "stack": maximum stack size (ulimit -s)
+
+**--userns** *how*
+
+Sets the configuration for user namespaces when handling `RUN` instructions.
+The configured value can be "" (the empty string) or "container" to indicate
+that a new user namespace should be created, it can be "host" to indicate that
+the user namespace in which `buildah` itself is being run should be reused, or
+it can be the path to an user namespace which is already in use by another
+process.
+
+**--userns-uid-map** *mapping*
+
+Directly specifies a UID mapping which should be used to set ownership, at the
+filesytem level, on the working container's contents.
+Commands run when handling `RUN` instructions will default to being run in
+their own user namespaces, configured using the UID and GID maps.
+Entries in this map take the form of one or more triples of a starting
+in-container UID, a corresponding starting host-level UID, and the number of
+consecutive IDs which the map entry represents.
+If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-uid-map
+are specified, but --userns-gid-map is specified, the UID map will be set to
+use the same numeric values as the GID map.
+
+**--userns-gid-map** *mapping*
+
+Directly specifies a GID mapping which should be used to set ownership, at the
+filesytem level, on the working container's contents.
+Commands run when handling `RUN` instructions will default to being run in
+their own user namespaces, configured using the UID and GID maps.
+Entries in this map take the form of one or more triples of a starting
+in-container GID, a corresponding starting host-level GID, and the number of
+consecutive IDs which the map entry represents.
+If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-gid-map
+are specified, but --userns-uid-map is specified, the GID map will be set to
+use the same numeric values as the UID map.
+
+**--userns-uid-map-user** *user*
+
+Specifies that a UID mapping which should be used to set ownership, at the
+filesytem level, on the working container's contents, can be found in entries
+in the `/etc/subuid` file which correspond to the specified user.
+Commands run when handling `RUN` instructions will default to being run in
+their own user namespaces, configured using the UID and GID maps.
+If --userns-gid-map-group is specified, but --userns-uid-map-user is not
+specified, `buildah` will assume that the specified group name is also a
+suitable user name to use as the default setting for this option.
+
+**--userns-gid-map-group** *group*
+
+Specifies that a GID mapping which should be used to set ownership, at the
+filesytem level, on the working container's contents, can be found in entries
+in the `/etc/subgid` file which correspond to the specified group.
+Commands run when handling `RUN` instructions will default to being run in
+their own user namespaces, configured using the UID and GID maps.
+If --userns-uid-map-user is specified, but --userns-gid-map-group is not
+specified, `buildah` will assume that the specified user name is also a
+suitable group name to use as the default setting for this option.
+
+**--uts** *how*
+
+Sets the configuration for UTS namespaces when the handling `RUN` instructions.
+The configured value can be "" (the empty string) or "container" to indicate
+that a new UTS namespace should be created, or it can be "host" to indicate
+that the UTS namespace in which `buildah` itself is being run should be reused,
+or it can be the path to a UTS namespace which is already in use by another
+process.
 
 **--volume, -v**[=*[HOST-DIR:CONTAINER-DIR[:OPTIONS]]*]
 
@@ -406,4 +500,4 @@ buildah bud --volume /home/test:/myvol:ro,Z -t imageName .
 registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
-buildah(1), podman-login(1), docker-login(1), policy.json(5), registries.conf(5)
+buildah(1), podman-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7)

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -104,7 +104,7 @@ Note: this setting is not present in the OCIv1 image format, so it is discarded 
 
 Set default *stop signal* for container. This signal will be sent when container is stopped, default is SIGINT.
 
-**--user** *user*
+**--user** *user*[:*group*]
 
 Set the default *user* to be used when running containers based on this image.
 The user can be specified as a user name

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -57,6 +57,18 @@ The default certificates directory is _/etc/containers/certs.d_.
 
 Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
 
+**--cni-config-dir**=*directory*
+
+Location of CNI configuration files which will dictate which plugins will be
+used to configure network interfaces and routing when the container is
+subsequently used for `buildah run`, if processes to be started will be run in
+their own network namespaces, and networking is not disabled.
+
+**--cni-plugin-path**=*directory[:directory[:directory[...]]]*
+
+List of directories in which the CNI plugins which will be used for configuring
+network namespaces can be found.
+
 **--cpu-period**=*0*
 
 Limit the CPU CFS (Completely Fair Scheduler) period

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -17,6 +17,34 @@ interactive shell, specify the --tty option.
 **--hostname**
 Set the hostname inside of the running container.
 
+**--ipc** *how*
+
+Sets the configuration for the IPC namespaces for the container.
+The configured value can be "" (the empty string) or "container" to indicate
+that a new IPC namespace should be created, or it can be "host" to indicate
+that the IPC namespace in which `buildah` itself is being run should be reused,
+or it can be the path to an IPC namespace which is already in use by another
+process.
+
+**--net** *how*
+**--network** *how*
+
+Sets the configuration for the network namespace for the container.
+The configured value can be "" (the empty string) or "container" to indicate
+that a new network namespace should be created, or it can be "host" to indicate
+that the network namespace in which `buildah` itself is being run should be
+reused, or it can be the path to a network namespace which is already in use by
+another process.
+
+**--pid** *how*
+
+Sets the configuration for the PID namespace for the container.
+The configured value can be "" (the empty string) or "container" to indicate
+that a new PID namespace should be created, or it can be "host" to indicate
+that the PID namespace in which `buildah` itself is being run should be reused,
+or it can be the path to a PID namespace which is already in use by another
+process.
+
 **--runtime** *path*
 
 The *path* to an alternate OCI-compatible runtime.
@@ -36,6 +64,23 @@ attached to a pseudo-TTY.  Setting the `--tty` option to `true` will cause a
 pseudo-TTY to be allocated inside the container connecting the user's "terminal"
 with the stdin and stdout stream of the container.  Setting the `--tty` option to
 `false` will prevent the pseudo-TTY from being allocated.
+
+**--user** *user*[:*group*]
+
+Set the *user* to be used for running the command in the container.
+The user can be specified as a user name
+or UID, optionally followed by a group name or GID, separated by a colon (':').
+If names are used, the container should include entries for those names in its
+*/etc/passwd* and */etc/group* files.
+
+**--uts** *how*
+
+Sets the configuration for the UTS namespace for the container.
+The configured value can be "" (the empty string) or "container" to indicate
+that a new UTS namespace should be created, or it can be "host" to indicate
+that the UTS namespace in which `buildah` itself is being run should be reused,
+or it can be the path to a UTS namespace which is already in use by another
+process.
 
 **--volume, -v** *source*:*destination*:*options*
 
@@ -104,6 +149,7 @@ will convert /foo into a `shared` mount point.  The propagation properties of th
 mount can be changed directly. For instance if `/` is the source mount for
 `/foo`, then use `mount --make-shared /` to convert `/` into a `shared` mount.
 
+
 NOTE: End parsing of options with the `--` option, so that other
 options can be passed to the command inside of the container.
 
@@ -124,4 +170,4 @@ buildah run --tty=false containerID ls /
 buildah run --volume /path/on/host:/path/in/container:ro,z containerID sh
 
 ## SEE ALSO
-buildah(1)
+buildah(1), namespaces(7), pid\_namespaces(7)

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -14,6 +14,18 @@ the *buildah config* command.  To execute *buildah run* within an
 interactive shell, specify the --tty option.
 
 ## OPTIONS
+**--cni-config-dir**=*directory*
+
+Location of CNI configuration files which will dictate which plugins will be
+used to configure network interfaces and routing inside the running container,
+if the container will be run in its own network namespace, and networking is
+not disabled.
+
+**--cni-plugin-path**=*directory[:directory[:directory[...]]]*
+
+List of directories in which the CNI plugins which will be used for configuring
+network namespaces can be found.
+
 **--hostname**
 Set the hostname inside of the running container.
 

--- a/docs/cni-examples/100-buildah-bridge.conf
+++ b/docs/cni-examples/100-buildah-bridge.conf
@@ -1,0 +1,17 @@
+{
+    "cniVersion": "0.3.1",
+    "name": "buildah-bridge",
+    "type": "bridge",
+    "bridge": "cni0",
+    "isGateway": true,
+    "ipMasq": true,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "10.88.0.0/16",
+        "routes": [
+            {
+                "dst": "0.0.0.0/0"
+            }
+        ]
+    }
+}

--- a/docs/cni-examples/200-loopback.conf
+++ b/docs/cni-examples/200-loopback.conf
@@ -1,0 +1,5 @@
+{
+    "cniVersion": "0.3.0",
+    "name": "loopback",
+    "type": "loopback"
+}

--- a/docs/cni-examples/README.md
+++ b/docs/cni-examples/README.md
@@ -1,0 +1,37 @@
+When [buildah](https://github.com/projectatomic/buildah)'s `buildah run`
+command is used, or when  `buildah build-using-dockerfile` needs to handle a
+`RUN` instruction, the processes which `buildah` starts are run in their own
+network namespace unless the `--network=host` option is used.
+
+When a network namespace is first created, it contains no network interfaces
+and is essentially disconnected from any networks that the host can access.
+
+In order to configure network interfaces and network access for those network
+namespaces, `buildah` uses the
+[CNI](https://github.com/containernetworking/cni) library, which in turn uses
+plugins ([CNI plugins](https://github.com/containernetworking/plugins), and
+possibly others).
+
+Which plugins get used, and how, is controlled using configuration files, which
+`buildah` scans `/etc/cni/net.d` to find.  By default, `buildah` expects to
+find plugins in `/opt/cni/bin`.
+
+This directory contains sample configuration files for the `loopback` and
+`bridge` plugins from the [CNI
+plugins](https://github.com/containernetworking/plugins) repository.  To
+install those plugins, try running:
+
+```
+  git clone https://github.com/containernetworking/plugins
+  ( cd ./plugins; ./build.sh )
+  mkdir -p /opt/cni/bin
+  install -v ./plugins/bin/* /opt/cni/bin
+```
+
+If you've already installed a CNI configuration (for example, for
+[CRI-O](https://github.com/kubernetes-incubator/cri-o)), it'll probably just
+work, but to install these sample configuration files:
+```
+  mkdir -p /etc/cni/net.d
+  install -v -m644 *.conf /etc/cni/net.d/
+```

--- a/image.go
+++ b/image.go
@@ -54,6 +54,7 @@ type containerImageRef struct {
 	preferredManifestType string
 	exporting             bool
 	squash                bool
+	tarPath               func(path string) (io.ReadCloser, error)
 }
 
 type containerImageSource struct {
@@ -132,10 +133,7 @@ func (i *containerImageRef) extractRootfs() (io.ReadCloser, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "error extracting container %q", i.containerID)
 	}
-	tarOptions := &archive.TarOptions{
-		Compression: archive.Uncompressed,
-	}
-	rc, err := archive.TarWithOptions(mountPoint, tarOptions)
+	rc, err := i.tarPath(mountPoint)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error extracting container %q", i.containerID)
 	}
@@ -623,6 +621,7 @@ func (b *Builder) makeImageRef(manifestType string, exporting bool, squash bool,
 		preferredManifestType: manifestType,
 		exporting:             exporting,
 		squash:                squash,
+		tarPath:               b.tarPath(),
 	}
 	return ref, nil
 }

--- a/install.md
+++ b/install.md
@@ -17,6 +17,38 @@ encounters a `RUN` instruction, so you'll also need to build and install a compa
 [runc](https://github.com/opencontainers/runc) for Buildah to call for those cases.  If Buildah is installed
 via a package manager such as yum, dnf or apt-get, runc will be installed as part of that process.
 
+### CNI Requirement
+
+When Buildah uses `runc` to run commands, it defaults to running those commands
+in the host's network namespace.  If the command is being run in a separate
+user namespace, though, for example when ID mapping is used, then the command
+will also be run in a separate network namespace.
+
+A newly-created network namespace starts with no network interfaces, so
+commands which are run in that namespace are effectively disconnected from the
+network unless additional setup is done.  Buildah relies on the CNI
+[library](https://github.com/containernetworking/cni) and
+[plugins](https://github.com/containernetworking/plugins) to set up interfaces
+and routing for network namespaces.
+
+If Buildah is installed via a package manager such as yum, dnf or apt-get, a
+package containing CNI plugins may be available (in Fedora, the package is
+named `containernetworking-cni`).  If not, they will need to be installed,
+for example using:
+```
+  git clone https://github.com/containernetworking/plugins
+  ( cd ./plugins; ./build.sh )
+  mkdir -p /opt/cni/bin
+  install -v ./plugins/bin/* /opt/cni/bin
+```
+
+The CNI library needs to be configured so that it will know which plugins to
+call to set up namespaces.  Usually, this configuration takes the form of one
+or more configuration files in the `/etc/cni/net.d` directory.  A set of example
+configuration files is included in the
+[`docs/cni-examples`](https://github.com/projectatomic/buildah/tree/master/docs/cni-examples)
+directory of this source tree.
+
 ## Package Installation
 
 Buildah is available on several software repositories and can be installed via a package manager such
@@ -66,7 +98,6 @@ In Fedora, you can use this command:
 
 Then to install Buildah on Fedora follow the steps in this example:
 
-
 ```
   mkdir ~/buildah
   cd ~/buildah
@@ -80,8 +111,8 @@ Then to install Buildah on Fedora follow the steps in this example:
 
 ### RHEL, CentOS
 
-In RHEL and CentOS 7, ensure that you are subscribed to `rhel-7-server-rpms`,
-`rhel-7-server-extras-rpms`, and `rhel-7-server-optional-rpms`, then
+In RHEL and CentOS 7, ensure that you are subscribed to the `rhel-7-server-rpms`,
+`rhel-7-server-extras-rpms`, and `rhel-7-server-optional-rpms` repositories, then
 run this command:
 
 ```
@@ -103,7 +134,7 @@ run this command:
     skopeo-containers
 ```
 
-The build steps for Buildah on RHEL or CentOS are the same as Fedora, above.
+The build steps for Buildah on RHEL or CentOS are the same as for Fedora, above.
 
 
 ### openSUSE
@@ -124,7 +155,7 @@ Currently openSUSE Leap 15 offers `go1.8` , while openSUSE Tumbleweed has `go1.9
     go-md2man
 ```
 
-The build steps for Buildah on SUSE / openSUSE are the same as Fedora, above.
+The build steps for Buildah on SUSE / openSUSE are the same as for Fedora, above.
 
 
 ### Ubuntu

--- a/new.go
+++ b/new.go
@@ -315,6 +315,9 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		MountLabel:            mountLabel,
 		DefaultMountsFilePath: options.DefaultMountsFilePath,
 		NamespaceOptions:      namespaceOptions,
+		ConfigureNetwork:      options.ConfigureNetwork,
+		CNIPluginPath:         options.CNIPluginPath,
+		CNIConfigDir:          options.CNIConfigDir,
 		IDMappingOptions: IDMappingOptions{
 			HostUIDMapping: len(uidmap) == 0,
 			HostGIDMapping: len(uidmap) == 0,

--- a/new.go
+++ b/new.go
@@ -278,6 +278,9 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 	if err != nil {
 		return nil, err
 	}
+	uidmap, gidmap := convertStorageIDMaps(container.UIDMap, container.GIDMap)
+	namespaceOptions := DefaultNamespaceOptions()
+	namespaceOptions.AddOrReplace(options.NamespaceOptions...)
 
 	builder := &Builder{
 		store:                 store,
@@ -293,7 +296,14 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		ProcessLabel:          processLabel,
 		MountLabel:            mountLabel,
 		DefaultMountsFilePath: options.DefaultMountsFilePath,
-		CommonBuildOpts:       options.CommonBuildOpts,
+		NamespaceOptions:      namespaceOptions,
+		IDMappingOptions: IDMappingOptions{
+			HostUIDMapping: len(uidmap) == 0,
+			HostGIDMapping: len(uidmap) == 0,
+			UIDMap:         uidmap,
+			GIDMap:         gidmap,
+		},
+		CommonBuildOpts: options.CommonBuildOpts,
 	}
 
 	if options.Mount {

--- a/new.go
+++ b/new.go
@@ -54,7 +54,7 @@ func reserveSELinuxLabels(store storage.Store, id string) error {
 					}
 					return err
 				}
-				// Prevent containers from using same MCS Label
+				// Prevent different containers from using same MCS label
 				if err := label.ReserveLabel(b.ProcessLabel); err != nil {
 					return err
 				}

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -7,6 +7,7 @@ package cli
 import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/projectatomic/buildah"
+	"github.com/projectatomic/buildah/util"
 	"github.com/urfave/cli"
 )
 
@@ -42,6 +43,16 @@ var (
 		cli.StringFlag{
 			Name:  string(specs.NetworkNamespace) + ", net",
 			Usage: "'container', `path` of network namespace to join, or 'host'",
+		},
+		cli.StringFlag{
+			Name:  "cni-config-dir",
+			Usage: "`directory` of CNI configuration files",
+			Value: util.DefaultCNIConfigDir,
+		},
+		cli.StringFlag{
+			Name:  "cni-plugin-path",
+			Usage: "`path` of CNI network plugins",
+			Value: util.DefaultCNIPluginPath,
 		},
 		cli.StringFlag{
 			Name:  string(specs.PIDNamespace),

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -5,11 +5,54 @@ package cli
 // that vendor in this code can use them too.
 
 import (
-	"github.com/projectatomic/buildah/imagebuildah"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/projectatomic/buildah"
 	"github.com/urfave/cli"
 )
 
 var (
+	usernsFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "userns",
+			Usage: "'container', `path` of user namespace to join, or 'host'",
+		},
+		cli.StringSliceFlag{
+			Name:  "userns-uid-map",
+			Usage: "`containerID:hostID:length` UID mapping to use in user namespace",
+		},
+		cli.StringSliceFlag{
+			Name:  "userns-gid-map",
+			Usage: "`containerID:hostID:length` GID mapping to use in user namespace",
+		},
+		cli.StringFlag{
+			Name:  "userns-uid-map-user",
+			Usage: "`name` of entries from /etc/subuid to use to set user namespace UID mapping",
+		},
+		cli.StringFlag{
+			Name:  "userns-gid-map-group",
+			Usage: "`name` of entries from /etc/subgid to use to set user namespace GID mapping",
+		},
+	}
+
+	NamespaceFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  string(specs.IPCNamespace),
+			Usage: "'container', `path` of IPC namespace to join, or 'host'",
+		},
+		cli.StringFlag{
+			Name:  string(specs.NetworkNamespace) + ", net",
+			Usage: "'container', `path` of network namespace to join, or 'host'",
+		},
+		cli.StringFlag{
+			Name:  string(specs.PIDNamespace),
+			Usage: "'container', `path` of PID namespace to join, or 'host'",
+		},
+		cli.StringFlag{
+			Name:  string(specs.UTSNamespace),
+			Usage: "'container', `path` of UTS namespace to join, or 'host'",
+		},
+	}
+
 	BudFlags = []cli.Flag{
 		cli.StringSliceFlag{
 			Name:  "annotation",
@@ -55,7 +98,7 @@ var (
 		},
 		cli.StringFlag{
 			Name:  "iidfile",
-			Usage: "Write the image ID to the file",
+			Usage: "`file` to write the image ID to",
 		},
 		cli.StringSliceFlag{
 			Name:  "label",
@@ -84,7 +127,7 @@ var (
 		cli.StringFlag{
 			Name:  "runtime",
 			Usage: "`path` to an alternate runtime",
-			Value: imagebuildah.DefaultRuntime,
+			Value: buildah.DefaultRuntime,
 		},
 		cli.StringSliceFlag{
 			Name:  "runtime-flag",
@@ -100,7 +143,7 @@ var (
 		},
 		cli.StringSliceFlag{
 			Name:  "tag, t",
-			Usage: "`tag` to apply to the built image",
+			Usage: "tagged `name` to apply to the built image",
 		},
 		cli.BoolTFlag{
 			Name:  "tls-verify",
@@ -108,7 +151,7 @@ var (
 		},
 	}
 
-	FromAndBudFlags = []cli.Flag{
+	FromAndBudFlags = append(append([]cli.Flag{
 		cli.StringSliceFlag{
 			Name:  "add-host",
 			Usage: "add a custom host-to-IP mapping (host:ip) (default [])",
@@ -162,5 +205,5 @@ var (
 			Name:  "volume, v",
 			Usage: "bind mount a volume into the container (default [])",
 		},
-	}
+	}, usernsFlags...), NamespaceFlags...)
 )

--- a/run.go
+++ b/run.go
@@ -778,6 +778,9 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	}
 	g.SetProcessUID(user.UID)
 	g.SetProcessGID(user.GID)
+	for _, gid := range user.AdditionalGids {
+		g.AddProcessAdditionalGid(gid)
+	}
 
 	// Now grab the spec from the generator.  Set the generator to nil so that future contributors
 	// will quickly be able to tell that they're supposed to be modifying the spec directly from here.

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -1,0 +1,378 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "user-and-network-namespace" {
+  mkdir -p $TESTDIR/no-cni-configs
+  RUNOPTS="--cni-config-dir=${TESTDIR}/no-cni-configs ${RUNC_BINARY:+--runtime $RUNC_BINARY}"
+  # Check if we're running in an environment that can even test this.
+  run readlink /proc/self/ns/user
+  echo "$output"
+  [ $status -eq 0 ] || skip "user namespaces not supported"
+  run readlink /proc/self/ns/net
+  echo "$output"
+  [ $status -eq 0 ] || skip "network namespaces not supported"
+  mynetns="$output"
+
+  # Generate the mappings to use for using-a-user-namespace cases.
+  uidbase=$((${RANDOM}+1024))
+  gidbase=$((${RANDOM}+1024))
+  uidsize=$((${RANDOM}+1024))
+  gidsize=$((${RANDOM}+1024))
+
+  # Create a container that uses that mapping.
+  run buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --quiet --userns-uid-map 0:$uidbase:$uidsize --userns-gid-map 0:$gidbase:$gidsize alpine
+  echo "$output"
+  [ $status -eq 0 ]
+  [ "$output" != "" ]
+  ctr="$output"
+
+  # Check that with settings that require a user namespace, we also get a new network namespace by default.
+  buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/net
+  run buildah --debug=false run $RUNOPTS "$ctr" readlink /proc/self/ns/net
+  echo "$output"
+  [ $status -eq 0 ]
+  [ "$output" != "" ]
+  [ "$output" != "$mynetns" ]
+
+  # Check that with settings that require a user namespace, we can still try to use the host's network namespace.
+  buildah run $RUNOPTS --net=host "$ctr" readlink /proc/self/ns/net
+  run buildah --debug=false run $RUNOPTS --net=host "$ctr" readlink /proc/self/ns/net
+  echo "$output"
+  [ $status -eq 0 ]
+  [ "$output" != "" ]
+  [ "$output" == "$mynetns" ]
+
+  # Create a container that doesn't use that mapping.
+  run buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --quiet alpine
+  echo "$output"
+  [ $status -eq 0 ]
+  [ "$output" != "" ]
+  ctr="$output"
+
+  # Check that with settings that don't require a user namespace, we don't get a new network namespace by default.
+  buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/net
+  run buildah --debug=false run $RUNOPTS "$ctr" readlink /proc/self/ns/net
+  echo "$output"
+  [ $status -eq 0 ]
+  [ "$output" != "" ]
+  [ "$output" == "$mynetns" ]
+
+  # Check that with settings that don't require a user namespace, we can request to use a per-container network namespace.
+  buildah run $RUNOPTS --net=container "$ctr" readlink /proc/self/ns/net
+  run buildah --debug=false run $RUNOPTS --net=container "$ctr" readlink /proc/self/ns/net
+  echo "$output"
+  [ $status -eq 0 ]
+  [ "$output" != "" ]
+  [ "$output" != "$mynetns" ]
+}
+
+@test "idmapping" {
+  mkdir -p $TESTDIR/no-cni-configs
+  RUNOPTS="--cni-config-dir=${TESTDIR}/no-cni-configs ${RUNC_BINARY:+--runtime $RUNC_BINARY}"
+
+  # Check if we're running in an environment that can even test this.
+  run readlink /proc/self/ns/user
+  echo "$output"
+  [ $status -eq 0 ] || skip "user namespaces not supported"
+  mynamespace="$output"
+
+  # Generate the mappings to use.
+  uidbase=$((${RANDOM}+1024))
+  gidbase=$((${RANDOM}+1024))
+  uidsize=$((${RANDOM}+1024))
+  gidsize=$((${RANDOM}+1024))
+  # Test with no mappings.
+  maps[0]=
+  uidmaps[0]="0 0 4294967295"
+  gidmaps[0]="0 0 4294967295"
+  # Test with both UID and GID maps specified.
+  maps[1]="--userns-uid-map=0:$uidbase:$uidsize --userns-gid-map=0:$gidbase:$gidsize"
+  uidmaps[1]="0 $uidbase $uidsize"
+  gidmaps[1]="0 $gidbase $gidsize"
+  # Test with just a UID map specified.
+  maps[2]=--userns-uid-map=0:$uidbase:$uidsize
+  uidmaps[2]="0 $uidbase $uidsize"
+  gidmaps[2]="0 $uidbase $uidsize"
+  # Test with just a GID map specified.
+  maps[3]=--userns-gid-map=0:$gidbase:$gidsize
+  uidmaps[3]="0 $gidbase $gidsize"
+  gidmaps[3]="0 $gidbase $gidsize"
+  # Conditionalize some tests on the subuid and subgid files being present.
+  if test -s /etc/subuid ; then
+    if test -s /etc/subgid ; then
+      # Look for a name that's in both the subuid and subgid files.
+      for candidate in $(sed -e 's,:.*,,g' /etc/subuid); do
+        if test $(sed -e 's,:.*,,g' -e "/$candidate/!d" /etc/subgid) == "$candidate"; then
+          # Read the start of the subuid/subgid ranges.  Assume length=65536.
+          userbase=$(sed -e "/^${candidate}:/!d" -e 's,^[^:]*:,,g' -e 's,:[^:]*,,g' /etc/subuid)
+          groupbase=$(sed -e "/^${candidate}:/!d" -e 's,^[^:]*:,,g' -e 's,:[^:]*,,g' /etc/subgid)
+          # Test specifying both the user and group names.
+          maps[${#maps[*]}]="--userns-uid-map-user $candidate --userns-gid-map-group $candidate"
+          uidmaps[${#uidmaps[*]}]="0 $userbase 65536"
+          gidmaps[${#gidmaps[*]}]="0 $groupbase 65536"
+          # Test specifying just the user name.
+          maps[${#maps[*]}]="--userns-uid-map-user $candidate"
+          uidmaps[${#uidmaps[*]}]="0 $userbase 65536"
+          gidmaps[${#gidmaps[*]}]="0 $groupbase 65536"
+          # Test specifying just the group name.
+          maps[${#maps[*]}]="--userns-gid-map-group $candidate"
+          uidmaps[${#uidmaps[*]}]="0 $userbase 65536"
+          gidmaps[${#gidmaps[*]}]="0 $groupbase 65536"
+          break
+        fi
+      done
+      # Choose different names from the files.
+      for candidateuser in $(sed -e 's,:.*,,g' /etc/subuid); do
+        for candidategroup in $(sed -e 's,:.*,,g' /etc/subgid); do
+          if test "$candidateuser" == "$candidate" ; then
+            continue
+          fi
+          if test "$candidategroup" == "$candidate" ; then
+            continue
+          fi
+          if test "$candidateuser" == "$candidategroup" ; then
+            continue
+          fi
+          # Read the start of the ranges.  Assume length=65536.
+          userbase=$(sed -e "/^${candidateuser}:/!d" -e 's,^[^:]*:,,g' -e 's,:[^:]*,,g' /etc/subuid)
+          groupbase=$(sed -e "/^${candidategroup}:/!d" -e 's,^[^:]*:,,g' -e 's,:[^:]*,,g' /etc/subgid)
+          # Test specifying both the user and group names.
+          maps[${#maps[*]}]="--userns-uid-map-user $candidateuser --userns-gid-map-group $candidategroup"
+          uidmaps[${#uidmaps[*]}]="0 $userbase 65536"
+          gidmaps[${#gidmaps[*]}]="0 $groupbase 65536"
+          break
+        done
+      done
+    fi
+  fi
+
+  touch ${TESTDIR}/somefile
+  mkdir ${TESTDIR}/somedir
+  touch ${TESTDIR}/somedir/someotherfile
+  chmod 700 ${TESTDIR}/somedir/someotherfile
+  chmod u+s ${TESTDIR}/somedir/someotherfile
+
+  for i in $(seq 0 "$((${#maps[*]}-1))") ; do
+    # Create a container using these mappings.
+    map="${maps[$i]}"
+    run buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --quiet $map alpine
+    echo "$output"
+    [ $status -eq 0 ]
+    [ "$output" != "" ]
+    ctr="$output"
+
+    # If we specified mappings, expect to be in a different namespace by default.
+    buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/user
+    run buildah --debug=false run $RUNOPTS "$ctr" readlink /proc/self/ns/user
+    echo "$output"
+    [ $status -eq 0 ]
+    [ "$output" != "" ]
+    case x"$map" in
+    x)
+      [ "$output" == "$mynamespace" ]
+      ;;
+    *)
+      [ "$output" != "$mynamespace" ]
+      ;;
+    esac
+    # Check that we got the mappings that we expected.
+    buildah run $RUNOPTS "$ctr" cat /proc/self/uid_map
+    run buildah --debug=false run $RUNOPTS "$ctr" cat /proc/self/uid_map
+    echo "$output"
+    [ $status -eq 0 ]
+    [ "$output" != "" ]
+    uidmap=$(sed -E -e 's, +, ,g' -e 's,^ +,,g' <<< "$output")
+    buildah run $RUNOPTS "$ctr" cat /proc/self/gid_map
+    run buildah --debug=false run $RUNOPTS "$ctr" cat /proc/self/gid_map
+    echo "$output"
+    [ $status -eq 0 ]
+    [ "$output" != "" ]
+    gidmap=$(sed -E -e 's, +, ,g' -e 's,^ +,,g' <<< "$output")
+    echo With settings "$map", expected UID map "${uidmaps[$i]}", got UID map "${uidmap}", expected GID map "${gidmaps[$i]}", got GID map "${gidmap}".
+    [ "$uidmap" == "${uidmaps[$i]}" ]
+    [ "$gidmap" == "${gidmaps[$i]}" ]
+    rootuid=$(sed -E -e 's,^([^ ]*) (.*) ([^ ]*),\2,' <<< "$uidmap")
+    rootgid=$(sed -E -e 's,^([^ ]*) (.*) ([^ ]*),\2,' <<< "$gidmap")
+
+    # Check that if we copy a file into the container, it gets the right permissions.
+    run buildah copy --chown 1:1 "$ctr" ${TESTDIR}/somefile /
+    echo "$output"
+    [ $status -eq 0 ]
+    buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somefile
+    run buildah --debug=false run $RUNOPTS "$ctr" stat -c '%u:%g' /somefile
+    echo "$output"
+    [ $status -eq 0 ]
+    [ "$output" = "1:1" ]
+
+    # Check that if we copy a directory into the container, its contents get the right permissions.
+    run buildah copy "$ctr" ${TESTDIR}/somedir /somedir
+    echo "$output"
+    [ $status -eq 0 ]
+    buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somedir
+    run buildah --debug=false run $RUNOPTS "$ctr" stat -c '%u:%g' /somedir
+    echo "$output"
+    [ $status -eq 0 ]
+    [ "$output" = "0:0" ]
+    run buildah --debug=false mount "$ctr"
+    echo "$output"
+    [ $status -eq 0 ]
+    mnt="$output"
+    run stat -c '%u:%g %a' "$mnt"/somedir/someotherfile
+    echo expecting owner/permissions "$rootuid:$rootgid 4700" ]
+    echo "$output"
+    [ $status -eq 0 ]
+    [ "$output" = "$rootuid:$rootgid 4700" ]
+    buildah run $RUNOPTS "$ctr" stat -c '%u:%g %a' /somedir/someotherfile
+    run buildah --debug=false run $RUNOPTS "$ctr" stat -c '%u:%g %a' /somedir/someotherfile
+    echo "$output"
+    [ $status -eq 0 ]
+    [ "$output" = "0:0 4700" ]
+  done
+}
+
+general_namespace() {
+  mkdir -p $TESTDIR/no-cni-configs
+  RUNOPTS="--cni-config-dir=${TESTDIR}/no-cni-configs ${RUNC_BINARY:+--runtime $RUNC_BINARY}"
+
+  # The name of the /proc/self/ns/$link.
+  nstype="$1"
+  # The flag to use, if it's not the same as the namespace name.
+  nsflag="${2:-$1}"
+
+  # Check if we're running in an environment that can even test this.
+  run readlink /proc/self/ns/"$nstype"
+  echo "$output"
+  [ $status -eq 0 ] || skip "$nstype namespaces not supported"
+  mynamespace="$output"
+
+  # Settings to test.
+  types[0]=
+  types[1]=container
+  types[2]=host
+  types[3]=/proc/$$/ns/$nstype
+
+  for namespace in "${types[@]}" ; do
+    # Specify the setting for this namespace for this container.
+    run buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --quiet --"$nsflag"=$namespace alpine
+    echo "$output"
+    [ $status -eq 0 ]
+    [ "$output" != "" ]
+    ctr="$output"
+
+    # Check that, unless we override it, we get that setting in "run".
+    run buildah --debug=false run $RUNOPTS "$ctr" readlink /proc/self/ns/"$nstype"
+    echo "$output"
+    [ $status -eq 0 ]
+    [ "$output" != "" ]
+    case "$namespace" in
+    ""|container)
+      [ "$output" != "$mynamespace" ]
+      ;;
+    host)
+      [ "$output" == "$mynamespace" ]
+      ;;
+    /*)
+      [ "$output" == $(readlink "$namespace") ]
+      ;;
+    esac
+
+    for different in $types ; do
+      # Check that, if we override it, we get what we specify for "run".
+      run buildah --debug=false run $RUNOPTS --"$nsflag"=$different "$ctr" readlink /proc/self/ns/"$nstype"
+      echo "$output"
+      [ $status -eq 0 ]
+      [ "$output" != "" ]
+      case "$different" in
+      ""|container)
+        [ "$output" != "$mynamespace" ]
+        ;;
+      host)
+        [ "$output" == "$mynamespace" ]
+        ;;
+      /*)
+        [ "$output" == $(readlink "$namespace") ]
+        ;;
+      esac
+    done
+
+  done
+}
+
+@test "ipc-namespace" {
+  general_namespace ipc
+}
+
+@test "net-namespace" {
+  general_namespace net
+}
+
+@test "network-namespace" {
+  general_namespace net network
+}
+
+@test "pid-namespace" {
+  general_namespace pid
+}
+
+@test "user-namespace" {
+  general_namespace user userns
+}
+
+@test "uts-namespace" {
+  general_namespace uts
+}
+
+@test "combination-namespaces" {
+  # mnt is always per-container, cgroup isn't a thing runc lets us configure
+  for ipc in host container ; do
+    for net in host container ; do
+      for pid in host container ; do
+        for userns in host container ; do
+          for uts in host container ; do
+
+            if test $userns == container -a $pid == host ; then
+              # We can't mount a fresh /proc, and runc won't let us bind mount the host's.
+              continue
+            fi
+
+            echo "buildah from --signature-policy ${TESTSDIR}/policy.json --ipc=$ipc --net=$net --pid=$pid --userns=$userns --uts=$uts alpine"
+            run buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --quiet --ipc=$ipc --net=$net --pid=$pid --userns=$userns --uts=$uts alpine
+            echo "$output"
+            [ $status -eq 0 ]
+            [ "$output" != "" ]
+            ctr="$output"
+            buildah run $ctr pwd
+            run buildah --debug=false run $ctr pwd
+            echo "$output"
+            [ $status -eq 0 ]
+            [ "$output" != "" ]
+            buildah run --tty=true  $ctr pwd
+            run buildah --debug=false run --tty=true  $ctr pwd
+            echo "$output"
+            [ $status -eq 0 ]
+            [ "$output" != "" ]
+            buildah run --tty=false $ctr pwd
+            run buildah --debug=false run --tty=false $ctr pwd
+            echo "$output"
+            [ $status -eq 0 ]
+            [ "$output" != "" ]
+          done
+        done
+      done
+    done
+  done
+}
+
+@test "idmapping-and-squash" {
+	createrandom ${TESTDIR}/randomfile
+	cid=$(buildah from --userns-uid-map 0:32:16 --userns-gid-map 0:48:16 scratch)
+	buildah copy "$cid" ${TESTDIR}/randomfile /
+	buildah commit --squash --signature-policy ${TESTSDIR}/policy.json --rm "$cid" squashed
+	cid=$(buildah from squashed)
+	mountpoint=$(buildah mount $cid)
+	run stat -c %u:%g $mountpoint/randomfile
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[ "$output" = 0:0 ]
+}

--- a/tests/selinux.bats
+++ b/tests/selinux.bats
@@ -3,24 +3,33 @@
 load helpers
 
 @test "selinux test" {
-  if ! which selinuxenabled ; then
+  if ! which selinuxenabled > /dev/null 2> /dev/null ; then
     skip "No selinuxenabled"
-   elif ! /usr/sbin/selinuxenabled; then
-     skip "selinux is disabled"
+  elif ! selinuxenabled ; then
+    skip "selinux is disabled"
   fi
+
   image=alpine
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $image)
-  firstlabel=$(buildah --debug=false run $cid cat /proc/1/attr/current)
-  run buildah --debug=false run $cid cat /proc/1/attr/current
-  [ "$status" -eq 0 ]
-  [ "$output" == $firstlabel ]
 
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $image)
-  run buildah --debug=false run $cid1 cat /proc/1/attr/current
+  # Create a container and read its context as a baseline.
+  cid=$(buildah --debug=false from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  run buildah --debug=false run $cid sh -c 'tr \\0 \\n < /proc/1/attr/current'
+  echo "$output"
   [ "$status" -eq 0 ]
-  [ "$output" != $firstlabel ]
+  [ "$output" != "" ]
+  firstlabel="$output"
 
-  buildah rm $cid
-  buildah rm $cid1
+  # Ensure that we label the same container consistently across multiple "run" instructions.
+  run buildah --debug=false run $cid sh -c 'tr \\0 \\n < /proc/1/attr/current'
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ "$output" == "$firstlabel" ]
+
+  # Ensure that different containers get different labels.
+  cid1=$(buildah --debug=false from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  run buildah --debug=false run $cid1 sh -c 'tr \\0 \\n < /proc/1/attr/current'
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ "$output" != "$firstlabel" ]
 }
 

--- a/util.go
+++ b/util.go
@@ -36,6 +36,15 @@ func copyStringSlice(s []string) []string {
 	return t
 }
 
+func stringInSlice(s string, slice []string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
 func convertStorageIDMaps(UIDMap, GIDMap []idtools.IDMap) ([]rspec.LinuxIDMapping, []rspec.LinuxIDMapping) {
 	uidmap := make([]rspec.LinuxIDMapping, 0, len(UIDMap))
 	gidmap := make([]rspec.LinuxIDMapping, 0, len(GIDMap))

--- a/util.go
+++ b/util.go
@@ -2,7 +2,9 @@ package buildah
 
 import (
 	"github.com/containers/storage/pkg/chrootarchive"
+	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/reexec"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 var (
@@ -31,4 +33,24 @@ func copyStringSlice(s []string) []string {
 	t := make([]string, len(s))
 	copy(t, s)
 	return t
+}
+
+func convertStorageIDMaps(UIDMap, GIDMap []idtools.IDMap) ([]rspec.LinuxIDMapping, []rspec.LinuxIDMapping) {
+	uidmap := make([]rspec.LinuxIDMapping, 0, len(UIDMap))
+	gidmap := make([]rspec.LinuxIDMapping, 0, len(GIDMap))
+	for _, m := range UIDMap {
+		uidmap = append(uidmap, rspec.LinuxIDMapping{
+			HostID:      uint32(m.HostID),
+			ContainerID: uint32(m.ContainerID),
+			Size:        uint32(m.Size),
+		})
+	}
+	for _, m := range GIDMap {
+		gidmap = append(gidmap, rspec.LinuxIDMapping{
+			HostID:      uint32(m.HostID),
+			ContainerID: uint32(m.ContainerID),
+			Size:        uint32(m.Size),
+		})
+	}
+	return uidmap, gidmap
 }

--- a/util/types.go
+++ b/util/types.go
@@ -1,0 +1,10 @@
+package util
+
+const (
+	// DefaultRuntime is the default command to use to run the container.
+	DefaultRuntime = "runc"
+	// DefaultCNIPluginPath is the default location of CNI plugin helpers.
+	DefaultCNIPluginPath = "/usr/libexec/cni:/opt/cni/bin"
+	// DefaultCNIConfigDir is the default location of CNI configuration files.
+	DefaultCNIConfigDir = "/etc/cni/net.d"
+)


### PR DESCRIPTION
This patch set wires in command line flags to select our strategy for using some of the namespace types when creating containers and running commands in them.
With user namespacing available, it properly sets up ID mapping for user namespaces when asked to do so for a container, and adopts the "intermediate bind mount" strategy from libpod to mount everything.
When creating a network namespace, it can now use CNI plugins to configure networking for the container's namespace.
It now handles passing data back and forth between the controlling terminal and a pseudo-terminal that it creates for a command being executed in the container, in order to have stdio still work when user namespaces with non-default mappings are being used, as the command would not normally be able to write to the controlling terminal.