### PR TITLE
build without seccomp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 AUTOTAGS := $(shell ./btrfs_tag.sh) $(shell ./libdm_tag.sh) $(shell ./ostree_tag.sh) $(shell ./selinux_tag.sh)
-TAGS := seccomp
+TAGS ?= seccomp
 PREFIX := /usr/local
 BINDIR := $(PREFIX)/bin
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions

--- a/config_noseccomp.go
+++ b/config_noseccomp.go
@@ -1,0 +1,11 @@
+// +build !seccomp
+
+package buildah
+
+import "github.com/opencontainers/runtime-spec/specs-go"
+
+func setupSeccomp(spec *specs.Spec, seccompProfilePath string) error {
+	// If no seccomp is being used, the Seccomp profile in the Linux spec
+	// is not set
+	return nil
+}

--- a/config_seccomp.go
+++ b/config_seccomp.go
@@ -1,0 +1,35 @@
+// +build seccomp
+
+package buildah
+
+import (
+	"io/ioutil"
+
+	"github.com/docker/docker/profiles/seccomp"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+)
+
+func setupSeccomp(spec *specs.Spec, seccompProfilePath string) error {
+	switch seccompProfilePath {
+	case "unconfined":
+		spec.Linux.Seccomp = nil
+	case "":
+		seccompConfig, err := seccomp.GetDefaultProfile(spec)
+		if err != nil {
+			return errors.Wrapf(err, "loading default seccomp profile failed")
+		}
+		spec.Linux.Seccomp = seccompConfig
+	default:
+		seccompProfile, err := ioutil.ReadFile(seccompProfilePath)
+		if err != nil {
+			return errors.Wrapf(err, "opening seccomp profile (%s) failed", seccompProfilePath)
+		}
+		seccompConfig, err := seccomp.LoadProfile(string(seccompProfile), spec)
+		if err != nil {
+			return errors.Wrapf(err, "loading seccomp profile (%s) failed", seccompProfilePath)
+		}
+		spec.Linux.Seccomp = seccompConfig
+	}
+	return nil
+}

--- a/run.go
+++ b/run.go
@@ -21,7 +21,6 @@ import (
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/reexec"
-	"github.com/docker/docker/profiles/seccomp"
 	units "github.com/docker/go-units"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -654,30 +653,6 @@ func setupCapabilities(g *generate.Generator, firstAdds, firstDrops, secondAdds,
 	}
 	if err := setupCapDrop(g, secondDrops...); err != nil {
 		return err
-	}
-	return nil
-}
-
-func setupSeccomp(spec *specs.Spec, seccompProfilePath string) error {
-	switch seccompProfilePath {
-	case "unconfined":
-		spec.Linux.Seccomp = nil
-	case "":
-		seccompConfig, err := seccomp.GetDefaultProfile(spec)
-		if err != nil {
-			return errors.Wrapf(err, "loading default seccomp profile failed")
-		}
-		spec.Linux.Seccomp = seccompConfig
-	default:
-		seccompProfile, err := ioutil.ReadFile(seccompProfilePath)
-		if err != nil {
-			return errors.Wrapf(err, "opening seccomp profile (%s) failed", seccompProfilePath)
-		}
-		seccompConfig, err := seccomp.LoadProfile(string(seccompProfile), spec)
-		if err != nil {
-			return errors.Wrapf(err, "loading seccomp profile (%s) failed", seccompProfilePath)
-		}
-		spec.Linux.Seccomp = seccompConfig
 	}
 	return nil
 }


### PR DESCRIPTION
If the seccomp build tag is disabled or selinux is not detected, build without
them.

Signed-off-by: baude <bbaude@redhat.com>