### PR TITLE
Change RunOptions.Stdin/Stdout/Stderr to just be Reader/Writers

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
-	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/docker/docker/builder/dockerfile/parser"
 	docker "github.com/fsouza/go-dockerclient"
@@ -472,8 +471,8 @@ func (b *Executor) Run(run imagebuilder.Run, config docker.Config) error {
 		Entrypoint: config.Entrypoint,
 		Cmd:        config.Cmd,
 		Stdin:      devNull,
-		Stdout:     ioutils.NopWriteCloser(b.out),
-		Stderr:     ioutils.NopWriteCloser(b.err),
+		Stdout:     b.out,
+		Stderr:     b.err,
 		Quiet:      b.quiet,
 	}
 	if config.NetworkDisabled {

--- a/run.go
+++ b/run.go
@@ -150,9 +150,9 @@ type RunOptions struct {
 	Terminal TerminalPolicy
 	// The stdin/stdout/stderr descriptors to use.  If set to nil, the
 	// corresponding files in the "os" package are used as defaults.
-	Stdin  io.ReadCloser  `json:"-"`
-	Stdout io.WriteCloser `json:"-"`
-	Stderr io.WriteCloser `json:"-"`
+	Stdin  io.Reader `json:"-"`
+	Stdout io.Writer `json:"-"`
+	Stderr io.Writer `json:"-"`
 	// Quiet tells the run to turn off output to stdout.
 	Quiet bool
 }


### PR DESCRIPTION
Change `RunOptions.Stdin` from a `ReadCloser` to a `Reader`, since we weren't closing it.  Likewise, change `RunOptions.Stdout` and `.Stderr` from `WriteCloser`s to `Writer`s, since we weren't closing them, either.