### PR TITLE
Remove tty check from images --format

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -17,7 +17,6 @@ import (
 	"github.com/projectatomic/buildah/pkg/parse"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 type jsonImage struct {
@@ -400,9 +399,7 @@ func outputUsingTemplate(format string, params imageOutputParams) error {
 	if err != nil {
 		return err
 	}
-	if terminal.IsTerminal(int(os.Stdout.Fd())) {
-		fmt.Println()
-	}
+	fmt.Println()
 	return nil
 }
 

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -26,7 +26,7 @@ load helpers
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
   run buildah --debug=false images --format "{{.Name}}"
-  [ $(wc -l <<< "$output") -eq 1 ]
+  [ $(wc -l <<< "$output") -eq 2 ]
   [ "${status}" -eq 0 ]
   buildah rm -a
   buildah rmi -a -f


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Remove the check for tty from the images --format command.  With it in place the images command in the bats tests was returning only one line of images all appended to each other.

@rhatdan, I didn't see a quick way to do the cr only for multiple lines, but I think without doing it after every line we'd end up with the command line prompt appended to the result.  But before poking at that further, thought I'd throw this PR together to see if any of the travis test got unhappy with the change.

@umohani if you could give this patch a quick testdrive in your environment, I'd appreciate it.