### PR TITLE
rm: add validation to args and all option

### DIFF
--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -35,6 +35,9 @@ func rmCmd(c *cli.Context) error {
 	if len(args) == 0 && !c.Bool("all") {
 		return errors.Errorf("container ID must be specified")
 	}
+	if len(args) > 0 && c.Bool("all") {
+		return errors.Errorf("when using the --all switch, you may not pass any containers names or IDs")
+	}
 	store, err := getStore(c)
 	if err != nil {
 		return err


### PR DESCRIPTION
When arg is greater than one and the all option is used, error need to be output.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>