### PR TITLE
Change 'registries' to 'container registries' in man

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -523,7 +523,7 @@ buildah bud --volume /home/test:/myvol:ro,Z -t imageName .
 
 **registries.conf** (`/etc/containers/registries.conf`)
 
-registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
+registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
 buildah(1), podman-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7)

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -98,7 +98,7 @@ This example commits the container to the image on the local registry using cred
 
 **registries.conf** (`/etc/containers/registries.conf`)
 
-registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
+registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
 buildah(1), policy.json(5), registries.conf(5)

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -431,7 +431,7 @@ buildah from --volume /home/test:/myvol:ro,Z myregistry/myrepository/imagename:i
 
 **registries.conf** (`/etc/containers/registries.conf`)
 
-registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
+registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
 buildah(1), podman-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7)

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -118,7 +118,7 @@ This example extracts the imageID image and puts it into the registry on the loc
 
 **registries.conf** (`/etc/containers/registries.conf`)
 
-registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
+registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
 buildah(1), podman-login(1), docker-login(1), policy.json(5), registries.conf(5)

--- a/docs/buildah-rmi.md
+++ b/docs/buildah-rmi.md
@@ -47,7 +47,7 @@ buildah rmi imageID1 imageID2 imageID3
 
 **registries.conf** (`/etc/containers/registries.conf`)
 
-registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
+registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
 buildah(1), registries.conf(5)

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -30,7 +30,7 @@ Show help
 
 **--registries-conf** *path*
 
-Pathname of the configuration file which specifies which registries should be
+Pathname of the configuration file which specifies which container registries should be
 consulted when completing image names which do not include a registry or domain
 portion.  It is not recommended that this option be used, as the default
 behavior of using the system-wide configuration
@@ -112,7 +112,7 @@ Print the version
 
 **registries.conf** (`/etc/containers/registries.conf`)
 
-	registries.conf is the configuration file which specifies which registries should be consulted when completing image names which do not include a registry or domain portion.
+	registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
 podman(1), mounts.conf(5), registries.conf(5), storage.conf(5)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Per a suggestion form @pixdrift, added 'container' before registries in some man pages.