### PR TITLE
Add Capabilities lists to BuilderInfo

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah/docker"
+	"github.com/projectatomic/buildah/util"
 )
 
 const (
@@ -200,6 +201,9 @@ type BuilderInfo struct {
 	CNIPluginPath         string
 	CNIConfigDir          string
 	IDMappingOptions      IDMappingOptions
+	DefaultCapabilities   []string
+	AddCapabilities       []string
+	DropCapabilities      []string
 }
 
 // GetBuildInfo gets a pointer to a Builder object and returns a BuilderInfo object from it.
@@ -225,6 +229,9 @@ func GetBuildInfo(b *Builder) BuilderInfo {
 		CNIPluginPath:         b.CNIPluginPath,
 		CNIConfigDir:          b.CNIConfigDir,
 		IDMappingOptions:      b.IDMappingOptions,
+		DefaultCapabilities:   append([]string{}, util.DefaultCapabilities...),
+		AddCapabilities:       append([]string{}, b.AddCapabilities...),
+		DropCapabilities:      append([]string{}, b.DropCapabilities...),
 	}
 }
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -674,7 +674,7 @@ func (b *Executor) Prepare(ctx context.Context, ib *imagebuilder.Builder, node *
 	}
 	b.mountPoint = mountPoint
 	b.builder = builder
-	// Add the top  layer of this image to b.topLayers so we can keep track of them
+	// Add the top layer of this image to b.topLayers so we can keep track of them
 	// when building with cached images.
 	b.topLayers = append(b.topLayers, builder.TopLayer)
 	return nil


### PR DESCRIPTION
Add the `DefaultCapabilities`, `AddCapabilities`, and `DropCapabilities` lists to `BuilderInfo` structures.