### PR TITLE
Fix buildah from docker.io/centos:7 pull

### DIFF
--- a/new.go
+++ b/new.go
@@ -133,6 +133,18 @@ func imageManifestAndConfig(ctx context.Context, ref types.ImageReference, syste
 	return nil, nil, nil
 }
 
+// Adds default transport if the image is not empty and does not have a transport
+func addTransport(image, transport string) string {
+	if image == "" {
+		return image
+	}
+
+	if _, err := alltransports.ParseImageName(image); err != nil {
+		return fmt.Sprintf("%s%s", transport, image)
+	}
+	return image
+}
+
 func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions) (*Builder, error) {
 	var ref types.ImageReference
 	var img *storage.Image
@@ -146,6 +158,8 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 	if options.Transport == "" {
 		options.Transport = DefaultTransport
 	}
+
+	options.FromImage = addTransport(options.FromImage, options.Transport)
 
 	systemContext := getSystemContext(options.SystemContext, options.SignaturePolicyPath)
 


### PR DESCRIPTION
Currently buildah does not parse the docker.io syntax correcly.
In the example above it should parse this to docker.io/library/centos:7

The change in this patch will check to see if the user specified a transport
if not, then it will append the default transport "docker://" and containers/image
takes care of the rest.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>