### PR TITLE
Run(): evaluate symlinks in the bundle path before using it

### DIFF
--- a/run.go
+++ b/run.go
@@ -709,6 +709,11 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	if err != nil {
 		return err
 	}
+	cleaned, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return errors.Wrapf(err, "error cleaning path %q", path)
+	}
+	path = cleaned
 	logrus.Debugf("using %q to hold bundle data", path)
 	defer func() {
 		if err2 := os.RemoveAll(path); err2 != nil {

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -335,3 +335,17 @@ load helpers
 	echo "$output"
 	[ "$status" -ne 0 ]
 }
+
+@test "run symlinks" {
+	if ! which runc ; then
+		skip
+	fi
+	runc --version
+	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	mkdir -p ${TESTDIR}/tmp
+	ln -s tmp ${TESTDIR}/tmp2
+	export TMPDIR=${TESTDIR}/tmp2
+	run buildah --debug=false run $cid id
+	echo "$output"
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
When we create a temporary directory for `Run()`, evaluate any symbolic links in it, because runc will return an error if any part of the path to the rootfs (which we've bind mounted) is a symbolic link.