### PR TITLE
Allow --userns-uid-map/--userns-gid-map to be global options

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -61,6 +61,14 @@ func main() {
 			Usage: "storage driver option",
 			Value: defaultStoreDriverOptions,
 		},
+		cli.StringSliceFlag{
+			Name:  "userns-uid-map",
+			Usage: "default `ctrID:hostID:length` UID mapping to use",
+		},
+		cli.StringSliceFlag{
+			Name:  "userns-gid-map",
+			Usage: "default `ctrID:hostID:length` GID mapping to use",
+		},
 		cli.StringFlag{
 			Name:   "default-mounts-file",
 			Usage:  "path to default mounts file",

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -388,9 +388,17 @@ Directly specifies a UID mapping which should be used to set ownership, at the
 filesytem level, on the working container's contents.
 Commands run when handling `RUN` instructions will default to being run in
 their own user namespaces, configured using the UID and GID maps.
+
 Entries in this map take the form of one or more triples of a starting
 in-container UID, a corresponding starting host-level UID, and the number of
 consecutive IDs which the map entry represents.
+
+This option overrides the *remap-uids* setting in the *options* section of
+/etc/containers/storage.conf.
+
+If this option is not specified, but a global --userns-uid-map setting is
+supplied, settings from the global option will be used.
+
 If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-uid-map
 are specified, but --userns-gid-map is specified, the UID map will be set to
 use the same numeric values as the GID map.
@@ -401,9 +409,17 @@ Directly specifies a GID mapping which should be used to set ownership, at the
 filesytem level, on the working container's contents.
 Commands run when handling `RUN` instructions will default to being run in
 their own user namespaces, configured using the UID and GID maps.
+
 Entries in this map take the form of one or more triples of a starting
 in-container GID, a corresponding starting host-level GID, and the number of
 consecutive IDs which the map entry represents.
+
+This option overrides the *remap-gids* setting in the *options* section of
+/etc/containers/storage.conf.
+
+If this option is not specified, but a global --userns-gid-map setting is
+supplied, settings from the global option will be used.
+
 If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-gid-map
 are specified, but --userns-uid-map is specified, the GID map will be set to
 use the same numeric values as the UID map.

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -298,9 +298,17 @@ Directly specifies a UID mapping which should be used to set ownership, at the
 filesytem level, on the container's contents.
 Commands run using `buildah run` will default to being run in their own user
 namespaces, configured using the UID and GID maps.
+
 Entries in this map take the form of one or more triples of a starting
 in-container UID, a corresponding starting host-level UID, and the number of
 consecutive IDs which the map entry represents.
+
+This option overrides the *remap-uids* setting in the *options* section of
+/etc/containers/storage.conf.
+
+If this option is not specified, but a global --userns-uid-map setting is
+supplied, settings from the global option will be used.
+
 If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-uid-map
 are specified, but --userns-gid-map is specified, the UID map will be set to
 use the same numeric values as the GID map.
@@ -311,9 +319,17 @@ Directly specifies a GID mapping which should be used to set ownership, at the
 filesytem level, on the container's contents.
 Commands run using `buildah run` will default to being run in their own user
 namespaces, configured using the UID and GID maps.
+
 Entries in this map take the form of one or more triples of a starting
 in-container GID, a corresponding starting host-level GID, and the number of
 consecutive IDs which the map entry represents.
+
+This option overrides the *remap-gids* setting in the *options* section of
+/etc/containers/storage.conf.
+
+If this option is not specified, but a global --userns-gid-map setting is
+supplied, settings from the global option will be used.
+
 If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-gid-map
 are specified, but --userns-uid-map is specified, the GID map will be set to
 use the same numeric values as the UID map.

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -64,10 +64,29 @@ specify additional options via the `--storage-opt` flag.
 
 Storage driver option, Default Storage driver options are configured in /etc/containers/storage.conf
 
+**--userns-uid-map** *mapping*
+
+Specifies UID mappings which should be used to set ownership, at the
+filesytem level, on the contents of images and containers.
+Entries in this map take the form of one or more triples of a starting
+in-container UID, a corresponding starting host-level UID, and the number of
+consecutive IDs which the map entry represents.
+This option overrides the *remap-uids* setting in the *options* section of
+/etc/containers/storage.conf.
+
+**--userns-gid-map** *mapping*
+
+Specifies GID mappings which should be used to set ownership, at the
+filesytem level, on the contents of images and containers.
+Entries in this map take the form of one or more triples of a starting
+in-container GID, a corresponding starting host-level GID, and the number of
+consecutive IDs which the map entry represents.
+This option overrides the *remap-gids* setting in the *options* section of
+/etc/containers/storage.conf.
+
 **--version, -v**
 
 Print the version
-
 
 ## COMMANDS
 

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -367,7 +367,14 @@ func IDMappingOptions(c *cli.Context) (usernsOptions buildah.NamespaceOptions, i
 		}
 		// Parse the flag's value as one or more triples (if it's even
 		// been set), and append them.
-		idmap, err := parseIDMap(c.StringSlice(option))
+		var spec []string
+		if c.GlobalIsSet(option) {
+			spec = c.GlobalStringSlice(option)
+		}
+		if c.IsSet(option) {
+			spec = c.StringSlice(option)
+		}
+		idmap, err := parseIDMap(spec)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Allow --userns-uid-map and --userns-gid-map to be specified as global options, which can be overridden by options specified to commands which know them as non-global options.

This will mainly benefit tools that want to set ID mappings for buildah to use, but which don't want to have to figure out whether or not they're invoking it with a subcommand that recognizes these options.