### PR TITLE
Report errors on bad transports specification when pushing images

### DIFF
--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -100,6 +100,11 @@ func pushCmd(c *cli.Context) error {
 	dest, err := alltransports.ParseImageName(destSpec)
 	// add the docker:// transport to see if they neglected it.
 	if err != nil {
+		destTransport := strings.Split(destSpec, ":")[0]
+		if t := transports.Get(destTransport); t != nil {
+			return err
+		}
+
 		if strings.Contains(destSpec, "://") {
 			return err
 		}


### PR DESCRIPTION
We ignore valid errors when pushing images. This patch will check
if the user gave us a valid transport and report the error.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>