### PR TITLE
Use the right formatting when adding entries to /etc/hosts

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -221,7 +221,7 @@ func GetBuildInfo(b *Builder) BuilderInfo {
 
 // CommonBuildOptions are resources that can be defined by flags for both buildah from and build-using-dockerfile
 type CommonBuildOptions struct {
-	// AddHost is the list of hostnames to add to the resolv.conf
+	// AddHost is the list of hostnames to add to the build container's /etc/hosts.
 	AddHost []string
 	// CgroupParent is the path to cgroups under which the cgroup for the container will be created.
 	CgroupParent string

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -185,7 +185,7 @@ var (
 	FromAndBudFlags = append(append([]cli.Flag{
 		cli.StringSliceFlag{
 			Name:  "add-host",
-			Usage: "add a custom host-to-IP mapping (host:ip) (default [])",
+			Usage: "add a custom host-to-IP mapping (`host:ip`) (default [])",
 		},
 		cli.StringFlag{
 			Name:  "cgroup-parent",

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -332,7 +332,7 @@ func getDockerAuth(creds string) (*types.DockerAuthConfig, error) {
 	}, nil
 }
 
-//  IDMappingOptions parses the build options from user namespace
+// IDMappingOptions parses the build options related to user namespaces and ID mapping.
 func IDMappingOptions(c *cli.Context) (usernsOptions buildah.NamespaceOptions, idmapOptions *buildah.IDMappingOptions, err error) {
 	user := c.String("userns-uid-map-user")
 	group := c.String("userns-gid-map-group")
@@ -466,7 +466,7 @@ func parseIDMap(spec []string) (m [][3]uint32, err error) {
 	return m, nil
 }
 
-//  NamesapceOptions parses the build options from all namespaces except user namespace
+// NamespaceOptions parses the build options for all namespaces except for user namespace.
 func NamespaceOptions(c *cli.Context) (namespaceOptions buildah.NamespaceOptions, networkPolicy buildah.NetworkConfigurationPolicy, err error) {
 	options := make(buildah.NamespaceOptions, 0, 7)
 	policy := buildah.NetworkDefault

--- a/run.go
+++ b/run.go
@@ -227,7 +227,17 @@ func addRlimits(ulimit []string, g *generate.Generator) error {
 func addHosts(hosts []string, w io.Writer) error {
 	buf := bufio.NewWriter(w)
 	for _, host := range hosts {
-		fmt.Fprintln(buf, host)
+		values := strings.SplitN(host, ":", 2)
+		if len(values) != 2 {
+			return errors.Errorf("unable to parse host entry %q: incorrect format", host)
+		}
+		if values[0] == "" {
+			return errors.Errorf("hostname in host entry %q is empty", host)
+		}
+		if values[1] == "" {
+			return errors.Errorf("IP address in host entry %q is empty", host)
+		}
+		fmt.Fprintf(buf, "%s\t%s\n", values[1], values[0])
 	}
 	return buf.Flush()
 }

--- a/run_test.go
+++ b/run_test.go
@@ -98,8 +98,8 @@ func TestAddHosts(t *testing.T) {
 		},
 		{
 			name:     "host list",
-			hosts:    []string{"localhost", "host-1", "host-2"},
-			expected: "localhost\nhost-1\nhost-2\n",
+			hosts:    []string{"localhost:127.0.0.1", "host-1:127.0.0.2", "host-2:127.0.0.3"},
+			expected: "127.0.0.1\tlocalhost\n127.0.0.2\thost-1\n127.0.0.3\thost-2\n",
 		},
 	}
 	for _, te := range tt {
@@ -126,8 +126,8 @@ func TestAddHostsToFile(t *testing.T) {
 			prepare: func() (*os.File, error) {
 				return ioutil.TempFile("", "buildah-hosts-test")
 			},
-			hosts:    []string{"host-1", "system-1"},
-			expected: "host-1\nsystem-1\n",
+			hosts:    []string{"host-1:127.0.0.2", "system-1:127.0.0.3", "ipv6-host:::1"},
+			expected: "127.0.0.2\thost-1\n127.0.0.3\tsystem-1\n::1\tipv6-host\n",
 		},
 		{
 			name: "append hosts to file",
@@ -144,8 +144,8 @@ func TestAddHostsToFile(t *testing.T) {
 				}
 				return file, nil
 			},
-			hosts:    []string{"host-0", "host-1", "dns.name.1"},
-			expected: "localhost\nhost-0\nhost-1\ndns.name.1\n",
+			hosts:    []string{"host-0:127.0.0.2", "host-1:127.0.0.3", "dns.name.1:127.0.0.4"},
+			expected: "localhost\n127.0.0.2\thost-0\n127.0.0.3\thost-1\n127.0.0.4\tdns.name.1\n",
 		},
 		{
 			name: "empty host list",


### PR DESCRIPTION
Append address+"\t"+hostname to the hosts file instead of the "hostname:address" format that we picked up from the command line.