### PR TITLE
mount: output it before replacing lastError

### DIFF
--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah/pkg/parse"
 	"github.com/projectatomic/buildah/util"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -47,11 +48,17 @@ func mountCmd(c *cli.Context) error {
 		for _, name := range args {
 			builder, err := openBuilder(getContext(), store, name)
 			if err != nil {
+				if lastError != nil {
+					logrus.Error(lastError)
+				}
 				lastError = util.WriteError(os.Stderr, errors.Wrapf(err, "error reading build container %q", name), lastError)
 				continue
 			}
 			mountPoint, err := builder.Mount(builder.MountLabel)
 			if err != nil {
+				if lastError != nil {
+					logrus.Error(lastError)
+				}
 				lastError = util.WriteError(os.Stderr, errors.Wrapf(err, "error mounting %q container %q", name, builder.Container), lastError)
 				continue
 			}


### PR DESCRIPTION
The same error was found in [#825 discussion](https://github.com/projectatomic/buildah/pull/825#discussion_r198082771). Fix it.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>