### PR TITLE
Scrub ~ from /root value in push

### DIFF
--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -86,6 +86,8 @@ func pushCmd(c *cli.Context) error {
 	}
 	src := args[0]
 	destSpec := args[1]
+	home := os.Getenv("HOME")
+	destSpec = strings.Replace(destSpec, "~", home, -1)
 
 	compress := archive.Gzip
 	if c.Bool("disable-compression") {


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

If the user supplies a tilde ('~') in the destination for push, replace the tilde with the value of the HOME environment variable.   This addresses #777.  As @pixdrift points out there, gnu spec states that the tilde won't be converted unless it's at the start of the string.  I've added this as a possible convenience for the end user.  No harm if we decide to stick with the gnu thinking and burn this pr.

Testing:
```
Before fix:
# buildah push alpine oci:~/tom.oci:latest
lstat /root/~: no such file or directory

After Fix:
# buildah push alpine oci:~/tom.oci:latest
Getting image source signatures
Copying blob sha256:cd7100a72410606589a54b932cabd804a17f9ae5b42a1882bd56d263e02b6215
 4.20 MiB / 4.20 MiB [======================================================] 0s
Copying config sha256:b1a7f144ece0194921befe57ab30ed1fd98c5950db7996719429020986092058
 585 B / 585 B [============================================================] 0s
Writing manifest to image destination
Storing signatures
```