### PR TITLE
runCopyStdio(): don't close stdin unless we saw POLLHUP

### DIFF
--- a/run.go
+++ b/run.go
@@ -1468,11 +1468,11 @@ func runCopyStdio(stdio *sync.WaitGroup, copyStdio bool, stdioPipe [][]int, copy
 			if pollFd.Revents&unix.POLLHUP == unix.POLLHUP {
 				removes = append(removes, int(pollFd.Fd))
 			}
-			// If the EPOLLIN flag isn't set, then there's no data to be read from this descriptor.
+			// If the POLLIN flag isn't set, then there's no data to be read from this descriptor.
 			if pollFd.Revents&unix.POLLIN == 0 {
-				// If we're using pipes and it's our stdin, close the writing end
-				// of the corresponding pipe.
-				if copyStdio && int(pollFd.Fd) == unix.Stdin {
+				// If we're using pipes and it's our stdin and it's closed, close the writing
+				// end of the corresponding pipe.
+				if copyStdio && int(pollFd.Fd) == unix.Stdin && pollFd.Revents&unix.POLLHUP != 0 {
 					unix.Close(stdioPipe[unix.Stdin][1])
 					stdioPipe[unix.Stdin][1] = -1
 				}


### PR DESCRIPTION
When polling for input on stdin (in Terminal == false cases), don't close the write end of the pipe that we're using to relay data from stdin to the container unless poll() tells us that we got a POLLHUP.

Assuming that was the case when POLLIN wasn't set meant that we'd close it as soon as poll() returned and there was no activity on the descriptor, and if poll() only returned because we had output from the container to relay back, we were doing so prematurely.