### PR TITLE
bind/mount_unsupported.go: remove import errors

### DIFF
--- a/bind/mount_unsupported.go
+++ b/bind/mount_unsupported.go
@@ -3,23 +3,11 @@
 package bind
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-	"sort"
-	"strings"
-	"syscall"
-
-	"github.com/containers/storage/pkg/idtools"
-	"github.com/containers/storage/pkg/mount"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 // SetupIntermediateMountNamespace returns a no-op unmountAll() and no error.
 func SetupIntermediateMountNamespace(spec *specs.Spec, bundlePath string) (unmountAll func() error, err error) {
-	stripNoBuildahBindOption(spec)
+	stripNoBindOption(spec)
 	return func() error { return nil }, nil
 }


### PR DESCRIPTION
In bind/mount_unsupported.go, no imports are needed. The current version
causes compilation errors when building for darwin.

../src/github.com/projectatomic/libpod/vendor/github.com/projectatomic/buildah/bind/mount_unsupported.go:6:2: imported and not used: "fmt"
../src/github.com/projectatomic/libpod/vendor/github.com/projectatomic/buildah/bind/mount_unsupported.go:7:2: imported and not used: "os"
../src/github.com/projectatomic/libpod/vendor/github.com/projectatomic/buildah/bind/mount_unsupported.go:8:2: imported and not used: "path/filepath"

...

Signed-off-by: baude <bbaude@redhat.com>