### PR TITLE
Add environment variable BUILDAH_RUNTIME

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -11,6 +11,7 @@ import (
 	"github.com/projectatomic/buildah"
 	buildahcli "github.com/projectatomic/buildah/pkg/cli"
 	"github.com/projectatomic/buildah/pkg/parse"
+	"github.com/projectatomic/buildah/util"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -24,7 +25,7 @@ var (
 		cli.StringFlag{
 			Name:  "runtime",
 			Usage: "`path` to an alternate runtime",
-			Value: buildah.DefaultRuntime,
+			Value: util.Runtime(),
 		},
 		cli.StringSliceFlag{
 			Name:  "runtime-flag",

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -269,7 +269,10 @@ Remove intermediate containers after a successful build. Buildah does not curren
 **--runtime** *path*
 
 The *path* to an alternate OCI-compatible runtime, which will be used to run
-commands specified by the **RUN** instruction.
+commands specified by the **RUN** instruction. Default is runc.
+
+Note: You can also override the default runtime by setting the BUILDAH_RUNTIME
+environment variable.  `export BUILDAH_FORMAT=/usr/local/bin/runc`
 
 **--runtime-flag** *flag*
 

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -59,7 +59,10 @@ process.
 
 **--runtime** *path*
 
-The *path* to an alternate OCI-compatible runtime.
+The *path* to an alternate OCI-compatible runtime. Default is runc.
+
+Note: You can also override the default runtime by setting the BUILDAH_RUNTIME
+environment variable.  `export BUILDAH_FORMAT=/usr/local/bin/runc`
 
 **--runtime-flag** *flag*
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -32,7 +32,6 @@ const (
 	PullIfMissing       = buildah.PullIfMissing
 	PullAlways          = buildah.PullAlways
 	PullNever           = buildah.PullNever
-	DefaultRuntime      = buildah.DefaultRuntime
 	OCIv1ImageFormat    = buildah.OCIv1ImageManifest
 	Dockerv2ImageFormat = buildah.Dockerv2ImageManifest
 

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -6,12 +6,12 @@ package cli
 
 import (
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/projectatomic/buildah"
 	"github.com/projectatomic/buildah/util"
 	"github.com/urfave/cli"
 )
 
 var (
+	runtime     = util.Runtime()
 	usernsFlags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "userns",
@@ -146,7 +146,7 @@ var (
 		cli.StringFlag{
 			Name:  "runtime",
 			Usage: "`path` to an alternate runtime",
-			Value: buildah.DefaultRuntime,
+			Value: runtime,
 		},
 		cli.StringSliceFlag{
 			Name:  "runtime-flag",

--- a/run.go
+++ b/run.go
@@ -41,8 +41,6 @@ import (
 const (
 	// DefaultWorkingDir is used if none was specified.
 	DefaultWorkingDir = "/"
-	// DefaultRuntime is the default command to use to run the container.
-	DefaultRuntime = "runc"
 	// runUsingRuntimeCommand is a command we use as a key for reexec
 	runUsingRuntimeCommand = Package + "-runtime"
 )
@@ -1007,7 +1005,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetwork
 	// Decide which runtime to use.
 	runtime := options.Runtime
 	if runtime == "" {
-		runtime = DefaultRuntime
+		runtime = util.Runtime()
 	}
 
 	// Default to not specifying a console socket location.

--- a/util/util.go
+++ b/util/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 
@@ -232,4 +233,13 @@ func WriteError(w io.Writer, err error, lastError error) error {
 		fmt.Fprintln(w, lastError)
 	}
 	return err
+}
+
+// Runtime is the default command to use to run the container.
+func Runtime() string {
+	runtime := os.Getenv("BUILDAH_RUNTIME")
+	if runtime != "" {
+		return runtime
+	}
+	return DefaultRuntime
 }


### PR DESCRIPTION
Allow user to setup alternate runtimes to use rather then
runc.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>