### PR TITLE
imagebuildah/build.go: write to reportwriter

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -532,10 +532,10 @@ func NewExecutor(store storage.Store, options BuildOptions) (*Executor, error) {
 		annotations:           append([]string{}, options.Annotations...),
 	}
 	if exec.err == nil {
-		exec.err = os.Stderr
+		exec.err = options.ReportWriter
 	}
 	if exec.out == nil {
-		exec.out = os.Stdout
+		exec.out = options.ReportWriter
 	}
 	if exec.log == nil {
 		stepCounter := 0
@@ -781,7 +781,7 @@ func (b *Executor) Commit(ctx context.Context, ib *imagebuilder.Builder) (err er
 // over each of the one or more parsed Dockerfiles and stages.
 func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) error {
 	if len(stages) == 0 {
-		errors.New("error building: no stages to build")
+		return errors.New("error building: no stages to build")
 	}
 	var stageExecutor *Executor
 	for _, stage := range stages {


### PR DESCRIPTION
when calling build through backends like varlink, writing to stdout or
stderr is not really option.  therefore, we should always write to the
provided reportwriter unless otherwise overriden.  this allows the build output
to be returned through the backend API and prevents it from landing in
journald.

Signed-off-by: baude <bbaude@redhat.com>