### PR TITLE
Restore CAP_NET_RAW

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -60,7 +60,7 @@ more.
 When executing RUN instructions, run the command specified in the instruction
 with the specified capability removed from its capability set.
 The CAP\_AUDIT\_WRITE, CAP\_CHOWN, CAP\_DAC\_OVERRIDE, CAP\_FOWNER,
-CAP\_FSETID, CAP\_KILL, CAP\_MKNOD, CAP\_NET\_BIND\_SERVICE, CAP\_SETFCAP,
+CAP\_FSETID, CAP\_KILL, CAP\_MKNOD, CAP\_NET\_BIND\_SERVICE, CAP\_NET\_RAW, CAP\_SETFCAP,
 CAP\_SETGID, CAP\_SETPCAP, CAP\_SETUID, and CAP\_SYS\_CHROOT capabilities are
 granted by default; this option can be used to remove them.
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -66,7 +66,7 @@ more.
 Remove the specified capability from the default set of capabilities which will
 be supplied for subsequent *buildah run* invocations which use this container.
 The CAP\_AUDIT\_WRITE, CAP\_CHOWN, CAP\_DAC\_OVERRIDE, CAP\_FOWNER,
-CAP\_FSETID, CAP\_KILL, CAP\_MKNOD, CAP\_NET\_BIND\_SERVICE, CAP\_SETFCAP,
+CAP\_FSETID, CAP\_KILL, CAP\_MKNOD, CAP\_NET\_BIND\_SERVICE, CAP\_NET\_RAW, CAP\_SETFCAP,
 CAP\_SETGID, CAP\_SETPCAP, CAP\_SETUID, and CAP\_SYS\_CHROOT capabilities are
 granted by default; this option can be used to remove them.
 

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -28,7 +28,7 @@ the container.
 Add the specified capability from the set of capabilities which will be granted
 to the specified command.
 The CAP\_AUDIT\_WRITE, CAP\_CHOWN, CAP\_DAC\_OVERRIDE, CAP\_FOWNER,
-CAP\_FSETID, CAP\_KILL, CAP\_MKNOD, CAP\_NET\_BIND\_SERVICE, CAP\_SETFCAP,
+CAP\_FSETID, CAP\_KILL, CAP\_MKNOD, CAP\_NET\_BIND\_SERVICE, CAP\_NET\_RAW, CAP\_SETFCAP,
 CAP\_SETGID, CAP\_SETPCAP, CAP\_SETUID, and CAP\_SYS\_CHROOT capabilities are
 granted by default; this option can be used to remove them from the defaults,
 which may have been modified by **--cap-add** and **--cap-drop** options used

--- a/util/types.go
+++ b/util/types.go
@@ -21,6 +21,7 @@ var (
 		"CAP_KILL",
 		"CAP_MKNOD",
 		"CAP_NET_BIND_SERVICE",
+		"CAP_NET_RAW",
 		"CAP_SETFCAP",
 		"CAP_SETGID",
 		"CAP_SETPCAP",


### PR DESCRIPTION
Add CAP_NET_RAW back to the default list of granted capabilities.

Add capabilities lists to `inspect` output.