### PR TITLE
Add environment variable to buildah --format

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -58,7 +58,7 @@ func budCmd(c *cli.Context) error {
 	}
 
 	dockerfiles := c.StringSlice("file")
-	format := "oci"
+	format := defaultFormat()
 	if c.IsSet("format") {
 		format = strings.ToLower(c.String("format"))
 	}

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -39,7 +39,7 @@ var (
 		cli.StringFlag{
 			Name:  "format, f",
 			Usage: "`format` of the image manifest and metadata",
-			Value: "oci",
+			Value: defaultFormat(),
 		},
 		cli.StringFlag{
 			Name:  "iidfile",

--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -326,3 +326,11 @@ func parseIDMap(spec []string) (m [][3]uint32, err error) {
 	}
 	return m, nil
 }
+
+func defaultFormat() string {
+	format := os.Getenv("BUILDAH_FORMAT")
+	if format != "" {
+		return format
+	}
+	return "oci"
+}

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -165,6 +165,9 @@ Control the format for the built image's manifest and configuration data.
 Recognized formats include *oci* (OCI image-spec v1.0, the default) and
 *docker* (version 2, using schema format 2 for the manifest).
 
+Note: You can also override the default format by setting the BUILDAH_FORMAT
+environment variable.  `export BUILDAH_FORMAT=docker`
+
 **--iidfile** *ImageIDfile*
 
 Write the image ID to the file.

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -42,6 +42,9 @@ Control the format for the image manifest and configuration data.  Recognized
 formats include *oci* (OCI image-spec v1.0, the default) and *docker* (version
 2, using schema format 2 for the manifest).
 
+Note: You can also override the default format by setting the BUILDAH_FORMAT
+environment variable.  `export BUILDAH_FORMAT=docker`
+
 **--iidfile** *ImageIDfile*
 
 Write the image ID to the file.


### PR DESCRIPTION
If you decide you want to only build and support docker format
images, you can set this in your environment and buildah
will defautl to building docker images.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>