### PR TITLE
mount: support multiple inputs

### DIFF
--- a/docs/buildah-mount.md
+++ b/docs/buildah-mount.md
@@ -6,7 +6,7 @@ buildah\-mount - Mount a working container's root filesystem.
 ## SYNOPSIS
 **buildah** **mount**
 
-**buildah** **mount** **containerID**
+**buildah** **mount** [**containerID** [...]]
 
 ## DESCRIPTION
 Mounts the specified container's root file system in a location which can be
@@ -36,6 +36,12 @@ buildah mount
 c831414b10a3 /var/lib/containers/storage/overlay2/f3ac502d97b5681989dff84dfedc8354239bcecbdc2692f9a639f4e080a02364/merged
 
 a7060253093b /var/lib/containers/storage/overlay2/0ff7d7ca68bed1ace424f9df154d2dd7b5a125c19d887f17653cbcd5b6e30ba1/merged
+
+buildah mount efdb54a2f0d7 644db0db094c adffbea87fa8
+
+efdb54a2f0d7 /var/lib/containers/storage/overlay/f8cac5cce73e5102ab321cc5b57c0824035b5cb82b6822e3c86ebaff69fefa9c/merged
+644db0db094c /var/lib/containers/storage/overlay/c3ec418be5bda5b72dca74c4d397e05829fe62ecd577dd7518b5f7fc1ca5f491/merged
+adffbea87fa8 /var/lib/containers/storage/overlay/03a071f206f70f4fcae5379bd5126be86b5352dc2a0c3449cd6fca01b77ea868/merged
 
 ## SEE ALSO
 buildah(1)

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -15,6 +15,26 @@ load helpers
   [ "${status}" -ne 0 ]
 }
 
+@test "mount multi images" {
+  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid3=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  run buildah mount "$cid1" "$cid2" "$cid3"
+  [ "${status}" -eq 0 ] 
+  buildah rm --all
+  buildah rmi -f alpine
+}
+
+@test "mount multi images one bad" {
+  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid3=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  run buildah mount "$cid1" badcontainer "$cid2" "$cid3"
+  [ "${status}" -ne 0 ]
+  buildah rm --all
+  buildah rmi -f alpine
+}
+
 @test "list currently mounted containers" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid1"


### PR DESCRIPTION
Multiple containers can be entered at one time for mount.
After change:
```
➜  buildah git:(mount-multiple) ✗ sudo ./buildah mount efd 644 adf
/var/lib/containers/storage/overlay/f8cac5cce73e5102ab321cc5b57c0824035b5cb82b6822e3c86ebaff69fefa9c/merged
/var/lib/containers/storage/overlay/c3ec418be5bda5b72dca74c4d397e05829fe62ecd577dd7518b5f7fc1ca5f491/merged
/var/lib/containers/storage/overlay/03a071f206f70f4fcae5379bd5126be86b5352dc2a0c3449cd6fca01b77ea868/merged
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>