### PR TITLE
Break out SetupIntermediateMountNamespace()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ LDFLAGS := -ldflags '-X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_I
 
 all: buildah imgtype docs
 
-buildah: *.go imagebuildah/*.go cmd/buildah/*.go docker/*.go pkg/cli/*.go pkg/parse/*.go util/*.go
+buildah: *.go imagebuildah/*.go bind/*.go cmd/buildah/*.go docker/*.go pkg/cli/*.go pkg/parse/*.go util/*.go
 	$(GO) build $(LDFLAGS) -o buildah $(BUILDFLAGS) ./cmd/buildah
 
 imgtype: *.go docker/*.go util/*.go tests/imgtype/imgtype.go

--- a/add.go
+++ b/add.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah/util"
 	"github.com/projectatomic/libpod/pkg/chrootuser"
 	"github.com/sirupsen/logrus"
 )
@@ -98,7 +99,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		return err
 	}
 	containerOwner := idtools.IDPair{UID: int(user.UID), GID: int(user.GID)}
-	hostUID, hostGID, err := getHostIDs(b.IDMappingOptions.UIDMap, b.IDMappingOptions.GIDMap, user.UID, user.GID)
+	hostUID, hostGID, err := util.GetHostIDs(b.IDMappingOptions.UIDMap, b.IDMappingOptions.GIDMap, user.UID, user.GID)
 	if err != nil {
 		return err
 	}

--- a/bind/mount.go
+++ b/bind/mount.go
@@ -1,0 +1,203 @@
+// +build linux
+
+package bind
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/mount"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah/util"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// SetupIntermediateMountNamespace creates a new mount namespace and bind
+// mounts all bind-mount sources into a subdirectory of bundlePath that can
+// only be reached by the root user of the container's user namespace, except
+// for Mounts which include the NoBindOption option in their options list.  The
+// NoBindOption will then merely be removed.
+func SetupIntermediateMountNamespace(spec *specs.Spec, bundlePath string) (unmountAll func() error, err error) {
+	defer stripNoBindOption(spec)
+
+	// We expect a root directory to be defined.
+	if spec.Root == nil {
+		return nil, errors.Errorf("configuration has no root filesystem?")
+	}
+	rootPath := spec.Root.Path
+
+	// Create a new mount namespace in which to do the things we're doing.
+	if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {
+		return nil, errors.Wrapf(err, "error creating new mount namespace for %v", spec.Process.Args)
+	}
+
+	// Make all of our mounts private to our namespace.
+	if err := mount.MakeRPrivate("/"); err != nil {
+		return nil, errors.Wrapf(err, "error making mounts private to mount namespace for %v", spec.Process.Args)
+	}
+
+	// Make sure the bundle directory is searchable.  We created it with
+	// TempDir(), so it should have started with permissions set to 0700.
+	info, err := os.Stat(bundlePath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error checking permissions on %q", bundlePath)
+	}
+	if err = os.Chmod(bundlePath, info.Mode()|0111); err != nil {
+		return nil, errors.Wrapf(err, "error loosening permissions on %q", bundlePath)
+	}
+
+	// Figure out who needs to be able to reach these bind mounts in order
+	// for the container to be started.
+	rootUID, rootGID, err := util.GetHostRootIDs(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	// Hand back a callback that the caller can use to clean up everything
+	// we're doing here.
+	unmount := []string{}
+	unmountAll = func() (err error) {
+		for _, mountpoint := range unmount {
+			subdirs := []string{}
+			var infos []*mount.Info
+			infos, err = mount.GetMounts()
+			// Gather up mountpoints below this one, since we did
+			// some recursive mounting.
+			if err == nil {
+				for _, info := range infos {
+					if info.Mountpoint != mountpoint && strings.HasPrefix(info.Mountpoint, mountpoint) {
+						subdirs = dedupeStringSlice(append(subdirs, info.Mountpoint))
+					}
+				}
+			}
+			// Unmount all of the lower mountpoints...
+			sort.Strings(subdirs)
+			for i := range subdirs {
+				var err2 error
+				subdir := subdirs[len(subdirs)-i-1]
+				for err2 == nil {
+					err2 = unix.Unmount(subdir, unix.MNT_DETACH)
+				}
+				if errno, ok := err2.(syscall.Errno); !ok || errno != unix.EINVAL {
+					logrus.Errorf("error unmounting %q: %v", subdir, err2)
+					if err == nil {
+						err = err2
+					}
+				}
+			}
+			// ... and then the mountpoint itself.
+			if err2 := unix.Unmount(mountpoint, unix.MNT_DETACH); err2 != nil {
+				if errno, ok := err2.(syscall.Errno); !ok || errno != unix.EINVAL {
+					logrus.Errorf("error unmounting %q (MNT_DETACH): %v", mountpoint, err2)
+					if err == nil {
+						err = err2
+					}
+				}
+			}
+			// Remove just the mountpoint.
+			if err2 := os.Remove(mountpoint); err2 != nil {
+				logrus.Warnf("error removing %q: %v", mountpoint, err2)
+				if err == nil {
+					err = err2
+				}
+			}
+		}
+		return err
+	}
+
+	// Create a top-level directory that the "root" user will be able to
+	// access, that "root" from containers which use different mappings, or
+	// other unprivileged users outside of containers, shouldn't be able to
+	// access.
+	mnt := filepath.Join(bundlePath, "mnt")
+	if err = idtools.MkdirAndChown(mnt, 0100, idtools.IDPair{UID: int(rootUID), GID: int(rootGID)}); err != nil {
+		return unmountAll, errors.Wrapf(err, "error creating %q owned by the container's root user", mnt)
+	}
+
+	// Make that directory private, and add it to the list of locations we
+	// unmount at cleanup time.
+	if err = mount.MakeRPrivate(mnt); err != nil {
+		return unmountAll, errors.Wrapf(err, "error marking filesystem at %q as private", mnt)
+	}
+	unmount = append([]string{mnt}, unmount...)
+
+	// Create a bind mount for the root filesystem and add it to the list.
+	rootfs := filepath.Join(mnt, "rootfs")
+	if err = os.Mkdir(rootfs, 0000); err != nil {
+		return unmountAll, errors.Wrapf(err, "error creating directory %q", rootfs)
+	}
+	if err = unix.Mount(rootPath, rootfs, "", unix.MS_BIND|unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
+		return unmountAll, errors.Wrapf(err, "error bind mounting root filesystem from %q to %q", rootPath, rootfs)
+	}
+	unmount = append([]string{rootfs}, unmount...)
+	spec.Root.Path = rootfs
+
+	// Do the same for everything we're binding in.
+	mounts := make([]specs.Mount, 0, len(spec.Mounts))
+	for i := range spec.Mounts {
+		// If we're not using an intermediate, leave it in the list.
+		if leaveBindMountAlone(spec.Mounts[i]) {
+			mounts = append(mounts, spec.Mounts[i])
+			continue
+		}
+		// Check if the source is a directory or something else.
+		info, err := os.Stat(spec.Mounts[i].Source)
+		if err != nil {
+			if os.IsNotExist(err) {
+				logrus.Warnf("couldn't find %q on host to bind mount into container", spec.Mounts[i].Source)
+				continue
+			}
+			return unmountAll, errors.Wrapf(err, "error checking if %q is a directory", spec.Mounts[i].Source)
+		}
+		stage := filepath.Join(mnt, fmt.Sprintf("buildah-bind-target-%d", i))
+		if info.IsDir() {
+			// If the source is a directory, make one to use as the
+			// mount target.
+			if err = os.Mkdir(stage, 0000); err != nil {
+				return unmountAll, errors.Wrapf(err, "error creating directory %q", stage)
+			}
+		} else {
+			// If the source is not a directory, create an empty
+			// file to use as the mount target.
+			file, err := os.OpenFile(stage, os.O_WRONLY|os.O_CREATE, 0000)
+			if err != nil {
+				return unmountAll, errors.Wrapf(err, "error creating file %q", stage)
+			}
+			file.Close()
+		}
+		// Bind mount the source from wherever it is to a place where
+		// we know the runtime helper will be able to get to it...
+		if err = unix.Mount(spec.Mounts[i].Source, stage, "", unix.MS_BIND|unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
+			return unmountAll, errors.Wrapf(err, "error bind mounting bind object from %q to %q", spec.Mounts[i].Source, stage)
+		}
+		logrus.Debugf("bind mounted %q to %q", spec.Mounts[i].Source, stage)
+		spec.Mounts[i].Source = stage
+		// ... and update the source location that we'll pass to the
+		// runtime to our intermediate location.
+		mounts = append(mounts, spec.Mounts[i])
+		unmount = append([]string{stage}, unmount...)
+	}
+	spec.Mounts = mounts
+
+	return unmountAll, nil
+}
+
+// Decide if the mount should not be redirected to an intermediate location first.
+func leaveBindMountAlone(mount specs.Mount) bool {
+	// If we know we shouldn't do a redirection for this mount, skip it.
+	if util.StringInSlice(NoBindOption, mount.Options) {
+		return true
+	}
+	// If we're not bind mounting it in, we don't need to do anything for it.
+	if mount.Type != "bind" && !util.StringInSlice("bind", mount.Options) && !util.StringInSlice("rbind", mount.Options) {
+		return true
+	}
+	return false
+}

--- a/bind/mount_unsupported.go
+++ b/bind/mount_unsupported.go
@@ -1,0 +1,25 @@
+// +build !linux
+
+package bind
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/mount"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// SetupIntermediateMountNamespace returns a no-op unmountAll() and no error.
+func SetupIntermediateMountNamespace(spec *specs.Spec, bundlePath string) (unmountAll func() error, err error) {
+	stripNoBuildahBindOption(spec)
+	return func() error { return nil }, nil
+}

--- a/bind/util.go
+++ b/bind/util.go
@@ -1,0 +1,39 @@
+package bind
+
+import (
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/projectatomic/buildah/util"
+)
+
+const (
+	// NoBindOption is an option which, if present in a Mount structure's
+	// options list, will cause SetupIntermediateMountNamespace to not
+	// redirect it through a bind mount.
+	NoBindOption = "nobuildahbind"
+)
+
+func stripNoBindOption(spec *specs.Spec) {
+	for i := range spec.Mounts {
+		if util.StringInSlice(NoBindOption, spec.Mounts[i].Options) {
+			prunedOptions := make([]string, 0, len(spec.Mounts[i].Options))
+			for _, option := range spec.Mounts[i].Options {
+				if option != NoBindOption {
+					prunedOptions = append(prunedOptions, option)
+				}
+			}
+			spec.Mounts[i].Options = prunedOptions
+		}
+	}
+}
+
+func dedupeStringSlice(slice []string) []string {
+	done := make([]string, 0, len(slice))
+	m := make(map[string]struct{})
+	for _, s := range slice {
+		if _, present := m[s]; !present {
+			m[s] = struct{}{}
+			done = append(done, s)
+		}
+	}
+	return done
+}

--- a/run.go
+++ b/run.go
@@ -664,15 +664,15 @@ func setupNamespaces(g *generate.Generator, namespaceOptions NamespaceOptions, i
 		if err := g.AddOrReplaceLinuxNamespace(specs.UserNamespace, ""); err != nil {
 			return false, nil, false, errors.Wrapf(err, "error adding new %q namespace for run", string(specs.UserNamespace))
 		}
+		hostUidmap, hostGidmap, err := util.GetHostIDMappings("")
+		if err != nil {
+			return false, nil, false, err
+		}
 		for _, m := range idmapOptions.UIDMap {
 			g.AddLinuxUIDMapping(m.HostID, m.ContainerID, m.Size)
 		}
 		if len(idmapOptions.UIDMap) == 0 {
-			mappings, err := getProcIDMappings("/proc/self/uid_map")
-			if err != nil {
-				return false, nil, false, err
-			}
-			for _, m := range mappings {
+			for _, m := range hostUidmap {
 				g.AddLinuxUIDMapping(m.ContainerID, m.ContainerID, m.Size)
 			}
 		}
@@ -680,11 +680,7 @@ func setupNamespaces(g *generate.Generator, namespaceOptions NamespaceOptions, i
 			g.AddLinuxGIDMapping(m.HostID, m.ContainerID, m.Size)
 		}
 		if len(idmapOptions.GIDMap) == 0 {
-			mappings, err := getProcIDMappings("/proc/self/gid_map")
-			if err != nil {
-				return false, nil, false, err
-			}
-			for _, m := range mappings {
+			for _, m := range hostGidmap {
 				g.AddLinuxGIDMapping(m.ContainerID, m.ContainerID, m.Size)
 			}
 		}

--- a/util.go
+++ b/util.go
@@ -2,11 +2,8 @@ package buildah
 
 import (
 	"archive/tar"
-	"bufio"
 	"io"
 	"os"
-	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/containers/image/docker/reference"
@@ -167,38 +164,6 @@ func (b *Builder) tarPath() func(path string) (io.ReadCloser, error) {
 			GIDMaps:     tarMappings.GIDs(),
 		})
 	}
-}
-
-// getProcIDMappings reads mappings from the named node under /proc.
-func getProcIDMappings(path string) ([]rspec.LinuxIDMapping, error) {
-	var mappings []rspec.LinuxIDMapping
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error reading ID mappings from %q", path)
-	}
-	defer f.Close()
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		fields := strings.Fields(line)
-		if len(fields) != 3 {
-			return nil, errors.Errorf("line %q from %q has %d fields, not 3", line, path, len(fields))
-		}
-		cid, err := strconv.ParseUint(fields[0], 10, 32)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing container ID value %q from line %q in %q", fields[0], line, path)
-		}
-		hid, err := strconv.ParseUint(fields[1], 10, 32)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing host ID value %q from line %q in %q", fields[1], line, path)
-		}
-		size, err := strconv.ParseUint(fields[2], 10, 32)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing size value %q from line %q in %q", fields[2], line, path)
-		}
-		mappings = append(mappings, rspec.LinuxIDMapping{ContainerID: uint32(cid), HostID: uint32(hid), Size: uint32(size)})
-	}
-	return mappings, nil
 }
 
 // getRegistries obtains the list of registries defined in the global registries file.

--- a/util.go
+++ b/util.go
@@ -41,15 +41,6 @@ func copyStringSlice(s []string) []string {
 	return t
 }
 
-func stringInSlice(s string, slice []string) bool {
-	for _, v := range slice {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}
-
 func convertStorageIDMaps(UIDMap, GIDMap []idtools.IDMap) ([]rspec.LinuxIDMapping, []rspec.LinuxIDMapping) {
 	uidmap := make([]rspec.LinuxIDMapping, 0, len(UIDMap))
 	gidmap := make([]rspec.LinuxIDMapping, 0, len(GIDMap))
@@ -208,45 +199,6 @@ func getProcIDMappings(path string) ([]rspec.LinuxIDMapping, error) {
 		mappings = append(mappings, rspec.LinuxIDMapping{ContainerID: uint32(cid), HostID: uint32(hid), Size: uint32(size)})
 	}
 	return mappings, nil
-}
-
-// getHostIDs uses ID mappings to compute the host-level IDs that will
-// correspond to a UID/GID pair in the container.
-func getHostIDs(uidmap, gidmap []rspec.LinuxIDMapping, uid, gid uint32) (uint32, uint32, error) {
-	uidMapped := true
-	for _, m := range uidmap {
-		uidMapped = false
-		if uid >= m.ContainerID && uid < m.ContainerID+m.Size {
-			uid = (uid - m.ContainerID) + m.HostID
-			uidMapped = true
-			break
-		}
-	}
-	if !uidMapped {
-		return 0, 0, errors.Errorf("container uses ID mappings, but doesn't map UID %d", uid)
-	}
-	gidMapped := true
-	for _, m := range gidmap {
-		gidMapped = false
-		if gid >= m.ContainerID && gid < m.ContainerID+m.Size {
-			gid = (gid - m.ContainerID) + m.HostID
-			gidMapped = true
-			break
-		}
-	}
-	if !gidMapped {
-		return 0, 0, errors.Errorf("container uses ID mappings, but doesn't map GID %d", gid)
-	}
-	return uid, gid, nil
-}
-
-// getHostRootIDs uses ID mappings in spec to compute the host-level IDs that will
-// correspond to UID/GID 0/0 in the container.
-func getHostRootIDs(spec *rspec.Spec) (uint32, uint32, error) {
-	if spec.Linux == nil {
-		return 0, 0, nil
-	}
-	return getHostIDs(spec.Linux.UIDMappings, spec.Linux.GIDMappings, 0, 0)
 }
 
 // getRegistries obtains the list of registries defined in the global registries file.

--- a/util/util.go
+++ b/util/util.go
@@ -1,11 +1,13 @@
 package util
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/containers/image/directory"
@@ -17,6 +19,7 @@ import (
 	"github.com/containers/image/tarball"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/idtools"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -293,4 +296,135 @@ func GetHostRootIDs(spec *specs.Spec) (uint32, uint32, error) {
 		return 0, 0, nil
 	}
 	return GetHostIDs(spec.Linux.UIDMappings, spec.Linux.GIDMappings, 0, 0)
+}
+
+// getHostIDMappings reads mappings from the named node under /proc.
+func getHostIDMappings(path string) ([]specs.LinuxIDMapping, error) {
+	var mappings []specs.LinuxIDMapping
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading ID mappings from %q", path)
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		if len(fields) != 3 {
+			return nil, errors.Errorf("line %q from %q has %d fields, not 3", line, path, len(fields))
+		}
+		cid, err := strconv.ParseUint(fields[0], 10, 32)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error parsing container ID value %q from line %q in %q", fields[0], line, path)
+		}
+		hid, err := strconv.ParseUint(fields[1], 10, 32)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error parsing host ID value %q from line %q in %q", fields[1], line, path)
+		}
+		size, err := strconv.ParseUint(fields[2], 10, 32)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error parsing size value %q from line %q in %q", fields[2], line, path)
+		}
+		mappings = append(mappings, specs.LinuxIDMapping{ContainerID: uint32(cid), HostID: uint32(hid), Size: uint32(size)})
+	}
+	return mappings, nil
+}
+
+// GetHostIDMappings reads mappings for the current process from the kernel.
+func GetHostIDMappings(pid string) ([]specs.LinuxIDMapping, []specs.LinuxIDMapping, error) {
+	if pid == "" {
+		pid = "self"
+	}
+	uidmap, err := getHostIDMappings(fmt.Sprintf("/proc/%s/uid_map", pid))
+	if err != nil {
+		return nil, nil, err
+	}
+	gidmap, err := getHostIDMappings(fmt.Sprintf("/proc/%s/gid_map", pid))
+	if err != nil {
+		return nil, nil, err
+	}
+	return uidmap, gidmap, nil
+}
+
+// GetSubIDMappings reads mappings from /etc/subuid and /etc/subgid.
+func GetSubIDMappings(user, group string) ([]specs.LinuxIDMapping, []specs.LinuxIDMapping, error) {
+	mappings, err := idtools.NewIDMappings(user, group)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "error reading subuid mappings for user %q and subgid mappings for group %q", user, group)
+	}
+	var uidmap, gidmap []specs.LinuxIDMapping
+	for _, m := range mappings.UIDs() {
+		uidmap = append(uidmap, specs.LinuxIDMapping{
+			ContainerID: uint32(m.ContainerID),
+			HostID:      uint32(m.HostID),
+			Size:        uint32(m.Size),
+		})
+	}
+	for _, m := range mappings.GIDs() {
+		gidmap = append(gidmap, specs.LinuxIDMapping{
+			ContainerID: uint32(m.ContainerID),
+			HostID:      uint32(m.HostID),
+			Size:        uint32(m.Size),
+		})
+	}
+	return uidmap, gidmap, nil
+}
+
+// ParseIDMappings parses mapping triples.
+func ParseIDMappings(uidmap, gidmap []string) ([]idtools.IDMap, []idtools.IDMap, error) {
+	nonDigitsToWhitespace := func(r rune) rune {
+		if strings.IndexRune("0123456789", r) == -1 {
+			return ' '
+		} else {
+			return r
+		}
+	}
+	parseTriple := func(spec []string) (container, host, size uint32, err error) {
+		cid, err := strconv.ParseUint(spec[0], 10, 32)
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("error parsing id map value %q: %v", spec[0], err)
+		}
+		hid, err := strconv.ParseUint(spec[1], 10, 32)
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("error parsing id map value %q: %v", spec[1], err)
+		}
+		sz, err := strconv.ParseUint(spec[2], 10, 32)
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("error parsing id map value %q: %v", spec[2], err)
+		}
+		return uint32(cid), uint32(hid), uint32(sz), nil
+	}
+	parseIDMap := func(mapSpec []string, mapSetting string) (idmap []idtools.IDMap, err error) {
+		for _, idMapSpec := range mapSpec {
+			idSpec := strings.Fields(strings.Map(nonDigitsToWhitespace, idMapSpec))
+			if len(idSpec)%3 != 0 {
+				return nil, errors.Errorf("error initializing ID mappings: %s setting is malformed", mapSetting)
+			}
+			for i := range idSpec {
+				if i%3 != 0 {
+					continue
+				}
+				cid, hid, size, err := parseTriple(idSpec[i : i+3])
+				if err != nil {
+					return nil, errors.Errorf("error initializing ID mappings: %s setting is malformed", mapSetting)
+				}
+				mapping := idtools.IDMap{
+					ContainerID: int(cid),
+					HostID:      int(hid),
+					Size:        int(size),
+				}
+				idmap = append(idmap, mapping)
+			}
+		}
+		return idmap, nil
+	}
+	uid, err := parseIDMap(uidmap, "userns-uid-map")
+	if err != nil {
+		return nil, nil, err
+	}
+	gid, err := parseIDMap(gidmap, "userns-gid-map")
+	if err != nil {
+		return nil, nil, err
+	}
+	return uid, gid, nil
 }


### PR DESCRIPTION
Move `SetupIntermediateMountNamespace()` into its own package.  Move a number of helper functions into the `util` subdirectory.