### PR TITLE
Fix buildah bud --layers

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -11,6 +11,10 @@ load helpers
   run buildah --debug=false images -a
   [ $(wc -l <<< "$output") -eq 6 ]
   [ "${status}" -eq 0 ]
+  run buildah inspect --format "{{.Docker.ContainerConfig.Env}}" test2
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [[ $output =~ "foo=bar" ]]
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a
@@ -33,7 +37,7 @@ load helpers
   [ $(wc -l <<< "$output") -eq 15 ]
   [ "${status}" -eq 0 ]
 
-  buildah rmi -a
+  buildah rmi -a -f
   rm -rf ${TESTSDIR}/bud/use-layers/mount
 }
 
@@ -49,7 +53,7 @@ load helpers
   [ "${status}" -eq 0 ]
 
   buildah rm -a
-  buildah rmi -a
+  buildah rmi -a -f
 }
 
 @test "bud with --force-rm flag" {
@@ -68,7 +72,7 @@ load helpers
   [ "${status}" -eq 0 ]
 
   buildah rm -a
-  buildah rmi -a
+  buildah rmi -a -f
 }
 
 @test "bud from base image should have base image ENV also" {

--- a/util/util.go
+++ b/util/util.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/image/docker/reference"
 	ociarchive "github.com/containers/image/oci/archive"
 	"github.com/containers/image/pkg/sysregistries"
+	"github.com/containers/image/signature"
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/tarball"
 	"github.com/containers/image/types"
@@ -463,4 +464,18 @@ func UnsharedRunrootPath(uid string) (string, error) {
 		return filepath.Join("/var/run/user", uid, "run"), nil
 	}
 	return "", errors.New("unable to determine a --runroot location: $XDG_RUNTIME_DIR is not set, and we don't know our UID")
+}
+
+// GetPolicyContext sets up, initializes and returns a new context for the specified policy
+func GetPolicyContext(ctx *types.SystemContext) (*signature.PolicyContext, error) {
+	policy, err := signature.DefaultPolicy(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	policyContext, err := signature.NewPolicyContext(policy)
+	if err != nil {
+		return nil, err
+	}
+	return policyContext, nil
 }


### PR DESCRIPTION
When building with layers, the last step wouldn't get implemented
if a cache already existed. This fix checks if every step in the dockerfile
is the same, and if it is it just creates a copy of the existing image
with the new name passed in by the user. The images will have the same
IDs and the new one will just be another tag of the original image.
This is what docker build does as well.

Signed-off-by: umohnani8 <umohnani@redhat.com>