### PR TITLE
Add(): learn to record hashes of what we add

### DIFF
--- a/docs/buildah-add.md
+++ b/docs/buildah-add.md
@@ -19,6 +19,10 @@ archive file itself.  If a local directory is specified as a source, its
 
 Sets the user and group ownership of the destination content.
 
+**--quiet**
+
+Refrain from printing a digest of the added content.
+
 ## EXAMPLE
 
 buildah add containerID '/myapp/app.conf' '/myapp/app.conf'

--- a/docs/buildah-copy.md
+++ b/docs/buildah-copy.md
@@ -17,6 +17,10 @@ specified as a source, its *contents* are copied to the destination.
 
 Sets the user and group ownership of the destination content.
 
+**--quiet**
+
+Refrain from printing a digest of the copied content.
+
 ## EXAMPLE
 
 buildah copy containerID '/myapp/app.conf' '/myapp/app.conf'

--- a/run.go
+++ b/run.go
@@ -393,7 +393,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, optionMounts 
 
 	// Add temporary copies of the contents of volume locations at the
 	// volume locations, unless we already have something there.
-	copyWithTar := b.copyWithTar(nil)
+	copyWithTar := b.copyWithTar(nil, nil)
 	builtins, err := runSetupBuiltinVolumes(b.MountLabel, mountPoint, cdir, copyWithTar, builtinVolumes)
 	if err != nil {
 		return err
@@ -534,7 +534,7 @@ func runSetupVolumeMounts(mountLabel string, volumeMounts []string, optionMounts
 
 // addNetworkConfig copies files from host and sets them up to bind mount into container
 func (b *Builder) addNetworkConfig(rdir, hostPath string) (string, error) {
-	copyFileWithTar := b.copyFileWithTar(nil)
+	copyFileWithTar := b.copyFileWithTar(nil, nil)
 
 	cfile := filepath.Join(rdir, filepath.Base(hostPath))
 


### PR DESCRIPTION
Add a field to `AddOrCopyOptions` that can take a 1hash.Hash1, or more often a `Hash` returned by `digest.Digester`'s `Hash()` method, to calculate a sum over what we add or copy.

Make the help output summarizing the arguments that `buildah add` and `buildah copy` accept more closely match their man pages.