### PR TITLE
Add info on registries.conf to from manpage

### DIFF
--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -32,6 +32,12 @@ Multiple transports are supported:
   **ostree:**_image_[**@**_/absolute/repo/path_]
   An image in local OSTree repository.  _/absolute/repo/path_ defaults to _/ostree/repo_.
 
+### DEPENDENCIES
+
+Buildah resolves the path to the registry to pull from by using the /etc/containers/registries.conf
+file, registries.conf(5).  If the `buildah from` command fails with an "image not known" error,
+first verify that the registries.conf file is installed and configured appropriately.
+
 ## RETURN VALUE
 The container ID of the container that was created.  On error, 1 is returned and errno is returned.
 

--- a/docs/buildah-inspect.md
+++ b/docs/buildah-inspect.md
@@ -33,5 +33,7 @@ buildah inspect --type container containerID
 
 buildah inspect --type image imageID
 
+buildah inspect --format '{{.OCIv1.Config.Env}}' alpine
+
 ## SEE ALSO
 buildah(1)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add a DEPENDENCIES sub-section to the `buildah-from` man page.  I realize it's a bit unconventional, but I think we've had enough folks outside of Fedora/RHEL who've stumbled into this.  Hopefully this will help address this.  Hopefully addresses #810

Also snuck in a small example into `buildah inspect` to show how to format the returned data from that command.  