### PR TITLE
Add registries.conf link to a few man pages

### DIFF
--- a/docs/buildah-rmi.md
+++ b/docs/buildah-rmi.md
@@ -13,7 +13,7 @@ Removes one or more locally stored images.
 If the image was pushed to a directory path using the 'dir:' transport
 the rmi command can not remove the image.  Instead standard file system
 commands should be used.
-If _imageID_ is a name, but does not include a registry name, buildah will attempt to find and remove an image named using the registry name *localhost*, if no such image is found, it will search for the intended image by attempting to expand the given name using the names of registries provided in the system's registries configuration.
+If _imageID_ is a name, but does not include a registry name, buildah will attempt to find and remove an image named using the registry name *localhost*, if no such image is found, it will search for the intended image by attempting to expand the given name using the names of registries provided in the system's registries configuration file, registries.conf.
 
 ## OPTIONS
 
@@ -43,5 +43,11 @@ buildah rmi --force imageID
 
 buildah rmi imageID1 imageID2 imageID3
 
+## Files
+
+**registries.conf** (`/etc/containers/registries.conf`)
+
+registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
+
 ## SEE ALSO
-buildah(1)
+buildah(1), registries.conf(5)

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -115,7 +115,7 @@ Print the version
 	registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
-podman(1), mounts.conf(5)
+podman(1), mounts.conf(5), registries.conf(5), storage.conf(5)
 
 ## HISTORY
 December 2017, Originally compiled by Tom Sweeney <tsweeney@redhat.com>


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Touch up a few spots where a man link to registries was missing.  Add registries.conf file info to the main buildah man page.