### PR TITLE
Give better messages to users when image can not be found

### DIFF
--- a/vendor/github.com/containers/image/docker/daemon/client.go
+++ b/vendor/github.com/containers/image/docker/daemon/client.go
@@ -30,13 +30,13 @@ func newDockerClient(sys *types.SystemContext) (*dockerclient.Client, error) {
 	//
 	// Similarly, if we want to communicate over plain HTTP on a TCP socket, we also need to set
 	// TLSClientConfig to nil. This can be achieved by using the form `http://`
-	proto, _, _, err := dockerclient.ParseHost(host)
+	url, err := dockerclient.ParseHostURL(host)
 	if err != nil {
 		return nil, err
 	}
 	var httpClient *http.Client
-	if proto != "unix" {
-		if proto == "http" {
+	if url.Scheme != "unix" {
+		if url.Scheme == "http" {
 			httpClient = httpConfig()
 		} else {
 			hc, err := tlsConfig(sys)

--- a/vendor/github.com/containers/image/ostree/ostree_dest.go
+++ b/vendor/github.com/containers/image/ostree/ostree_dest.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -394,6 +395,9 @@ func (d *ostreeImageDestination) PutSignatures(ctx context.Context, signatures [
 }
 
 func (d *ostreeImageDestination) Commit(ctx context.Context) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	repo, err := otbuiltin.OpenRepo(d.ref.repo)
 	if err != nil {
 		return err

--- a/vendor/github.com/containers/image/pkg/sysregistries/system_registries.go
+++ b/vendor/github.com/containers/image/pkg/sysregistries/system_registries.go
@@ -42,16 +42,7 @@ func normalizeRegistries(regs *registries) {
 // Reads the global registry file from the filesystem. Returns
 // a byte array
 func readRegistryConf(sys *types.SystemContext) ([]byte, error) {
-	dirPath := systemRegistriesConfPath
-	if sys != nil {
-		if sys.SystemRegistriesConfPath != "" {
-			dirPath = sys.SystemRegistriesConfPath
-		} else if sys.RootForImplicitAbsolutePaths != "" {
-			dirPath = filepath.Join(sys.RootForImplicitAbsolutePaths, systemRegistriesConfPath)
-		}
-	}
-	configBytes, err := ioutil.ReadFile(dirPath)
-	return configBytes, err
+	return ioutil.ReadFile(RegistriesConfPath(sys))
 }
 
 // For mocking in unittests
@@ -96,4 +87,17 @@ func GetInsecureRegistries(sys *types.SystemContext) ([]string, error) {
 		return nil, err
 	}
 	return config.Registries.Insecure.Registries, nil
+}
+
+// RegistriesConfPath is the path to the system-wide registry configuration file
+func RegistriesConfPath(ctx *types.SystemContext) string {
+	path := systemRegistriesConfPath
+	if ctx != nil {
+		if ctx.SystemRegistriesConfPath != "" {
+			path = ctx.SystemRegistriesConfPath
+		} else if ctx.RootForImplicitAbsolutePaths != "" {
+			path = filepath.Join(ctx.RootForImplicitAbsolutePaths, systemRegistriesConfPath)
+		}
+	}
+	return path
 }

--- a/vendor/github.com/containers/image/vendor.conf
+++ b/vendor/github.com/containers/image/vendor.conf
@@ -5,10 +5,11 @@ github.com/containers/storage master
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
 github.com/docker/distribution 5f6282db7d65e6d72ad7c2cc66310724a57be716
-github.com/docker/docker 30eb4d8cdc422b023d5f11f29a82ecb73554183b
-github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
+github.com/docker/docker da99009bbb1165d1ac5688b5c81d2f589d418341
+github.com/docker/go-connections 7beb39f0b969b075d1325fecb092faf27fd357b6
 github.com/docker/go-units 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 github.com/docker/libtrust aabc10ec26b754e797f9028f4589c5b7bd90dc20
+github.com/containerd/continuity d8fb8589b0e8e85b8c8bbaa8840226d0dfeb7371
 github.com/ghodss/yaml 04f313413ffd65ce25f2541bfd2b2ceec5c0908c
 github.com/gorilla/mux 94e7d24fd285520f3d12ae998f7fdd6b5393d453
 github.com/imdario/mergo 50d4dbd4eb0e84778abe37cefef140271d96fade
@@ -38,3 +39,4 @@ github.com/BurntSushi/toml b26d9c308763d68093482582cea63d69be07a0f0
 github.com/ostreedev/ostree-go aeb02c6b6aa2889db3ef62f7855650755befd460
 github.com/gogo/protobuf fcdc5011193ff531a548e9b0301828d5a5b97fd8
 github.com/pquerna/ffjson master
+github.com/syndtr/gocapability master


### PR DESCRIPTION
Had to vendor latest containers/image to get path to /etc/containers/registries.conf

Currently if /etc/containers/registries.conf does not exist, you can not pull images
and the error message tells you bad information.

 buildah from alpine
Get https://localhost/v2/: dial tcp [::1]:443: connect: connection refused

With this change

./buildah from alpine
image "alpine" not found in /etc/containers/registries.conf registries: image not known

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>