### PR TITLE
build-using-dockerfile: add --annotation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,4 +63,4 @@ script:
     - make install.tools install.libseccomp.sudo all runc validate TAGS="apparmor seccomp containers_image_ostree_stub"
     - go test -c -tags "apparmor seccomp `./btrfs_tag.sh` `./libdm_tag.sh` `./ostree_tag.sh` `./selinux_tag.sh`" ./cmd/buildah
     - tmp=`mktemp -d`; mkdir $tmp/root $tmp/runroot; sudo PATH="$PATH" ./buildah.test -test.v -root $tmp/root -runroot $tmp/runroot -storage-driver vfs -signature-policy `pwd`/tests/policy.json -registries-conf `pwd`/tests/registries.conf
-    - cd tests; sudo PATH="$PATH" ./test_runner.sh
+    - cd tests; travis_wait sudo PATH="$PATH" ./test_runner.sh

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -185,6 +185,7 @@ func budCmd(c *cli.Context) error {
 		IIDFile:               c.String("iidfile"),
 		Squash:                c.Bool("squash"),
 		Labels:                c.StringSlice("label"),
+		Annotations:           c.StringSlice("annotation"),
 	}
 
 	if !c.Bool("quiet") {

--- a/commit.go
+++ b/commit.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"strings"
 	"time"
 
 	cp "github.com/containers/image/copy"
@@ -53,8 +52,6 @@ type CommitOptions struct {
 	// Squash tells the builder to produce an image with a single layer
 	// instead of with possibly more than one layer.
 	Squash bool
-	// Labels metadata for an image
-	Labels []string
 }
 
 // PushOptions can be used to alter how an image is copied somewhere.
@@ -88,15 +85,6 @@ type PushOptions struct {
 // if commit was successful and the image destination was local
 func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options CommitOptions) (string, error) {
 	var imgID string
-
-	for _, labelSpec := range options.Labels {
-		label := strings.SplitN(labelSpec, "=", 2)
-		if len(label) > 1 {
-			b.SetLabel(label[0], label[1])
-		} else {
-			b.SetLabel(label[0], "")
-		}
-	}
 
 	systemContext := getSystemContext(options.SystemContext, options.SignaturePolicyPath)
 	policy, err := signature.DefaultPolicy(systemContext)

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -366,6 +366,7 @@ return 1
 
      local options_with_args="
      --add-host
+     --annotation
      --authfile
      --build-arg
      --cert-dir

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -26,6 +26,12 @@ Add a custom host-to-IP mapping (host:ip)
 
 Add a line to /etc/hosts. The format is hostname:ip. The **--add-host** option can be set multiple times.
 
+**--annotation** *annotation*
+
+Add an image *annotation* (e.g. annotation=*value*) to the image metadata. Can be used multiple times.
+
+Note: this information is not present in Docker image formats, so it is discarded when writing images in Docker formats.
+
 **--authfile** *path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -11,6 +11,10 @@ import (
 
 var (
 	BudFlags = []cli.Flag{
+		cli.StringSliceFlag{
+			Name:  "annotation",
+			Usage: "Set metadata for an image (default [])",
+		},
 		cli.StringFlag{
 			Name:  "authfile",
 			Usage: "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -37,6 +37,16 @@ load helpers
   buildah rmi ${target}
 }
 
+@test "bud-from-scratch-annotation" {
+  target=scratch-image
+  buildah bud --annotation "test=annotation" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run buildah --debug=false inspect --format '{{printf "%q" .ImageAnnotations}}' ${target}
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = 'map["test":"annotation"]' ]
+  buildah rmi ${target}
+}
+
 @test "bud-from-multiple-files-one-from" {
   target=scratch-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.nofrom


### PR DESCRIPTION
Add an `--annotation` flag to "buildah build-using-dockerfile".

Refactor the logic for `--label` handling to use `SetLabel()` to set them in the image configuration in `Executor.Commit()`, instead of passing them as a field in `CommitOptions` for `Builder.Commit()` and expecting it to do so.