### PR TITLE
util.ResolveName(): handle completion for tagged/digested image names

### DIFF
--- a/tests/from.bats
+++ b/tests/from.bats
@@ -127,6 +127,22 @@ load helpers
   [ "$cid" == alpine2-working-container ]
   buildah rm ${cid}
   buildah rmi alpine alpine2
+
+  cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+  buildah rm ${cid}
+  buildah rmi docker.io/alpine
+
+  cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/alpine:latest)
+  buildah rm ${cid}
+  buildah rmi docker.io/alpine:latest
+
+  cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/centos:7)
+  buildah rm ${cid}
+  buildah rmi docker.io/centos:7
+
+  cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/centos:latest)
+  buildah rm ${cid}
+  buildah rmi docker.io/centos:latest
 }
 
 @test "from the following transports: docker-archive, oci-archive, and dir" {

--- a/util/util.go
+++ b/util/util.go
@@ -70,7 +70,7 @@ func ResolveName(name string, firstRegistry string, sc *types.SystemContext, sto
 		}
 	}
 
-	// If the image is from a different transport
+	// If the image includes a transport's name as a prefix, use it as-is.
 	split := strings.SplitN(name, ":", 2)
 	if len(split) == 2 {
 		if _, ok := Transports[split[0]]; ok {
@@ -91,8 +91,16 @@ func ResolveName(name string, firstRegistry string, sc *types.SystemContext, sto
 		// If this domain can cause us to insert something in the middle, check if that happened.
 		repoPath := reference.Path(named)
 		domain := reference.Domain(named)
+		tag := ""
+		if tagged, ok := named.(reference.Tagged); ok {
+			tag = ":" + tagged.Tag()
+		}
+		digest := ""
+		if digested, ok := named.(reference.Digested); ok {
+			digest = "@" + digested.Digest().String()
+		}
 		defaultPrefix := RegistryDefaultPathPrefix[reference.Domain(named)] + "/"
-		if strings.HasPrefix(repoPath, defaultPrefix) && path.Join(domain, repoPath[len(defaultPrefix):]) == name {
+		if strings.HasPrefix(repoPath, defaultPrefix) && path.Join(domain, repoPath[len(defaultPrefix):])+tag+digest == name {
 			// Yup, parsing just inserted a bit in the middle, so there was a domain name there to begin with.
 			return []string{name}
 		}


### PR DESCRIPTION
When checking if an image name includes a registry name, when checking for cases where parsing it inserts additional path components, handle cases where the provided name includes a tag or digest component.