### PR TITLE
umount: add all option to umount all mounted containers

### DIFF
--- a/cmd/buildah/umount.go
+++ b/cmd/buildah/umount.go
@@ -5,11 +5,16 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"github.com/projectatomic/buildah/util"
 	"github.com/urfave/cli"
 )
 
 var (
+	umountFlags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "all, a",
+			Usage: "umount all of the currently mounted containers",
+		},
+	}
 	umountCommand = cli.Command{
 		Name:           "umount",
 		Aliases:        []string{"unmount"},
@@ -17,15 +22,20 @@ var (
 		Description:    "Unmounts the root file system on the specified working containers",
 		Action:         umountCmd,
 		ArgsUsage:      "CONTAINER-NAME-OR-ID [...]",
+		Flags:          umountFlags,
 		SkipArgReorder: true,
 	}
 )
 
 func umountCmd(c *cli.Context) error {
+	umountAll := c.Bool("all")
 	umountContainerErrStr := "error unmounting container"
 	args := c.Args()
-	if len(args) == 0 {
+	if len(args) == 0 && !umountAll {
 		return errors.Errorf("at least one container ID must be specified")
+	}
+	if len(args) > 0 && umountAll {
+		return errors.Errorf("when using the --all switch, you may not pass any container IDs")
 	}
 
 	store, err := getStore(c)
@@ -34,20 +44,50 @@ func umountCmd(c *cli.Context) error {
 	}
 
 	var lastError error
-	for _, name := range args {
+	if len(args) > 0 {
+		for _, name := range args {
+			builder, err := openBuilder(getContext(), store, name)
+			if err != nil {
+				if lastError != nil {
+					fmt.Fprintln(os.Stderr, lastError)
+				}
+				lastError = errors.Wrapf(err, "%s %s", umountContainerErrStr, name)
+				continue
+			}
+			if builder.MountPoint == "" {
+				continue
+			}
 
-		builder, err := openBuilder(getContext(), store, name)
+			id := builder.ContainerID
+			if err = builder.Unmount(); err != nil {
+				if lastError != nil {
+					fmt.Fprintln(os.Stderr, lastError)
+				}
+				lastError = errors.Wrapf(err, "%s %q", umountContainerErrStr, builder.Container)
+				continue
+			}
+			fmt.Printf("%s\n", id)
+		}
+	} else {
+		builders, err := openBuilders(store)
 		if err != nil {
-			lastError = util.WriteError(os.Stderr, errors.Wrapf(err, "%s %s", umountContainerErrStr, name), lastError)
-			continue
+			return errors.Wrapf(err, "error reading build Containers")
 		}
+		for _, builder := range builders {
+			if builder.MountPoint == "" {
+				continue
+			}
 
-		id := builder.ContainerID
-		if err = builder.Unmount(); err != nil {
-			lastError = util.WriteError(os.Stderr, errors.Wrapf(err, "%s %q", umountContainerErrStr, builder.Container), lastError)
-			continue
+			id := builder.ContainerID
+			if err = builder.Unmount(); err != nil {
+				if lastError != nil {
+					fmt.Fprintln(os.Stderr, lastError)
+				}
+				lastError = errors.Wrapf(err, "%s %q", umountContainerErrStr, builder.Container)
+				continue
+			}
+			fmt.Printf("%s\n", id)
 		}
-		fmt.Printf("%s\n", id)
 	}
 	return lastError
 }

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -522,6 +522,8 @@ return 1
 
  _buildah_umount() {
      local boolean_options="
+     --all
+     -a
      --help
      -h
   "

--- a/docs/buildah-umount.md
+++ b/docs/buildah-umount.md
@@ -9,11 +9,18 @@ buildah\-umount - Unmount the root file system on the specified working containe
 ## DESCRIPTION
 Unmounts the root file system on the specified working containers.
 
+## OPTIONS
+**--all, -a**
+
+All of the currently mounted containers will be unmounted.
+
 ## EXAMPLE
 
 buildah umount containerID
 
 buildah umount containerID1 containerID2 containerID3
+
+buildah umount --all
 
 ## SEE ALSO
 buildah(1)

--- a/tests/umount.bats
+++ b/tests/umount.bats
@@ -28,6 +28,18 @@ load helpers
   buildah rm --all
 }
 
+@test "umount all images" {
+  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah mount "$cid1"
+  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah mount "$cid2"
+  cid3=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah mount "$cid3"
+  run buildah umount --all
+  [ "${status}" -eq 0 ]
+  buildah rm --all
+}
+
 @test "umount multi images one bad" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid1"


### PR DESCRIPTION
Umount all of the currently mounted containers.
After change:

```
➜  buildah git:(umount-all) sudo ./buildah umount --all
43e674866c4cb46dfc64988b95a8247d6ae5fd17f0b15a46f16a81cb62a55353
14d5fbebf8eadf8056f72271cff1e86147fe40990331c5bf76e251f3cdd25b81
07d02e23e58503a33ec1886c1bfd6e9831fe05c5ac2ea8c6d9e2a939cb40b9fc
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>