### PR TITLE
Change freenode chan to buildah

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ commit automatically with `git commit -s`.
 ## Communications
 
 For general questions, or discussions, please use the
-IRC group on `irc.freenode.net` called `cri-o`
+IRC group on `irc.freenode.net` called `buildah`
 that has been setup.
 
 For discussions around issues/bugs and features, you can use the github


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Switching our freenode channel from cri-o to buildah