### PR TITLE
inspect: Increase err judgments to avoid panic

### DIFF
--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -99,8 +99,11 @@ func inspectCmd(c *cli.Context) error {
 		} else if !matched {
 			return errors.Errorf("error invalid format provided: %s", format)
 		}
-		t := template.Must(template.New("format").Parse(format))
-		if err := t.Execute(os.Stdout, out); err != nil {
+		t, err := template.New("format").Parse(format)
+		if err != nil {
+			return errors.Wrapf(err, "Template parsing error")
+		}
+		if err = t.Execute(os.Stdout, out); err != nil {
 			return err
 		}
 		if terminal.IsTerminal(int(os.Stdout.Fd())) {


### PR DESCRIPTION
Avoid the following panic:

```
➜  buildah git:(inspect-error-fix) ✗ sudo buildah inspect --format {{ID}} 0b1
panic: template: format:1: function "ID" not defined

goroutine 1 [running]:
text/template.Must(0x0, 0xca9f40, 0xc420057d60, 0x0)
        /usr/lib/go-1.10/src/text/template/helper.go:23 +0x54
main.inspectCmd(0xc4200da2c0, 0xc420260c00, 0xc4200da2c0)
        /data/workspace/Go/src/github.com/projectatomic/buildah/cmd/buildah/inspect.go:102 +0x447
github.com/projectatomic/buildah/vendor/github.com/urfave/cli.HandleAction(0xb0ade0, 0xc49758, 0xc4200da2c0, 0x0, 0xc420260c60)
        /data/workspace/Go/src/github.com/projectatomic/buildah/vendor/github.com/urfave/cli/app.go:501 +0xc8
github.com/projectatomic/buildah/vendor/github.com/urfave/cli.Command.Run(0xc10db4, 0x7, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc34c12, 0x32, 0x0, ...)
        /data/workspace/Go/src/github.com/projectatomic/buildah/vendor/github.com/urfave/cli/command.go:165 +0x47d
github.com/projectatomic/buildah/vendor/github.com/urfave/cli.(*App).Run(0xc420020540, 0xc42001e140, 0x5, 0x5, 0x0, 0x0)
        /data/workspace/Go/src/github.com/projectatomic/buildah/vendor/github.com/urfave/cli/app.go:259 +0x6e8
main.main()
        /data/workspace/Go/src/github.com/projectatomic/buildah/cmd/buildah/main.go:107 +0xbff
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>