### PR TITLE
Run(): add options for adding and removing capabilities

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -163,6 +163,13 @@ type Builder struct {
 	CNIConfigDir string
 	// ID mapping options to use when running processes in the container with non-host user namespaces.
 	IDMappingOptions IDMappingOptions
+	// AddCapabilities is a list of capabilities to add to the default set when running
+	// commands in the container.
+	AddCapabilities []string
+	// DropCapabilities is a list of capabilities to remove from the default set,
+	// after processing the AddCapabilities set, when running commands in the container.
+	// If a capability appears in both lists, it will be dropped.
+	DropCapabilities []string
 
 	CommonBuildOpts *CommonBuildOptions
 	// TopLayer is the top layer of the image
@@ -327,6 +334,13 @@ type BuilderOptions struct {
 	CNIConfigDir string
 	// ID mapping options to use if we're setting up our own user namespace.
 	IDMappingOptions *IDMappingOptions
+	// AddCapabilities is a list of capabilities to add to the default set when
+	// running commands in the container.
+	AddCapabilities []string
+	// DropCapabilities is a list of capabilities to remove from the default set,
+	// after processing the AddCapabilities set, when running commands in the
+	// container.  If a capability appears in both lists, it will be dropped.
+	DropCapabilities []string
 
 	CommonBuildOpts *CommonBuildOptions
 }

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -199,6 +199,8 @@ func budCmd(c *cli.Context) error {
 		CNIPluginPath:           c.String("cni-plugin-path"),
 		CNIConfigDir:            c.String("cni-config-dir"),
 		IDMappingOptions:        idmappingOptions,
+		AddCapabilities:         c.StringSlice("cap-add"),
+		DropCapabilities:        c.StringSlice("cap-drop"),
 		CommonBuildOpts:         commonOpts,
 		DefaultMountsFilePath:   c.GlobalString("default-mounts-file"),
 		IIDFile:                 c.String("iidfile"),

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -214,6 +214,8 @@ func fromCmd(c *cli.Context) error {
 		CNIPluginPath:         c.String("cni-plugin-path"),
 		CNIConfigDir:          c.String("cni-config-dir"),
 		IDMappingOptions:      idmappingOptions,
+		AddCapabilities:       c.StringSlice("cap-add"),
+		DropCapabilities:      c.StringSlice("cap-drop"),
 		CommonBuildOpts:       commonOpts,
 	}
 

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -18,6 +18,14 @@ import (
 
 var (
 	runFlags = []cli.Flag{
+		cli.StringSliceFlag{
+			Name:  "cap-add",
+			Usage: "add the specified capability (default [])",
+		},
+		cli.StringSliceFlag{
+			Name:  "cap-drop",
+			Usage: "drop the specified capability (default [])",
+		},
 		cli.StringFlag{
 			Name:  "hostname",
 			Usage: "set the hostname inside of the container",
@@ -104,6 +112,8 @@ func runCmd(c *cli.Context) error {
 		ConfigureNetwork: networkPolicy,
 		CNIPluginPath:    c.String("cni-plugin-path"),
 		CNIConfigDir:     c.String("cni-config-dir"),
+		AddCapabilities:  c.StringSlice("cap-add"),
+		DropCapabilities: c.StringSlice("cap-drop"),
 	}
 
 	if c.IsSet("tty") {

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -48,6 +48,26 @@ resulting image's configuration.
 
 Images to utilise as potential cache sources. Buildah does not currently support caching so this is a NOOP.
 
+**--cap-add**=*CAP\_xxx*
+
+When executing RUN instructions, run the command specified in the instruction
+with the specified capability added to its capability set.
+Certain capabilities are granted by default; this option can be used to add
+more.
+
+**--cap-drop**=*CAP\_xxx*
+
+When executing RUN instructions, run the command specified in the instruction
+with the specified capability removed from its capability set.
+The CAP\_AUDIT\_WRITE, CAP\_CHOWN, CAP\_DAC\_OVERRIDE, CAP\_FOWNER,
+CAP\_FSETID, CAP\_KILL, CAP\_MKNOD, CAP\_NET\_BIND\_SERVICE, CAP\_SETFCAP,
+CAP\_SETGID, CAP\_SETPCAP, CAP\_SETUID, and CAP\_SYS\_CHROOT capabilities are
+granted by default; this option can be used to remove them.
+
+If a capability is specified to both the **--cap-add** and **--cap-drop**
+options, it will be dropped, regardless of the order in which the options were
+given.
+
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -48,6 +48,26 @@ Add a line to /etc/hosts. The format is hostname:ip. The **--add-host** option c
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
+**--cap-add**=*CAP\_xxx*
+
+Add the specified capability to the default set of capabilities which will be
+supplied for subsequent *buildah run* invocations which use this container.
+Certain capabilities are granted by default; this option can be used to add
+more.
+
+**--cap-drop**=*CAP\_xxx*
+
+Remove the specified capability from the default set of capabilities which will
+be supplied for subsequent *buildah run* invocations which use this container.
+The CAP\_AUDIT\_WRITE, CAP\_CHOWN, CAP\_DAC\_OVERRIDE, CAP\_FOWNER,
+CAP\_FSETID, CAP\_KILL, CAP\_MKNOD, CAP\_NET\_BIND\_SERVICE, CAP\_SETFCAP,
+CAP\_SETGID, CAP\_SETPCAP, CAP\_SETUID, and CAP\_SYS\_CHROOT capabilities are
+granted by default; this option can be used to remove them.
+
+If a capability is specified to both the **--cap-add** and **--cap-drop**
+options, it will be dropped, regardless of the order in which the options were
+given.
+
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -14,6 +14,30 @@ the *buildah config* command.  To execute *buildah run* within an
 interactive shell, specify the --tty option.
 
 ## OPTIONS
+**--cap-add**=*CAP\_xxx*
+
+Add the specified capability to the set of capabilities which will be granted
+to the specified command.
+Certain capabilities are granted by default; this option can be used to add
+more beyond the defaults, which may have been modified by **--cap-add** and
+**--cap-drop** options used with the *buildah from* invocation which created
+the container.
+
+**--cap-drop**=*CAP\_xxx*
+
+Add the specified capability from the set of capabilities which will be granted
+to the specified command.
+The CAP\_AUDIT\_WRITE, CAP\_CHOWN, CAP\_DAC\_OVERRIDE, CAP\_FOWNER,
+CAP\_FSETID, CAP\_KILL, CAP\_MKNOD, CAP\_NET\_BIND\_SERVICE, CAP\_SETFCAP,
+CAP\_SETGID, CAP\_SETPCAP, CAP\_SETUID, and CAP\_SYS\_CHROOT capabilities are
+granted by default; this option can be used to remove them from the defaults,
+which may have been modified by **--cap-add** and **--cap-drop** options used
+with the *buildah from* invocation which created the container.
+
+If a capability is specified to both the **--cap-add** and **--cap-drop**
+options, it will be dropped, regardless of the order in which the options were
+given.
+
 **--cni-config-dir**=*directory*
 
 Location of CNI configuration files which will dictate which plugins will be

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -127,6 +127,13 @@ type BuildOptions struct {
 	// ID mapping options to use if we're setting up our own user namespace
 	// when handling RUN instructions.
 	IDMappingOptions *buildah.IDMappingOptions
+	// AddCapabilities is a list of capabilities to add to the default set when
+	// handling RUN instructions.
+	AddCapabilities []string
+	// DropCapabilities is a list of capabilities to remove from the default set
+	// when handling RUN instructions. If a capability appears in both lists, it
+	// will be dropped.
+	DropCapabilities []string
 	CommonBuildOpts  *buildah.CommonBuildOptions
 	// DefaultMountsFilePath is the file path holding the mounts to be mounted in "host-path:container-path" format
 	DefaultMountsFilePath string

--- a/new.go
+++ b/new.go
@@ -317,8 +317,10 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 			UIDMap:         uidmap,
 			GIDMap:         gidmap,
 		},
-		CommonBuildOpts: options.CommonBuildOpts,
-		TopLayer:        topLayer,
+		AddCapabilities:  copyStringSlice(options.AddCapabilities),
+		DropCapabilities: copyStringSlice(options.DropCapabilities),
+		CommonBuildOpts:  options.CommonBuildOpts,
+		TopLayer:         topLayer,
 	}
 
 	if options.Mount {

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -187,6 +187,14 @@ var (
 			Name:  "add-host",
 			Usage: "add a custom host-to-IP mapping (host:ip) (default [])",
 		},
+		cli.StringSliceFlag{
+			Name:  "cap-add",
+			Usage: "add the specified capability when running (default [])",
+		},
+		cli.StringSliceFlag{
+			Name:  "cap-drop",
+			Usage: "drop the specified capability when running (default [])",
+		},
 		cli.StringFlag{
 			Name:  "cgroup-parent",
 			Usage: "optional parent cgroup for the container",

--- a/util/types.go
+++ b/util/types.go
@@ -8,3 +8,23 @@ const (
 	// DefaultCNIConfigDir is the default location of CNI configuration files.
 	DefaultCNIConfigDir = "/etc/cni/net.d"
 )
+
+var (
+	// DefaultCapabilities is the list of capabilities which we grant by
+	// default to containers which are running under UID 0.
+	DefaultCapabilities = []string{
+		"CAP_AUDIT_WRITE",
+		"CAP_CHOWN",
+		"CAP_DAC_OVERRIDE",
+		"CAP_FOWNER",
+		"CAP_FSETID",
+		"CAP_KILL",
+		"CAP_MKNOD",
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SETFCAP",
+		"CAP_SETGID",
+		"CAP_SETPCAP",
+		"CAP_SETUID",
+		"CAP_SYS_CHROOT",
+	}
+)


### PR DESCRIPTION
Add `RunOptions` and `BuildOptions` flags for modifying the list of granted capabilities from the default.

Default to dropping CAP_NET_RAW.