### PR TITLE
Provide redirection for stdio

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -191,6 +191,11 @@ OCI Runtime, using the --runtime flag.
 
 Add an image *label* (e.g. label=*value*) to the image metadata. Can be used multiple times.
 
+**--logfile** *filename*
+
+Log output which would be sent to standard output and standard error to the
+specified file instead of to standard output and standard error.
+
 **--memory, -m**=""
 
 Memory limit (format: <number>[<unit>], where unit = b, k, m or g)

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -119,6 +119,10 @@ var (
 			Name:  "no-cache",
 			Usage: "Do not use caching for the container build. Buildah does not currently support caching so this is a NOOP.",
 		},
+		cli.StringFlag{
+			Name:  "logfile",
+			Usage: "log to `file` instead of stdout/stderr",
+		},
 		cli.BoolTFlag{
 			Name:  "pull",
 			Usage: "pull the image if not present",

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -735,3 +735,12 @@ load helpers
   buildah rm ${cid}
   buildah rmi --all
 }
+
+@test "bud-logfile" {
+  rm -f ${TESTDIR}/logfile
+  run buildah bud --logfile ${TESTDIR}/logfile --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/preserve-volumes
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+  test -s ${TESTDIR}/logfile
+}


### PR DESCRIPTION
Provide `RunOption` fields for callers to give us stdio as an `io.ReadCloser` and a pair of `io.WriteClosers`, or `nil` to use `os.Stdin`/`os.Stdout`/`os.Stderr`.