### PR TITLE
Add --all,-a flag to buildah images

### DIFF
--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -217,7 +217,7 @@ func TestOutputImagesQuietTruncated(t *testing.T) {
 
 	// Tests quiet and truncated output
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:1], "", store, nil, "", false, true, false, true)
+		return outputImages(getContext(), images[:1], "", store, nil, "", false, true, false, true, false)
 	})
 	expectedOutput := fmt.Sprintf("%-64s\n", images[0].ID)
 	if err != nil {
@@ -251,7 +251,7 @@ func TestOutputImagesQuietNotTruncated(t *testing.T) {
 
 	// Tests quiet and non-truncated output
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:1], "", store, nil, "", false, false, false, true)
+		return outputImages(getContext(), images[:1], "", store, nil, "", false, false, false, true, false)
 	})
 	expectedOutput := fmt.Sprintf("%-64s\n", images[0].ID)
 	if err != nil {
@@ -285,7 +285,7 @@ func TestOutputImagesFormatString(t *testing.T) {
 
 	// Tests output with format template
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:1], "{{.ID}}", store, nil, "", true, true, false, false)
+		return outputImages(getContext(), images[:1], "{{.ID}}", store, nil, "", true, true, false, false, false)
 	})
 	expectedOutput := images[0].ID
 	if err != nil {
@@ -319,7 +319,7 @@ func TestOutputImagesFormatTemplate(t *testing.T) {
 
 	// Tests quiet and non-truncated output
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:1], "", store, nil, "", false, false, false, true)
+		return outputImages(getContext(), images[:1], "", store, nil, "", false, false, false, true, false)
 	})
 	expectedOutput := fmt.Sprintf("%-64s\n", images[0].ID)
 	if err != nil {
@@ -355,7 +355,7 @@ func TestOutputImagesArgNoMatch(t *testing.T) {
 	// because all images in the repository must have a tag, and here the tag is an
 	// empty string
 	_, err = captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:1], "", store, nil, "foo:", false, true, false, false)
+		return outputImages(getContext(), images[:1], "", store, nil, "foo:", false, true, false, false, false)
 	})
 	if err == nil || err.Error() != "No such image foo:" {
 		t.Fatalf("expected error arg no match")
@@ -390,7 +390,7 @@ func TestOutputMultipleImages(t *testing.T) {
 
 	// Tests quiet and truncated output
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:2], "", store, nil, "", false, true, false, true)
+		return outputImages(getContext(), images[:2], "", store, nil, "", false, true, false, true, false)
 	})
 	expectedOutput := fmt.Sprintf("%-64s\n%-64s\n", images[0].ID, images[1].ID)
 	if err != nil {

--- a/cmd/buildah/rmi_test.go
+++ b/cmd/buildah/rmi_test.go
@@ -104,7 +104,7 @@ func TestStorageImageIDTrue(t *testing.T) {
 		t.Fatalf("Error reading images: %v", err)
 	}
 	id, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images, "", store, nil, "busybox:latest", false, false, false, true)
