### PR TITLE
run.bats: check that we can run with symlinks in the bundle path

### DIFF
--- a/run.go
+++ b/run.go
@@ -705,7 +705,7 @@ func setupNamespaces(g *generate.Generator, namespaceOptions NamespaceOptions, i
 // Run runs the specified command in the container's root filesystem.
 func (b *Builder) Run(command []string, options RunOptions) error {
 	var user specs.User
-	p, err := ioutil.TempDir(os.TempDir(), Package)
+	p, err := ioutil.TempDir("", Package)
 	if err != nil {
 		return err
 	}

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -335,3 +335,17 @@ load helpers
 	echo "$output"
 	[ "$status" -ne 0 ]
 }
+
+@test "run symlinks" {
+	if ! which runc ; then
+		skip
+	fi
+	runc --version
+	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	mkdir -p ${TESTDIR}/tmp
+	ln -s tmp ${TESTDIR}/tmp2
+	export TMPDIR=${TESTDIR}/tmp2
+	run buildah --debug=false run $cid id
+	echo "$output"
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Make sure that we don't trigger error messages in `runc` when `$TMPDIR`, which affects `os.TempDir()` (which is the default for `ioutil.TempDir()`), is itself a symbolic link.  Tests #745.