### PR TITLE
Implement basic recognition of the "--isolation" option

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -149,6 +149,8 @@ type Builder struct {
 	// DefaultMountsFilePath is the file path holding the mounts to be mounted in "host-path:container-path" format.
 	DefaultMountsFilePath string `json:"defaultMountsFilePath,omitempty"`
 
+	// Isolation controls how we handle "RUN" statements and the Run() method.
+	Isolation Isolation
 	// NamespaceOptions controls how we set up the namespaces for processes that we run in the container.
 	NamespaceOptions NamespaceOptions
 	// ConfigureNetwork controls whether or not network interfaces and
@@ -195,6 +197,7 @@ type BuilderInfo struct {
 	OCIv1                 v1.Image
 	Docker                docker.V2Image
 	DefaultMountsFilePath string
+	Isolation             string
 	NamespaceOptions      NamespaceOptions
 	ConfigureNetwork      string
 	CNIPluginPath         string
@@ -220,6 +223,7 @@ func GetBuildInfo(b *Builder) BuilderInfo {
 		OCIv1:                 b.OCIv1,
 		Docker:                b.Docker,
 		DefaultMountsFilePath: b.DefaultMountsFilePath,
+		Isolation:             b.Isolation.String(),
 		NamespaceOptions:      b.NamespaceOptions,
 		ConfigureNetwork:      fmt.Sprintf("%v", b.ConfigureNetwork),
 		CNIPluginPath:         b.CNIPluginPath,
@@ -322,6 +326,9 @@ type BuilderOptions struct {
 	// DefaultMountsFilePath is the file path holding the mounts to be
 	// mounted in "host-path:container-path" format
 	DefaultMountsFilePath string
+	// Isolation controls how we handle "RUN" statements and the Run()
+	// method.
+	Isolation Isolation
 	// NamespaceOptions controls how we set up namespaces for processes that
 	// we might need to run using the container's root filesystem.
 	NamespaceOptions NamespaceOptions

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -138,6 +138,11 @@ func budCmd(c *cli.Context) error {
 		return errors.Wrapf(err, "error building system context")
 	}
 
+	isolation, err := parse.IsolationOption(c)
+	if err != nil {
+		return err
+	}
+
 	runtimeFlags := []string{}
 	for _, arg := range c.StringSlice("runtime-flag") {
 		runtimeFlags = append(runtimeFlags, "--"+arg)
@@ -194,6 +199,7 @@ func budCmd(c *cli.Context) error {
 		RuntimeArgs:             runtimeFlags,
 		OutputFormat:            format,
 		SystemContext:           systemContext,
+		Isolation:               isolation,
 		NamespaceOptions:        namespaceOptions,
 		ConfigureNetwork:        networkPolicy,
 		CNIPluginPath:           c.String("cni-plugin-path"),

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -191,6 +191,11 @@ func fromCmd(c *cli.Context) error {
 		}
 	}
 
+	isolation, err := parse.IsolationOption(c)
+	if err != nil {
+		return err
+	}
+
 	namespaceOptions, networkPolicy, err := parse.NamespaceOptions(c)
 	if err != nil {
 		return errors.Wrapf(err, "error parsing namespace-related options")
@@ -209,6 +214,7 @@ func fromCmd(c *cli.Context) error {
 		SignaturePolicyPath:   signaturePolicy,
 		SystemContext:         systemContext,
 		DefaultMountsFilePath: c.GlobalString("default-mounts-file"),
+		Isolation:             isolation,
 		NamespaceOptions:      namespaceOptions,
 		ConfigureNetwork:      networkPolicy,
 		CNIPluginPath:         c.String("cni-plugin-path"),

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -31,8 +31,12 @@ var (
 			Usage: "set the hostname inside of the container",
 		},
 		cli.StringFlag{
+			Name:  "isolation",
+			Usage: "which process isolation `type` to use",
+		},
+		cli.StringFlag{
 			Name:  "runtime",
-			Usage: "`path` to an alternate runtime",
+			Usage: "`path` to an alternate OCI runtime",
 			Value: util.Runtime(),
 		},
 		cli.StringSliceFlag{
@@ -93,6 +97,11 @@ func runCmd(c *cli.Context) error {
 		return errors.Wrapf(err, "error reading build container %q", name)
 	}
 
+	isolation, err := parse.IsolationOption(c)
+	if err != nil {
+		return err
+	}
+
 	runtimeFlags := []string{}
 	for _, arg := range c.StringSlice("runtime-flag") {
 		runtimeFlags = append(runtimeFlags, "--"+arg)
@@ -108,6 +117,7 @@ func runCmd(c *cli.Context) error {
 		Runtime:          c.String("runtime"),
 		Args:             runtimeFlags,
 		User:             c.String("user"),
+		Isolation:        isolation,
 		NamespaceOptions: namespaceOptions,
 		ConfigureNetwork: networkPolicy,
 		CNIPluginPath:    c.String("cni-plugin-path"),

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -207,11 +207,13 @@ that the IPC namespace in which `buildah` itself is being run should be reused,
 or it can be the path to an IPC namespace which is already in use by
 another process.
 
-**--isolation** [Not Supported]
+**--isolation** *type*
 
-Buildah is not currently supported on Windows, and does not have a daemon.
-If you want to override the container isolation you can choose a different
-OCI Runtime, using the --runtime flag.
+Controls what type of isolation is used when processing RUN instructions.
+Recognized types include *oci* (OCI-compatible runtime, the default).
+
+Note: You can also override the default isolation type by setting the
+BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`
 
 **--label** *label*
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -174,6 +174,14 @@ that the IPC namespace in which `buildah` itself is being run should be reused,
 or it can be the path to an IPC namespace which is already in use by
 another process.
 
+**--isolation** *type*
+
+Controls what type of isolation will be used by default by `buildah run`.
+Recognized types include *oci* (OCI-compatible runtime, the default).
+
+Note: You can also override the default isolation type by setting the
+BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`
+
 **--memory, -m**=""
 
 Memory limit (format: <number>[<unit>], where unit = b, k, m or g)

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -63,6 +63,14 @@ that the IPC namespace in which `buildah` itself is being run should be reused,
 or it can be the path to an IPC namespace which is already in use by another
 process.
 
+**--isolation** *type*
+
+Controls what type of isolation is used for running the process.
+Recognized types include *oci* (OCI-compatible runtime, the default).
+
+Note: You can also override the default isolation type by setting the
+BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`
+
 **--net** *how*
 **--network** *how*
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -67,8 +67,11 @@ type BuildOptions struct {
 	IgnoreUnrecognizedInstructions bool
 	// Quiet tells us whether or not to announce steps as we go through them.
 	Quiet bool
-	// Runtime is the name of the command to run for RUN instructions.  It
-	// should accept the same arguments and flags that runc does.
+	// Isolation controls how Run() runs things.
+	Isolation buildah.Isolation
+	// Runtime is the name of the command to run for RUN instructions when
+	// Isolation is either IsolationDefault or IsolationOCI.  It should
+	// accept the same arguments and flags that runc does.
 	Runtime string
 	// RuntimeArgs adds global arguments for the runtime.
 	RuntimeArgs []string
@@ -193,6 +196,7 @@ type Executor struct {
 	volumeCache                    map[string]string
 	volumeCacheInfo                map[string]os.FileInfo
 	reportWriter                   io.Writer
+	isolation                      buildah.Isolation
 	namespaceOptions               []buildah.NamespaceOption
 	configureNetwork               buildah.NetworkConfigurationPolicy
 	cniPluginPath                  string
@@ -551,6 +555,7 @@ func NewExecutor(store storage.Store, options BuildOptions) (*Executor, error) {
 		out:                     options.Out,
 		err:                     options.Err,
 		reportWriter:            options.ReportWriter,
+		isolation:               options.Isolation,
 		namespaceOptions:        options.NamespaceOptions,
 		configureNetwork:        options.ConfigureNetwork,
 		cniPluginPath:           options.CNIPluginPath,
@@ -609,6 +614,7 @@ func (b *Executor) Prepare(ctx context.Context, ib *imagebuilder.Builder, node *
 		SignaturePolicyPath:   b.signaturePolicyPath,
 		ReportWriter:          b.reportWriter,
 		SystemContext:         b.systemContext,
+		Isolation:             b.isolation,
 		NamespaceOptions:      b.namespaceOptions,
 		ConfigureNetwork:      b.configureNetwork,
 		CNIPluginPath:         b.cniPluginPath,

--- a/new.go
+++ b/new.go
@@ -307,6 +307,7 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		ProcessLabel:          processLabel,
 		MountLabel:            mountLabel,
 		DefaultMountsFilePath: options.DefaultMountsFilePath,
+		Isolation:             options.Isolation,
 		NamespaceOptions:      namespaceOptions,
 		ConfigureNetwork:      options.ConfigureNetwork,
 		CNIPluginPath:         options.CNIPluginPath,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -119,6 +119,10 @@ var (
 			Name:  "iidfile",
 			Usage: "`file` to write the image ID to",
 		},
+		cli.StringFlag{
+			Name:  "isolation",
+			Usage: "`type` of process isolation to use",
+		},
 		cli.StringSliceFlag{
 			Name:  "label",
 			Usage: "Set metadata for an image (default [])",

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -530,3 +530,23 @@ func NamespaceOptions(c *cli.Context) (namespaceOptions buildah.NamespaceOptions
 	}
 	return options, policy, nil
 }
+
+func defaultIsolation() buildah.Isolation {
+	isolation := os.Getenv("BUILDAH_ISOLATION")
+	if strings.HasPrefix(strings.ToLower(isolation), "oci") {
+		return buildah.IsolationOCI
+	}
+	return buildah.IsolationDefault
+}
+
+// IsolationOption parses the --isolation flag.
+func IsolationOption(c *cli.Context) (buildah.Isolation, error) {
+	if c.String("isolation") != "" {
+		if strings.HasPrefix(strings.ToLower(c.String("isolation")), "oci") {
+			return buildah.IsolationOCI, nil
+		} else {
+			return buildah.IsolationDefault, errors.Errorf("unrecognized isolation type %q", c.String("isolation"))
+		}
+	}
+	return defaultIsolation(), nil
+}

--- a/run.go
+++ b/run.go
@@ -103,10 +103,34 @@ type IDMappingOptions struct {
 	GIDMap         []specs.LinuxIDMapping
 }
 
+// Isolation provides a way to specify whether we're supposed to use a proper
+// OCI runtime, or some other method for running commands.
+type Isolation int
+
+const (
+	// IsolationDefault is whatever we think will work best.
+	IsolationDefault Isolation = iota
+	// IsolationOCI is a proper OCI runtime.
+	IsolationOCI
+)
+
+// String converts a Isolation into a string.
+func (i Isolation) String() string {
+	switch i {
+	case IsolationDefault:
+		return "IsolationDefault"
+	case IsolationOCI:
+		return "IsolationOCI"
+	}
+	return fmt.Sprintf("unrecognized isolation type %d", i)
+}
+
 // RunOptions can be used to alter how a command is run in the container.
 type RunOptions struct {
 	// Hostname is the hostname we set for the running container.
 	Hostname string
+	// Isolation is either IsolationDefault or IsolationOCI.
+	Isolation Isolation
 	// Runtime is the name of the command to run.  It should accept the same arguments
 	// that runc does, and produce similar output.
 	Runtime string
@@ -971,7 +995,20 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		}
 	}
 
-	return b.runUsingRuntimeSubproc(options, configureNetwork, configureNetworks, spec, mountPoint, path, Package+"-"+filepath.Base(path))
+	isolation := options.Isolation
+	if isolation == IsolationDefault {
+		isolation = b.Isolation
+		if isolation == IsolationDefault {
+			isolation = IsolationOCI
+		}
+	}
+	switch isolation {
+	case IsolationOCI:
+		err = b.runUsingRuntimeSubproc(options, configureNetwork, configureNetworks, spec, mountPoint, path, Package+"-"+filepath.Base(path))
+	default:
+		err = errors.Errorf("don't know how to run this command")
+	}
+	return err
 }
 
 type runUsingRuntimeSubprocOptions struct {


### PR DESCRIPTION
Add the basics of handling the "--isolation" option, though at the moment, the only recognized option is "oci", which is our default.