### PR TITLE
Fix v2s1 parsing, and use c/image for config conversion.

### DIFF
--- a/config.go
+++ b/config.go
@@ -180,7 +180,7 @@ func makeDockerV2S1Image(manifest docker.V2S1Manifest) (docker.V2Image, error) {
 
 func (b *Builder) initConfig(ctx context.Context, img types.Image) error {
 	if img != nil { // A pre-existing image, as opposed to a "FROM scratch" new one.
-		rawManifest, _, err := img.Manifest(ctx)
+		rawManifest, manifestMIMEType, err := img.Manifest(ctx)
 		if err != nil {
 			return errors.Wrapf(err, "error reading image manifest for %q", transports.ImageName(img.Reference()))
 		}
@@ -191,7 +191,7 @@ func (b *Builder) initConfig(ctx context.Context, img types.Image) error {
 		b.Manifest = rawManifest
 		b.Config = rawConfig
 
-		switch mt := manifest.GuessMIMEType(b.Manifest); mt {
+		switch manifestMIMEType {
 		case manifest.DockerV2Schema2MediaType:
 			dimage := docker.V2Image{}
 			if err := json.Unmarshal(b.Config, &dimage); err != nil {
@@ -231,7 +231,7 @@ func (b *Builder) initConfig(ctx context.Context, img types.Image) error {
 		case "":
 			return errors.Errorf("can't work with an unrecognized manifest type")
 		default:
-			return errors.Errorf("unsupported manifest type %#v", mt)
+			return errors.Errorf("unsupported manifest type %#v", manifestMIMEType)
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -174,7 +174,7 @@ func makeDockerV2S1Image(manifest docker.V2S1Manifest) (docker.V2Image, error) {
 	return dimage, nil
 }
 
-func (b *Builder) initConfig() {
+func (b *Builder) initConfig() error {
 	if len(b.Manifest) > 0 { // A pre-existing image, as opposed to a "FROM scratch" new one.
 		image := ociv1.Image{}
 		dimage := docker.V2Image{}
@@ -183,20 +183,26 @@ func (b *Builder) initConfig() {
 			if err := json.Unmarshal(b.Config, &dimage); err == nil && dimage.DockerVersion != "" {
 				image = makeOCIv1Image(&dimage)
 			} else {
-				if err := json.Unmarshal(b.Config, &image); err == nil {
-					dimage = makeDockerV2S2Image(&image)
+				if err := json.Unmarshal(b.Config, &image); err != nil {
+					return errors.Wrapf(err, "error parsing config (as either Docker v2s2 or OCI)")
 				}
+				dimage = makeDockerV2S2Image(&image)
 			}
 			b.OCIv1 = image
 			b.Docker = dimage
 		} else {
 			// Try to dig out the image configuration from the manifest.
 			manifest := docker.V2S1Manifest{}
-			if err := json.Unmarshal(b.Manifest, &manifest); err == nil && manifest.SchemaVersion == 1 {
-				if dimage, err = makeDockerV2S1Image(manifest); err == nil {
-					image = makeOCIv1Image(&dimage)
-				}
+			if err := json.Unmarshal(b.Manifest, &manifest); err != nil {
+				return errors.Wrapf(err, "error parsing v2s1 manifest")
 			}
+			if manifest.SchemaVersion != 1 {
+				return errors.Errorf("manifest is not v2s1, config is not available")
+			}
+			if dimage, err = makeDockerV2S1Image(manifest); err != nil {
+				return errors.Wrapf(err, "error converting v2s1 image to v2s2")
+			}
+			image = makeOCIv1Image(&dimage)
 			b.OCIv1 = image
 			b.Docker = dimage
 		}
@@ -208,6 +214,7 @@ func (b *Builder) initConfig() {
 	}
 
 	b.fixupConfig()
+	return nil
 }
 
 func (b *Builder) fixupConfig() {

--- a/config.go
+++ b/config.go
@@ -182,7 +182,7 @@ func (b *Builder) initConfig() {
 		if err := json.Unmarshal(b.Config, &dimage); err == nil && dimage.DockerVersion != "" {
 			image = makeOCIv1Image(&dimage)
 		} else {
-			if err := json.Unmarshal(b.Config, &image); err != nil {
+			if err := json.Unmarshal(b.Config, &image); err == nil {
 				dimage = makeDockerV2S2Image(&image)
 			}
 		}

--- a/config.go
+++ b/config.go
@@ -127,7 +127,7 @@ func makeDockerV2S1Image(manifest docker.V2S1Manifest) (docker.V2Image, error) {
 	if err != nil {
 		return docker.V2Image{}, err
 	}
-	if dimage.DockerVersion == "" {
+	if dimage.ID == "" {
 		return docker.V2Image{}, errors.Errorf("error parsing image configuration from history")
 	}
 	// The DiffID list is intended to contain the sums of _uncompressed_ blobs, and these are most

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/containers/image/manifest"
+	"github.com/containers/image/types"
 	digest "github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -175,7 +176,7 @@ func makeDockerV2S1Image(manifest docker.V2S1Manifest) (docker.V2Image, error) {
 	return dimage, nil
 }
 
-func (b *Builder) initConfig() error {
+func (b *Builder) initConfig(_ types.Image) error {
 	if len(b.Manifest) > 0 { // A pre-existing image, as opposed to a "FROM scratch" new one.
 		switch mt := manifest.GuessMIMEType(b.Manifest); mt {
 		case manifest.DockerV2Schema2MediaType:

--- a/import.go
+++ b/import.go
@@ -70,7 +70,9 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 		},
 	}
 
-	builder.initConfig()
+	if err := builder.initConfig(); err != nil {
+		return nil, errors.Wrapf(err, "error preparing image configuration")
+	}
 
 	return builder, nil
 }

--- a/import.go
+++ b/import.go
@@ -28,14 +28,7 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 		return nil, errors.Wrapf(err2, "error instantiating image")
 	}
 	defer src.Close()
-	config, err := src.ConfigBlob(ctx)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error reading image configuration")
-	}
-	manifest, _, err := src.Manifest(ctx)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error reading image manifest")
-	}
+
 	imageName := ""
 	if img, err3 := store.Image(imageID); err3 == nil {
 		if len(img.Names) > 0 {
@@ -55,8 +48,6 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 		Type:             containerType,
 		FromImage:        imageName,
 		FromImageID:      imageID,
-		Config:           config,
-		Manifest:         manifest,
 		Container:        containerName,
 		ContainerID:      containerID,
 		ImageAnnotations: map[string]string{},
@@ -70,7 +61,7 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 		},
 	}
 
-	if err := builder.initConfig(src); err != nil {
+	if err := builder.initConfig(ctx, src); err != nil {
 		return nil, errors.Wrapf(err, "error preparing image configuration")
 	}
 

--- a/import.go
+++ b/import.go
@@ -13,40 +13,40 @@ import (
 )
 
 func importBuilderDataFromImage(ctx context.Context, store storage.Store, systemContext *types.SystemContext, imageID, containerName, containerID string) (*Builder, error) {
-	manifest := []byte{}
-	config := []byte{}
-	imageName := ""
+	if imageID == "" {
+		return nil, errors.Errorf("Internal error: imageID is empty in importBuilderDataFromImage")
+	}
+
 	uidmap, gidmap := convertStorageIDMaps(storage.DefaultStoreOptions.UIDMap, storage.DefaultStoreOptions.GIDMap)
 
-	if imageID != "" {
-		ref, err := is.Transport.ParseStoreReference(store, imageID)
-		if err != nil {
-			return nil, errors.Wrapf(err, "no such image %q", imageID)
+	ref, err := is.Transport.ParseStoreReference(store, imageID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "no such image %q", imageID)
+	}
+	src, err2 := ref.NewImage(ctx, systemContext)
+	if err2 != nil {
+		return nil, errors.Wrapf(err2, "error instantiating image")
+	}
+	defer src.Close()
+	config, err := src.ConfigBlob(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading image configuration")
+	}
+	manifest, _, err := src.Manifest(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading image manifest")
+	}
+	imageName := ""
+	if img, err3 := store.Image(imageID); err3 == nil {
+		if len(img.Names) > 0 {
+			imageName = img.Names[0]
 		}
-		src, err2 := ref.NewImage(ctx, systemContext)
-		if err2 != nil {
-			return nil, errors.Wrapf(err2, "error instantiating image")
-		}
-		defer src.Close()
-		config, err = src.ConfigBlob(ctx)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error reading image configuration")
-		}
-		manifest, _, err = src.Manifest(ctx)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error reading image manifest")
-		}
-		if img, err3 := store.Image(imageID); err3 == nil {
-			if len(img.Names) > 0 {
-				imageName = img.Names[0]
+		if img.TopLayer != "" {
+			layer, err4 := store.Layer(img.TopLayer)
+			if err4 != nil {
+				return nil, errors.Wrapf(err4, "error reading information about image's top layer")
 			}
-			if img.TopLayer != "" {
-				layer, err4 := store.Layer(img.TopLayer)
-				if err4 != nil {
-					return nil, errors.Wrapf(err4, "error reading information about image's top layer")
-				}
-				uidmap, gidmap = convertStorageIDMaps(layer.UIDMap, layer.GIDMap)
-			}
+			uidmap, gidmap = convertStorageIDMaps(layer.UIDMap, layer.GIDMap)
 		}
 	}
 

--- a/import.go
+++ b/import.go
@@ -70,7 +70,7 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 		},
 	}
 
-	if err := builder.initConfig(); err != nil {
+	if err := builder.initConfig(src); err != nil {
 		return nil, errors.Wrapf(err, "error preparing image configuration")
 	}
 

--- a/new.go
+++ b/new.go
@@ -347,7 +347,9 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		}
 	}
 
-	builder.initConfig()
+	if err := builder.initConfig(); err != nil {
+		return nil, errors.Wrapf(err, "error preparing image configuration")
+	}
 	err = builder.Save()
 	if err != nil {
 		return nil, errors.Wrapf(err, "error saving builder state")


### PR DESCRIPTION
<s>DO NOT MERGE YET, this includes #775, which needs to be reviewed first.</s>

---

Don't ignore v2s1 history if `docker_version` is not set:

`buildah` itself clears `docker_version` in `Builder.fixupConfig`; so, buildah-created v2s1 images do not pass this test, `buildah from buildah-created-v2s1` creates an image with empty history, which causes `buildah commit` to complain about a mismatch between the history and layer `DiffID` list.

Now also includes a fair amount of subsequent cleanups.

---

<s>WIP, this one-liner is the ultimate cause, but really the first problem is the extremely forgiving error handling which caused this failure to be silently ignored.  I should also check whether the conversion code in here needs to exist at all, or whether c/image could be used to get the data.</s>