### PR TITLE
Run(): process RunOptions.Mounts, and its flags

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -122,9 +122,9 @@ func runCmd(c *cli.Context) error {
 	for _, volumeSpec := range c.StringSlice("volume") {
 		volSpec := strings.Split(volumeSpec, ":")
 		if len(volSpec) >= 2 {
-			mountOptions := "bind"
+			var mountOptions string
 			if len(volSpec) >= 3 {
-				mountOptions = mountOptions + "," + volSpec[2]
+				mountOptions = volSpec[2]
 			}
 			mountOpts := strings.Split(mountOptions, ",")
 			mount := specs.Mount{

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -318,3 +318,20 @@ load helpers
 	[ "$output" = "foobar" ]
 	buildah rm $cid
 }
+
+@test "run --volume" {
+	if ! which runc ; then
+		skip
+	fi
+	runc --version
+	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	mkdir -p ${TESTDIR}/was-empty
+	# As a baseline, this should succeed.
+	run buildah --debug=false run -v ${TESTDIR}/was-empty:/var/not-empty    $cid touch /var/not-empty/testfile
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# If we're parsing the options at all, this should be read-only, so it should fail.
+	run buildah --debug=false run -v ${TESTDIR}/was-empty:/var/not-empty:ro $cid touch /var/not-empty/testfile
+	echo "$output"
+	[ "$status" -ne 0 ]
+}


### PR DESCRIPTION
`RunOptions.Mounts` has been mistakenly ignored since #700; handle them.

Process the options on the bind mounts in `RunOptions.Mounts` the same way we handle the ones in `Builder.CommonBuildOpts.Volumes`, so that flags that control read-only/read-write usage, SELinux labeling, and mount propagation will work.