+		return outputImages(getContext(), images, "", store, nil, "busybox:latest", false, false, false, true, false)
 	})
 	if err != nil {
 		t.Fatalf("Error getting id of image: %v", err)

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -638,6 +638,8 @@ return 1
 
  _buildah_images() {
      local boolean_options="
+     --all
+     -a
      --digests
      --help
      -h

--- a/docs/buildah-images.md
+++ b/docs/buildah-images.md
@@ -12,6 +12,10 @@ The created date is displayed in the time locale of the local machine.
 
 ## OPTIONS
 
+**--all, -a**
+
+Show all images, including intermediate images from a build.
+
 **--digests**
 
 Show the image digests.
@@ -58,6 +62,23 @@ buildah images --quiet fedora:latest
 buildah images --filter dangling=true
 
 buildah images --format "ImageID: {{.ID}}"
+
+```
+# buildah images
+IMAGE ID             IMAGE NAME                                               CREATED AT             SIZE
+3fd9065eaf02         docker.io/library/alpine:latest                          Jan 9, 2018 16:10      4.41 MB
+c0cfe75da054         localhost/test:latest                                    Jun 13, 2018 15:52     4.42 MB
+```
+
+```
+# buildah images -a
+IMAGE ID             IMAGE NAME                                               CREATED AT             SIZE
+3fd9065eaf02         docker.io/library/alpine:latest                          Jan 9, 2018 16:10      4.41 MB
+12515a2658dc         <none>                                                   Jun 13, 2018 15:52     4.41 MB
+fcc3ddd28930         <none>                                                   Jun 13, 2018 15:52     4.41 MB
+8c6e16890c2b         <none>                                                   Jun 13, 2018 15:52     4.42 MB
+c0cfe75da054         localhost/test:latest                                    Jun 13, 2018 15:52     4.42 MB
+```
 
 ## SEE ALSO
 buildah(1)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4,30 +4,34 @@ load helpers
 
 @test "bud with --layers and --no-cache flags" {
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTSDIR}/bud/use-layers
-  images1=$(buildah images | grep "" -c)
+  run buildah --debug=false images -a
+  [ $(wc -l <<< "$output") -eq 5 ]
+  [ "${status}" -eq 0 ]
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 ${TESTSDIR}/bud/use-layers
-  images2=$(buildah images | grep "" -c)
-  diff="$(($images2-$images1))"
-  [[ "$diff" == "1" ]]
+  run buildah --debug=false images -a
+  [ $(wc -l <<< "$output") -eq 6 ]
+  [ "${status}" -eq 0 ]
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
-  images3=$(buildah images | grep "" -c)
-  diff="$(($images3-$images2))"
-  [[ "$diff" == "2" ]]
+  run buildah --debug=false images -a
+  [ $(wc -l <<< "$output") -eq 8 ]
+  [ "${status}" -eq 0 ]
 
   mkdir -p ${TESTSDIR}/bud/use-layers/mount/subdir
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test4 -f Dockerfile.3 ${TESTSDIR}/bud/use-layers
-  images4=$(buildah images | grep "" -c)
+  run buildah --debug=false images -a
+  [ $(wc -l <<< "$output") -eq 10 ]
+  [ "${status}" -eq 0 ]
   touch ${TESTSDIR}/bud/use-layers/mount/subdir/file.txt
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test5 -f Dockerfile.3 ${TESTSDIR}/bud/use-layers
-  images5=$(buildah images | grep "" -c)
-  diff="$(($images5-$images4))"
-  [[ "$diff" == "2" ]]
+  run buildah --debug=false images -a
+  [ $(wc -l <<< "$output") -eq 12 ]
+  [ "${status}" -eq 0 ]
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --no-cache -t test6 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
-  images6=$(buildah images | grep "" -c)
-  diff="$(($images6-$images5))"
-  [[ "$diff" == "3" ]]
+  run buildah --debug=false images -a
+  [ $(wc -l <<< "$output") -eq 15 ]
+  [ "${status}" -eq 0 ]
 
   buildah rmi -a
   rm -rf ${TESTSDIR}/bud/use-layers/mount

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -12,6 +12,22 @@ load helpers
   buildah rmi -a -f
 }
 
+@test "images all test" {
+  buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test ${TESTSDIR}/bud/use-layers
+  run buildah --debug=false images
+  [ $(wc -l <<< "$output") -eq 3 ]
+  [ "${status}" -eq 0 ]
+  run buildah --debug=false images -a
+  [ $(wc -l <<< "$output") -eq 5 ]
+
+  # create a no name image which should show up when doing buildah images without the --all flag
+  buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/use-layers
+  run buildah --debug=false images
+  [ $(wc -l <<< "$output") -eq 4 ]
+
+  buildah rmi -a -f
+}
+
 @test "images filter test" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)


### PR DESCRIPTION
By default buildah will not show intermediate images created during builds.
When the --a flag is set, buildah will output the intermediate images as well.

Signed-off-by: umohnani8 <umohnani@redhat.com>