### PR TITLE
buildah bud picks up ENV from base image

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -705,7 +705,6 @@ func (b *Executor) Commit(ctx context.Context, ib *imagebuilder.Builder) (err er
 	for p := range config.ExposedPorts {
 		b.builder.SetPort(string(p))
 	}
-	b.builder.ClearEnv()
 	for _, envSpec := range config.Env {
 		spec := strings.SplitN(envSpec, "=", 2)
 		b.builder.SetEnv(spec[0], spec[1])

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2,6 +2,18 @@
 
 load helpers
 
+@test "bud from base image should have base image ENV also" {
+  buildah bud --signature-policy ${TESTSDIR}/policy.json -t test -f ${TESTSDIR}/bud/env/Dockerfile.check-env
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json test)
+  buildah config --env random=hello ${cid}
+  buildah commit --signature-policy ${TESTSDIR}/policy.json ${cid} test1
+  buildah --debug inspect test1 | grep foo=bar
+  buildah --debug  inspect test1 | grep random=hello
+  buildah rm ${cid}
+  buildah rmi test
+  buildah rmi test1
+}
+
 @test "bud-from-scratch" {
   target=scratch-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch

--- a/tests/bud/env/Dockerfile.check-env
+++ b/tests/bud/env/Dockerfile.check-env
@@ -1,0 +1,2 @@
+FROM alpine
+ENV foo=bar


### PR DESCRIPTION
buildah bud was not picking up the ENV from the base image
as it was being cleared. Fixes buildah bud to pick up the ENV.

Fixes https://github.com/projectatomic/buildah/issues/719

Signed-off-by: umohnani8 <umohnani@redhat.com>