### PR TITLE
API: make PullPolicy and TerminalPolicy their own types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LDFLAGS := -ldflags '-X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_I
 
 all: buildah imgtype docs
 
-buildah: *.go imagebuildah/*.go cmd/buildah/*.go docker/*.go util/*.go
+buildah: *.go imagebuildah/*.go cmd/buildah/*.go docker/*.go pkg/cli/*.go pkg/parse/*.go util/*.go
 	$(GO) build $(LDFLAGS) -o buildah $(BUILDFLAGS) ./cmd/buildah
 
 imgtype: *.go docker/*.go util/*.go tests/imgtype/imgtype.go

--- a/buildah.go
+++ b/buildah.go
@@ -3,6 +3,7 @@ package buildah
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -35,11 +36,14 @@ const (
 	stateFile = Package + ".json"
 )
 
+// PullPolicy takes the value PullIfMissing, PullAlways, or PullNever.
+type PullPolicy int
+
 const (
 	// PullIfMissing is one of the values that BuilderOptions.PullPolicy
 	// can take, signalling that the source image should be pulled from a
 	// registry if a local copy of it is not already present.
-	PullIfMissing = iota
+	PullIfMissing PullPolicy = iota
 	// PullAlways is one of the values that BuilderOptions.PullPolicy can
 	// take, signalling that a fresh, possibly updated, copy of the image
 	// should be pulled from a registry before the build proceeds.
@@ -49,6 +53,19 @@ const (
 	// registry if a local copy of it is not already present.
 	PullNever
 )
+
+// String converts a PullPolicy into a string.
+func (p PullPolicy) String() string {
+	switch p {
+	case PullIfMissing:
+		return "PullIfMissing"
+	case PullAlways:
+		return "PullAlways"
+	case PullNever:
+		return "PullNever"
+	}
+	return fmt.Sprintf("unrecognized policy %d", p)
+}
 
 // Builder objects are used to represent containers which are being used to
 // build images.  They also carry potential updates which will be applied to
@@ -184,7 +201,7 @@ type BuilderOptions struct {
 	// PullPolicy decides whether or not we should pull the image that
 	// we're using as a base image.  It should be PullIfMissing,
 	// PullAlways, or PullNever.
-	PullPolicy int
+	PullPolicy PullPolicy
 	// Registry is a value which is prepended to the image's name, if it
 	// needs to be pulled and the image name alone can not be resolved to a
 	// reference to a source image.  No separator is implicitly added.

--- a/image.go
+++ b/image.go
@@ -440,15 +440,15 @@ func (i *containerImageSource) Reference() types.ImageReference {
 }
 
 func (i *containerImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
-	if instanceDigest != nil && *instanceDigest != digest.FromBytes(i.manifest) {
-		return nil, errors.Errorf("TODO")
+	if instanceDigest != nil {
+		return nil, errors.Errorf("containerImageSource does not support manifest lists")
 	}
 	return nil, nil
 }
 
 func (i *containerImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
-	if instanceDigest != nil && *instanceDigest != digest.FromBytes(i.manifest) {
-		return nil, "", errors.Errorf("TODO")
+	if instanceDigest != nil {
+		return nil, "", errors.Errorf("containerImageSource does not support manifest lists")
 	}
 	return i.manifest, i.manifestType, nil
 }

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -51,7 +51,7 @@ type BuildOptions struct {
 	ContextDirectory string
 	// PullPolicy controls whether or not we pull images.  It should be one
 	// of PullIfMissing, PullAlways, or PullNever.
-	PullPolicy int
+	PullPolicy buildah.PullPolicy
 	// Registry is a value which is prepended to the image's name, if it
 	// needs to be pulled and the image name alone can not be resolved to a
 	// reference to a source image.  No separator is implicitly added.
@@ -126,7 +126,7 @@ type Executor struct {
 	store                          storage.Store
 	contextDir                     string
 	builder                        *buildah.Builder
-	pullPolicy                     int
+	pullPolicy                     buildah.PullPolicy
 	registry                       string
 	transport                      string
 	ignoreUnrecognizedInstructions bool

--- a/run.go
+++ b/run.go
@@ -31,10 +31,13 @@ const (
 	DefaultRuntime = "runc"
 )
 
+// TerminalPolicy takes the value DefaultTerminal, WithoutTerminal, or WithTerminal.
+type TerminalPolicy int
+
 const (
 	// DefaultTerminal indicates that this Run invocation should be
 	// connected to a pseudoterminal if we're connected to a terminal.
-	DefaultTerminal = iota
+	DefaultTerminal TerminalPolicy = iota
 	// WithoutTerminal indicates that this Run invocation should NOT be
 	// connected to a pseudoterminal.
 	WithoutTerminal
@@ -42,6 +45,19 @@ const (
 	// to a pseudoterminal.
 	WithTerminal
 )
+
+// String converts a TerminalPoliicy into a string.
+func (t TerminalPolicy) String() string {
+	switch t {
+	case DefaultTerminal:
+		return "DefaultTerminal"
+	case WithoutTerminal:
+		return "WithoutTerminal"
+	case WithTerminal:
+		return "WithTerminal"
+	}
+	return fmt.Sprintf("unrecognized terminal setting %d", t)
+}
 
 // RunOptions can be used to alter how a command is run in the container.
 type RunOptions struct {
@@ -72,7 +88,7 @@ type RunOptions struct {
 	// terminal is used if os.Stdout is connected to a terminal, but that
 	// decision can be overridden by specifying either WithTerminal or
 	// WithoutTerminal.
-	Terminal int
+	Terminal TerminalPolicy
 	// Quiet tells the run to turn off output to stdout.
 	Quiet bool
 }

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -7,8 +7,8 @@ STORAGE_DRIVER=${STORAGE_DRIVER:-vfs}
 PATH=$(dirname ${BASH_SOURCE})/..:${PATH}
 
 function setup() {
-	suffix=$(dd if=/dev/urandom bs=12 count=1 status=none | base64 | tr +/ABCDEFGHIJKLMNOPQRSTUVWXYZ _.abcdefghijklmnopqrstuvwxyz)
-	TESTDIR=${BATS_TMPDIR}/tmp.${suffix}
+	suffix=$(dd if=/dev/urandom bs=12 count=1 status=none | od -An -tx1 | sed -e 's, ,,g')
+	TESTDIR=${BATS_TMPDIR}/tmp${suffix}
 	rm -fr ${TESTDIR}
 	mkdir -p ${TESTDIR}/{root,runroot}
 }


### PR DESCRIPTION
Make PullPolicy and TerminalPolicy their own types, instead of just integer values, so that we can give them a `String()` method, and return more informative errors from a couple of `containerImageSource` methods when they're asked for particular manifest instances, which it doesn't support.