### PR TITLE
fix make clean error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ imgtype: *.go docker/*.go util/*.go tests/imgtype/imgtype.go
 
 .PHONY: clean
 clean:
-	$(RM) buildah imgtype build
+	$(RM) -r buildah imgtype build
 	$(MAKE) -C docs clean 
 
 .PHONY: docs


### PR DESCRIPTION
Fix the following error:

```
➜  buildah git:(master) ✗ make clean                                                                                            
rm -f buildah imgtype build                                                                                                 
rm: cannot remove 'build': Is a directory                                                                                    
Makefile:28: recipe for target 'clean' failed
make: *** [clean] Error 1      
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>