### PR TITLE
Add context dir to bud command in baseline test

### DIFF
--- a/tests/test_buildah_baseline.sh
+++ b/tests/test_buildah_baseline.sh
@@ -190,7 +190,7 @@ chmod +x $FILE
 ########
 # Build with the Dockerfile
 ########
-buildah bud -f Dockerfile -t whale-says 
+buildah bud -f Dockerfile -t whale-says . 
 
 ########
 # Create a whalesays container 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

With a recent change to the bud processing, a context directory is not required.  Add a '.' to the end of the bud call in the baseline tests.

This test is not run in the CI, it is only run by hand.