### PR TITLE
Fix ARGS parsing for run commands

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -105,6 +105,8 @@ func (p NetworkConfigurationPolicy) String() string {
 type Builder struct {
 	store storage.Store
 
+	// Args define variables that users can pass at build-time to the builder
+	Args map[string]string
 	// Type is used to help identify a build container's metadata.  It
 	// should not be modified.
 	Type string `json:"type"`
@@ -279,6 +281,9 @@ type CommonBuildOptions struct {
 
 // BuilderOptions are used to initialize a new Builder.
 type BuilderOptions struct {
+
+	// Args define variables that users can pass at build-time to the builder
+	Args map[string]string
 	// FromImage is the name of the image which should be used as the
 	// starting point for the container.  It can be set to an empty value
 	// or "scratch" to indicate that the container should not be based on

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -601,6 +601,7 @@ func (b *Executor) Prepare(ctx context.Context, ib *imagebuilder.Builder, node *
 		b.log("FROM %s", from)
 	}
 	builderOptions := buildah.BuilderOptions{
+		Args:                  ib.Args,
 		FromImage:             from,
 		PullPolicy:            b.pullPolicy,
 		Registry:              b.registry,

--- a/new.go
+++ b/new.go
@@ -321,6 +321,7 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		DropCapabilities: copyStringSlice(options.DropCapabilities),
 		CommonBuildOpts:  options.CommonBuildOpts,
 		TopLayer:         topLayer,
+		Args:             options.Args,
 	}
 
 	if options.Mount {

--- a/run.go
+++ b/run.go
@@ -824,6 +824,10 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		}
 	}
 
+	for src, dest := range b.Args {
+		g.AddProcessEnv(src, dest)
+	}
+
 	if b.CommonBuildOpts == nil {
 		return errors.Errorf("Invalid format on container you must recreate the container")
 	}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -783,3 +783,11 @@ load helpers
   [ "$output" = "" ]
   test -s ${TESTDIR}/logfile
 }
+
+@test "bud with ARGS" {
+  target=alpine-image
+  run buildah -debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.args ${TESTSDIR}/bud/run-scenarios
+  echo "$output"
+  [[ "$output" =~ "arg_value" ]]
+  [ "$status" -eq 0 ]
+}

--- a/tests/bud/run-scenarios/Dockerfile.args
+++ b/tests/bud/run-scenarios/Dockerfile.args
@@ -1,0 +1,4 @@
+FROM alpine
+ARG arg="arg_value"
+RUN echo ${arg}
+


### PR DESCRIPTION
Currently we are not adding the ARGS passed in via Dockerfile
or --build-args into the running container as environment variables.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>