### PR TITLE
Add --isolation chroot

### DIFF
--- a/.papr.sh
+++ b/.papr.sh
@@ -15,6 +15,7 @@ dnf install -y \
   findutils \
   git \
   glib2-devel \
+  glibc-static \
   gnupg \
   golang \
   gpgme-devel \
@@ -37,3 +38,4 @@ go get github.com/onsi/gomega/...
 # up to, but not including, the merge commit.
 export GITVALIDATE_TIP=$(cd $GOSRC; git log -2 --pretty='%H' | tail -n 1)
 make -C $GOSRC install.tools runc all validate test-unit test-integration TAGS="seccomp"
+env BUILDAH_ISOLATION=chroot make -C $GOSRC test-integration TAGS="seccomp"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ go:
     - 1.10.x
     - tip
 
+env:
+    - BUILDAH_ISOLATION=oci
+    - BUILDAH_ISOLATION=chroot
+
 matrix:
   # If the latest unstable development version of go fails, that's OK.
   allow_failures:
@@ -21,7 +25,7 @@ services:
 before_install:
     - sudo add-apt-repository -y ppa:duggan/bats
     - sudo apt-get update
-    - sudo apt-get -qq install bats btrfs-tools git libapparmor-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libselinux1-dev
+    - sudo apt-get -qq install bats btrfs-tools git libapparmor-dev libc-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libselinux1-dev
     - sudo apt-get -qq remove libseccomp2
     - sudo apt-get -qq update
     - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce

--- a/chroot/run.go
+++ b/chroot/run.go
@@ -1,0 +1,1211 @@
+// +build linux
+
+package chroot
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"github.com/containers/storage/pkg/ioutils"
+	"github.com/containers/storage/pkg/mount"
+	"github.com/containers/storage/pkg/reexec"
+	"github.com/opencontainers/runc/libcontainer/apparmor"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah/bind"
+	"github.com/projectatomic/buildah/unshare"
+	"github.com/projectatomic/buildah/util"
+	"github.com/sirupsen/logrus"
+	"github.com/syndtr/gocapability/capability"
+	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// runUsingChrootCommand is a command we use as a key for reexec
+	runUsingChrootCommand = "buildah-chroot-runtime"
+	// runUsingChrootExec is a command we use as a key for reexec
+	runUsingChrootExecCommand = "buildah-chroot-exec"
+)
+
+func init() {
+	reexec.Register(runUsingChrootCommand, runUsingChrootMain)
+	reexec.Register(runUsingChrootExecCommand, runUsingChrootExecMain)
+}
+
+type runUsingChrootSubprocOptions struct {
+	Spec        *specs.Spec
+	BundlePath  string
+	UIDMappings []syscall.SysProcIDMap
+	GIDMappings []syscall.SysProcIDMap
+}
+
+type runUsingChrootExecSubprocOptions struct {
+	Spec       *specs.Spec
+	BundlePath string
+}
+
+// RunUsingChroot runs a chrooted process, using some of the settings from the
+// passed-in spec, and using the specified bundlePath to hold temporary files,
+// directories, and mountpoints.
+func RunUsingChroot(spec *specs.Spec, bundlePath string, stdin io.Reader, stdout, stderr io.Writer) (err error) {
+	var confwg sync.WaitGroup
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Write the runtime configuration, mainly for debugging.
+	specbytes, err := json.Marshal(spec)
+	if err != nil {
+		return err
+	}
+	if err = ioutils.AtomicWriteFile(filepath.Join(bundlePath, "config.json"), specbytes, 0600); err != nil {
+		return errors.Wrapf(err, "error storing runtime configuration")
+	}
+
+	// Run the grandparent subprocess in a user namespace that reuses the mappings that we have.
+	uidmap, gidmap, err := util.GetHostIDMappings("")
+	if err != nil {
+		return err
+	}
+	for i := range uidmap {
+		uidmap[i].HostID = uidmap[i].ContainerID
+	}
+	for i := range gidmap {
+		gidmap[i].HostID = gidmap[i].ContainerID
+	}
+
+	// Default to using stdin/stdout/stderr if we weren't passed objects to use.
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+
+	// Create a pipe for passing configuration down to the next process.
+	preader, pwriter, err := os.Pipe()
+	if err != nil {
+		return errors.Wrapf(err, "error creating configuration pipe")
+	}
+	config, conferr := json.Marshal(runUsingChrootSubprocOptions{
+		Spec:       spec,
+		BundlePath: bundlePath,
+	})
+	if conferr != nil {
+		return errors.Wrapf(conferr, "error encoding configuration for %q", runUsingChrootCommand)
+	}
+
+	// Set our terminal's mode to raw, to pass handling of special
+	// terminal input to the terminal in the container.
+	if spec.Process.Terminal && terminal.IsTerminal(unix.Stdin) {
+		state, err := terminal.MakeRaw(unix.Stdin)
+		if err != nil {
+			logrus.Warnf("error setting terminal state: %v", err)
+		} else {
+			defer func() {
+				if err = terminal.Restore(unix.Stdin, state); err != nil {
+					logrus.Errorf("unable to restore terminal state: %v", err)
+				}
+			}()
+		}
+	}
+
+	// Start the grandparent subprocess.
+	cmd := unshare.Command(runUsingChrootCommand)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdin, stdout, stderr
+	cmd.Dir = "/"
+	cmd.Env = append([]string{fmt.Sprintf("LOGLEVEL=%d", logrus.GetLevel())}, os.Environ()...)
+	cmd.UnshareFlags = syscall.CLONE_NEWUSER
+	cmd.UidMappings = uidmap
+	cmd.GidMappings = gidmap
+	cmd.GidMappingsEnableSetgroups = true
+
+	logrus.Debugf("Running %#v in %#v", cmd.Cmd, cmd)
+	confwg.Add(1)
+	go func() {
+		_, conferr = io.Copy(pwriter, bytes.NewReader(config))
+		pwriter.Close()
+		confwg.Done()
+	}()
+	cmd.ExtraFiles = append([]*os.File{preader}, cmd.ExtraFiles...)
+	err = cmd.Run()
+	confwg.Wait()
+	if err == nil {
+		return conferr
+	}
+	return err
+}
+
+// main() for grandparent subprocess.  Its main job is to shuttle stdio back
+// and forth, managing a pseudo-terminal if we want one, for our child, the
+// parent subprocess.
+func runUsingChrootMain() {
+	var options runUsingChrootSubprocOptions
+
+	runtime.LockOSThread()
+
+	// Set logging.
+	if level := os.Getenv("LOGLEVEL"); level != "" {
+		if ll, err := strconv.Atoi(level); err == nil {
+			logrus.SetLevel(logrus.Level(ll))
+		}
+		os.Unsetenv("LOGLEVEL")
+	}
+
+	// Unpack our configuration.
+	confPipe := os.NewFile(3, "confpipe")
+	if confPipe == nil {
+		fmt.Fprintf(os.Stderr, "error reading options pipe\n")
+		os.Exit(1)
+	}
+	defer confPipe.Close()
+	if err := json.NewDecoder(confPipe).Decode(&options); err != nil {
+		fmt.Fprintf(os.Stderr, "error decoding options: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Prepare to shuttle stdio back and forth.
+	rootUid32, rootGid32, err := util.GetHostRootIDs(options.Spec)
+	if err != nil {
+		logrus.Errorf("error determining ownership for container stdio")
+		os.Exit(1)
+	}
+	rootUid := int(rootUid32)
+	rootGid := int(rootGid32)
+	relays := make(map[int]int)
+	closeOnceRunning := []*os.File{}
+	var ctty *os.File
+	var stdin io.Reader
+	var stdinCopy io.WriteCloser
+	var stdout io.Writer
+	var stderr io.Writer
+	fdDesc := make(map[int]string)
+	deferred := func() {}
+	if options.Spec.Process.Terminal {
+		// Create a pseudo-terminal -- open a copy of the master side.
+		ptyMasterFd, err := unix.Open("/dev/ptmx", os.O_RDWR, 0600)
+		if err != nil {
+			logrus.Errorf("error opening PTY master using /dev/ptmx: %v", err)
+			os.Exit(1)
+		}
+		// Set the kernel's lock to "unlocked".
+		locked := 0
+		if result, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(ptyMasterFd), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&locked))); int(result) == -1 {
+			logrus.Errorf("error locking PTY descriptor: %v", err)
+			os.Exit(1)
+		}
+		// Get a handle for the other end.
+		ptyFd, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(ptyMasterFd), unix.TIOCGPTPEER, unix.O_RDWR|unix.O_NOCTTY)
+		if int(ptyFd) == -1 {
+			if errno, isErrno := err.(syscall.Errno); !isErrno || (errno != syscall.EINVAL && errno != syscall.ENOTTY) {
+				logrus.Errorf("error getting PTY descriptor: %v", err)
+				os.Exit(1)
+			}
+			// EINVAL means the kernel's too old to understand TIOCGPTPEER.  Try TIOCGPTN.
+			ptyN, err := unix.IoctlGetInt(ptyMasterFd, unix.TIOCGPTN)
+			if err != nil {
+				logrus.Errorf("error getting PTY number: %v", err)
+				os.Exit(1)
+			}
+			ptyName := fmt.Sprintf("/dev/pts/%d", ptyN)
+			fd, err := unix.Open(ptyName, unix.O_RDWR|unix.O_NOCTTY, 0620)
+			if err != nil {
+				logrus.Errorf("error opening PTY %q: %v", ptyName, err)
+				os.Exit(1)
+			}
+			ptyFd = uintptr(fd)
+		}
+		// Make notes about what's going where.
+		relays[ptyMasterFd] = unix.Stdout
+		relays[unix.Stdin] = ptyMasterFd
+		fdDesc[ptyMasterFd] = "container terminal"
+		fdDesc[unix.Stdin] = "stdin"
+		fdDesc[unix.Stdout] = "stdout"
+		winsize := &unix.Winsize{}
+		// Set the pseudoterminal's size to the configured size, or our own.
+		if options.Spec.Process.ConsoleSize != nil {
+			// Use configured sizes.
+			winsize.Row = uint16(options.Spec.Process.ConsoleSize.Height)
+			winsize.Col = uint16(options.Spec.Process.ConsoleSize.Width)
+		} else {
+			if terminal.IsTerminal(unix.Stdin) {
+				// Use the size of our terminal.
+				winsize, err = unix.IoctlGetWinsize(unix.Stdin, unix.TIOCGWINSZ)
+				if err != nil {
+					logrus.Debugf("error reading current terminal's size")
+					winsize.Row = 0
+					winsize.Col = 0
+				}
+			}
+		}
+		if winsize.Row != 0 && winsize.Col != 0 {
+			if err = unix.IoctlSetWinsize(int(ptyFd), unix.TIOCSWINSZ, winsize); err != nil {
+				logrus.Warnf("error setting terminal size for pty")
+			}
+			// FIXME - if we're connected to a terminal, we should
+			// be passing the updated terminal size down when we
+			// receive a SIGWINCH.
+		}
+		// Open an *os.File object that we can pass to our child.
+		ctty = os.NewFile(ptyFd, "/dev/tty")
+		// Set ownership for the PTY.
+		if err = ctty.Chown(rootUid, rootGid); err != nil {
+			var cttyInfo unix.Stat_t
+			err2 := unix.Fstat(int(ptyFd), &cttyInfo)
+			from := ""
+			op := "setting"
+			if err2 == nil {
+				op = "changing"
+				from = fmt.Sprintf("from %d/%d ", cttyInfo.Uid, cttyInfo.Gid)
+			}
+			logrus.Warnf("error %s ownership of container PTY %sto %d/%d: %v", op, from, rootUid, rootGid, err)
+		}
+		// Set permissions on the PTY.
+		if err = ctty.Chmod(0620); err != nil {
+			logrus.Errorf("error setting permissions of container PTY: %v", err)
+			os.Exit(1)
+		}
+		// Make a note that our child (the parent subprocess) should
+		// have the PTY connected to its stdio, and that we should
+		// close it once it's running.
+		stdin = ctty
+		stdout = ctty
+		stderr = ctty
+		closeOnceRunning = append(closeOnceRunning, ctty)
+	} else {
+		// Create pipes for stdio.
+		stdinRead, stdinWrite, err := os.Pipe()
+		if err != nil {
+			logrus.Errorf("error opening pipe for stdin: %v", err)
+		}
+		stdoutRead, stdoutWrite, err := os.Pipe()
+		if err != nil {
+			logrus.Errorf("error opening pipe for stdout: %v", err)
+		}
+		stderrRead, stderrWrite, err := os.Pipe()
+		if err != nil {
+			logrus.Errorf("error opening pipe for stderr: %v", err)
+		}
+		// Make notes about what's going where.
+		relays[unix.Stdin] = int(stdinWrite.Fd())
+		relays[int(stdoutRead.Fd())] = unix.Stdout
+		relays[int(stderrRead.Fd())] = unix.Stderr
+		fdDesc[int(stdinWrite.Fd())] = "container stdin pipe"
+		fdDesc[int(stdoutRead.Fd())] = "container stdout pipe"
+		fdDesc[int(stderrRead.Fd())] = "container stderr pipe"
+		fdDesc[unix.Stdin] = "stdin"
+		fdDesc[unix.Stdout] = "stdout"
+		fdDesc[unix.Stderr] = "stderr"
+		// Set ownership for the pipes.
+		if err = stdinRead.Chown(rootUid, rootGid); err != nil {
+			logrus.Errorf("error setting ownership of container stdin pipe: %v", err)
+			os.Exit(1)
+		}
+		if err = stdoutWrite.Chown(rootUid, rootGid); err != nil {
+			logrus.Errorf("error setting ownership of container stdout pipe: %v", err)
+			os.Exit(1)
+		}
+		if err = stderrWrite.Chown(rootUid, rootGid); err != nil {
+			logrus.Errorf("error setting ownership of container stderr pipe: %v", err)
+			os.Exit(1)
+		}
+		// Make a note that our child (the parent subprocess) should
+		// have the pipes connected to its stdio, and that we should
+		// close its ends of them once it's running.
+		stdin = stdinRead
+		stdout = stdoutWrite
+		stderr = stderrWrite
+		closeOnceRunning = append(closeOnceRunning, stdinRead, stdoutWrite, stderrWrite)
+		stdinCopy = stdinWrite
+		defer stdoutRead.Close()
+		defer stderrRead.Close()
+	}
+	// A helper that returns false if err is an error that would cause us
+	// to give up.
+	logIfNotRetryable := func(err error, what string) (retry bool) {
+		if err == nil {
+			return true
+		}
+		if errno, isErrno := err.(syscall.Errno); isErrno {
+			switch errno {
+			case syscall.EINTR, syscall.EAGAIN:
+				return true
+			}
+		}
+		logrus.Error(what)
+		return false
+	}
+	for readFd := range relays {
+		if err := unix.SetNonblock(readFd, true); err != nil {
+			logrus.Errorf("error setting descriptor %d (%s) non-blocking: %v", readFd, fdDesc[readFd], err)
+			return
+		}
+	}
+	go func() {
+		buffers := make(map[int]*bytes.Buffer)
+		for _, writeFd := range relays {
+			buffers[writeFd] = new(bytes.Buffer)
+		}
+		pollTimeout := -1
+		for len(relays) > 0 {
+			fds := make([]unix.PollFd, 0, len(relays))
+			for fd := range relays {
+				fds = append(fds, unix.PollFd{Fd: int32(fd), Events: unix.POLLIN | unix.POLLHUP})
+			}
+			_, err := unix.Poll(fds, pollTimeout)
+			if !logIfNotRetryable(err, fmt.Sprintf("poll: %v", err)) {
+				return
+			}
+			removeFds := make(map[int]struct{})
+			for _, rfd := range fds {
+				if rfd.Revents&unix.POLLHUP == unix.POLLHUP {
+					removeFds[int(rfd.Fd)] = struct{}{}
+				}
+				if rfd.Revents&unix.POLLNVAL == unix.POLLNVAL {
+					logrus.Debugf("error polling descriptor %s: closed?", fdDesc[int(rfd.Fd)])
+					removeFds[int(rfd.Fd)] = struct{}{}
+				}
+				if rfd.Revents&unix.POLLIN == 0 {
+					continue
+				}
+				b := make([]byte, 8192)
+				nread, err := unix.Read(int(rfd.Fd), b)
+				logIfNotRetryable(err, fmt.Sprintf("read %s: %v", fdDesc[int(rfd.Fd)], err))
+				if nread > 0 {
+					if wfd, ok := relays[int(rfd.Fd)]; ok {
+						nwritten, err := buffers[wfd].Write(b[:nread])
+						if err != nil {
+							logrus.Debugf("buffer: %v", err)
+							continue
+						}
+						if nwritten != nread {
+							logrus.Debugf("buffer: expected to buffer %d bytes, wrote %d", nread, nwritten)
+							continue
+						}
+					}
+				}
+				if nread == 0 {
+					removeFds[int(rfd.Fd)] = struct{}{}
+				}
+			}
+			pollTimeout = -1
+			for wfd, buffer := range buffers {
+				if buffer.Len() > 0 {
+					nwritten, err := unix.Write(wfd, buffer.Bytes())
+					logIfNotRetryable(err, fmt.Sprintf("write %s: %v", fdDesc[wfd], err))
+					if nwritten >= 0 {
+						_ = buffer.Next(nwritten)
+					}
+				}
+				if buffer.Len() > 0 {
+					pollTimeout = 100
+				}
+			}
+			for rfd := range removeFds {
+				if !options.Spec.Process.Terminal && rfd == unix.Stdin {
+					stdinCopy.Close()
+				}
+				delete(relays, rfd)
+			}
+		}
+	}()
+
+	// Set up mounts and namespaces, and run the parent subprocess.
+	status, err := runUsingChroot(options.Spec, options.BundlePath, ctty, stdin, stdout, stderr, closeOnceRunning)
+	deferred()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error running subprocess: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Pass the process's exit status back to the caller by exiting with the same status.
+	if status.Exited() {
+		if status.ExitStatus() != 0 {
+			fmt.Fprintf(os.Stderr, "subprocess exited with status %d\n", status.ExitStatus())
+		}
+		os.Exit(status.ExitStatus())
+	} else if status.Signaled() {
+		fmt.Fprintf(os.Stderr, "subprocess exited on %s\n", status.Signal())
+		os.Exit(1)
+	}
+}
+
+// runUsingChroot, still in the grandparent process, sets up various bind
+// mounts and then runs the parent process in its own user namespace with the
+// necessary ID mappings.
+func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io.Reader, stdout, stderr io.Writer, closeOnceRunning []*os.File) (wstatus unix.WaitStatus, err error) {
+	var confwg sync.WaitGroup
+
+	// Create a new mount namespace for ourselves and bind mount everything to a new location.
+	undoIntermediates, err := bind.SetupIntermediateMountNamespace(spec, bundlePath)
+	if err != nil {
+		return 1, err
+	}
+	defer func() {
+		undoIntermediates()
+	}()
+
+	// Bind mount in our filesystems.
+	undoChroots, err := setupChrootBindMounts(spec, bundlePath)
+	if err != nil {
+		return 1, err
+	}
+	defer func() {
+		undoChroots()
+	}()
+
+	// Create a pipe for passing configuration down to the next process.
+	preader, pwriter, err := os.Pipe()
+	if err != nil {
+		return 1, errors.Wrapf(err, "error creating configuration pipe")
+	}
+	config, conferr := json.Marshal(runUsingChrootExecSubprocOptions{
+		Spec:       spec,
+		BundlePath: bundlePath,
+	})
+	if conferr != nil {
+		fmt.Fprintf(os.Stderr, "error re-encoding configuration for %q", runUsingChrootExecCommand)
+		os.Exit(1)
+	}
+
+	// Apologize for the namespace configuration that we're about to ignore.
+	logNamespaceDiagnostics(spec)
+
+	// If we have configured ID mappings, set them here so that they can apply to the child.
+	hostUidmap, hostGidmap, err := util.GetHostIDMappings("")
+	if err != nil {
+		return 1, err
+	}
+	uidmap, gidmap := spec.Linux.UIDMappings, spec.Linux.GIDMappings
+	if len(uidmap) == 0 {
+		// No UID mappings are configured for the container.  Borrow our parent's mappings.
+		uidmap = append([]specs.LinuxIDMapping{}, hostUidmap...)
+		for i := range uidmap {
+			uidmap[i].HostID = uidmap[i].ContainerID
+		}
+	}
+	if len(gidmap) == 0 {
+		// No GID mappings are configured for the container.  Borrow our parent's mappings.
+		gidmap = append([]specs.LinuxIDMapping{}, hostGidmap...)
+		for i := range gidmap {
+			gidmap[i].HostID = gidmap[i].ContainerID
+		}
+	}
+
+	// Start the parent subprocess.
+	cmd := unshare.Command(append([]string{runUsingChrootExecCommand}, spec.Process.Args...)...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdin, stdout, stderr
+	cmd.Dir = "/"
+	cmd.Env = append([]string{fmt.Sprintf("LOGLEVEL=%d", logrus.GetLevel())}, os.Environ()...)
+	cmd.UnshareFlags = syscall.CLONE_NEWUSER | syscall.CLONE_NEWUTS | syscall.CLONE_NEWNS
+	cmd.UidMappings = uidmap
+	cmd.GidMappings = gidmap
+	cmd.GidMappingsEnableSetgroups = true
+	if ctty != nil {
+		cmd.Setsid = true
+		cmd.Ctty = ctty
+	}
+	if spec.Process.OOMScoreAdj != nil {
+		cmd.OOMScoreAdj = *spec.Process.OOMScoreAdj
+	}
+	cmd.ExtraFiles = append([]*os.File{preader}, cmd.ExtraFiles...)
+	cmd.Hook = func(int) error {
+		for _, f := range closeOnceRunning {
+			f.Close()
+		}
+		return nil
+	}
+
+	logrus.Debugf("Running %#v in %#v", cmd.Cmd, cmd)
+	confwg.Add(1)
+	go func() {
+		_, conferr = io.Copy(pwriter, bytes.NewReader(config))
+		pwriter.Close()
+		confwg.Done()
+	}()
+	err = cmd.Run()
+	confwg.Wait()
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if waitStatus, ok := exitError.ProcessState.Sys().(syscall.WaitStatus); ok {
+				if waitStatus.Exited() {
+					if waitStatus.ExitStatus() != 0 {
+						fmt.Fprintf(os.Stderr, "subprocess exited with status %d\n", waitStatus.ExitStatus())
+					}
+					os.Exit(waitStatus.ExitStatus())
+				} else if waitStatus.Signaled() {
+					fmt.Fprintf(os.Stderr, "subprocess exited on %s\n", waitStatus.Signal())
+					os.Exit(1)
+				}
+			}
+		}
+		fmt.Fprintf(os.Stderr, "process exited with error: %v", err)
+		os.Exit(1)
+	}
+
+	return 0, nil
+}
+
+// main() for parent subprocess.  Its main job is to try to make our
+// environment look like the one described by the runtime configuration blob,
+// and then launch the intended command as a child, since we can't exec()
+// directly.
+func runUsingChrootExecMain() {
+	args := os.Args[1:]
+	var options runUsingChrootExecSubprocOptions
+	var err error
+
+	runtime.LockOSThread()
+
+	// Set logging.
+	if level := os.Getenv("LOGLEVEL"); level != "" {
+		if ll, err := strconv.Atoi(level); err == nil {
+			logrus.SetLevel(logrus.Level(ll))
+		}
+		os.Unsetenv("LOGLEVEL")
+	}
+
+	// Unpack our configuration.
+	confPipe := os.NewFile(3, "confpipe")
+	if confPipe == nil {
+		fmt.Fprintf(os.Stderr, "error reading options pipe\n")
+		os.Exit(1)
+	}
+	defer confPipe.Close()
+	if err := json.NewDecoder(confPipe).Decode(&options); err != nil {
+		fmt.Fprintf(os.Stderr, "error decoding options: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Set the hostname.  We're already in a distinct UTS namespace and are admins in the user
+	// namespace which created it, so we shouldn't get a permissions error, but seccomp policy
+	// might deny our attempt to call sethostname() anyway, so log a debug message for that.
+	if options.Spec.Hostname != "" {
+		if err := unix.Sethostname([]byte(options.Spec.Hostname)); err != nil {
+			logrus.Debugf("failed to set hostname %q for process: %v", options.Spec.Hostname, err)
+		}
+	}
+
+	// not doing because it's still shared: creating devices
+	// not doing because it's not applicable: setting annotations
+	// not doing because it's still shared: setting sysctl settings
+	// not doing because cgroupfs is read only: configuring control groups
+	// -> this means we can use the freezer to make sure there aren't any lingering processes
+	// -> this means we ignore cgroups-based controls
+	// not doing because we don't set any in the config: running hooks
+	// not doing because we don't set it in the config: setting rootfs read-only
+	// not doing because we don't set it in the config: setting rootfs propagation
+	logrus.Debugf("setting apparmor profile")
+	if err = setApparmorProfile(options.Spec); err != nil {
+		fmt.Fprintf(os.Stderr, "error setting apparmor profile for process: %v\n", err)
+		os.Exit(1)
+	}
+	if err = setSelinuxLabel(options.Spec); err != nil {
+		fmt.Fprintf(os.Stderr, "error setting SELinux label for process: %v\n", err)
+		os.Exit(1)
+	}
+	logrus.Debugf("setting capabilities")
+	if err := setCapabilities(options.Spec); err != nil {
+		fmt.Fprintf(os.Stderr, "error setting capabilities for process %v\n", err)
+		os.Exit(1)
+	}
+	if err = setSeccomp(options.Spec); err != nil {
+		fmt.Fprintf(os.Stderr, "error setting seccomp filter for process: %v\n", err)
+		os.Exit(1)
+	}
+	logrus.Debugf("setting resource limits")
+	if err = setRlimits(options.Spec); err != nil {
+		fmt.Fprintf(os.Stderr, "error setting process resource limits for process: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Try to chroot into the root.
+	if err := unix.Chroot(options.Spec.Root.Path); err != nil {
+		fmt.Fprintf(os.Stderr, "error chroot()ing into directory %q: %v\n", options.Spec.Root.Path, err)
+		os.Exit(1)
+	}
+	cwd := options.Spec.Process.Cwd
+	if !filepath.IsAbs(cwd) {
+		cwd = "/" + cwd
+	}
+	if err := unix.Chdir(cwd); err != nil {
+		fmt.Fprintf(os.Stderr, "error chdir()ing into directory %q: %v\n", cwd, err)
+		os.Exit(1)
+	}
+	logrus.Debugf("chrooted into %q, changed working directory to %q", options.Spec.Root.Path, cwd)
+
+	// Drop privileges.
+	user := options.Spec.Process.User
+	if len(user.AdditionalGids) > 0 {
+		gids := make([]int, len(user.AdditionalGids))
+		for i := range user.AdditionalGids {
+			gids[i] = int(user.AdditionalGids[i])
+		}
+		logrus.Debugf("setting supplemental groups")
+		if err = syscall.Setgroups(gids); err != nil {
+			fmt.Fprintf(os.Stderr, "error setting supplemental groups list: %v", err)
+			os.Exit(1)
+		}
+	} else {
+		logrus.Debugf("clearing supplemental groups")
+		if err = syscall.Setgroups([]int{}); err != nil {
+			fmt.Fprintf(os.Stderr, "error clearing supplemental groups list: %v", err)
+			os.Exit(1)
+		}
+	}
+	logrus.Debugf("setting gid")
+	if err = syscall.Setresgid(int(user.GID), int(user.GID), int(user.GID)); err != nil {
+		fmt.Fprintf(os.Stderr, "error setting GID: %v", err)
+		os.Exit(1)
+	}
+	logrus.Debugf("setting uid")
+	if err = syscall.Setresuid(int(user.UID), int(user.UID), int(user.UID)); err != nil {
+		fmt.Fprintf(os.Stderr, "error setting UID: %v", err)
+		os.Exit(1)
+	}
+
+	// Actually run the specified command.
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Env = options.Spec.Process.Env
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	cmd.Dir = cwd
+	logrus.Debugf("Running %#v (PATH = %q)", cmd, os.Getenv("PATH"))
+	if err = cmd.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if waitStatus, ok := exitError.ProcessState.Sys().(syscall.WaitStatus); ok {
+				if waitStatus.Exited() {
+					if waitStatus.ExitStatus() != 0 {
+						fmt.Fprintf(os.Stderr, "subprocess exited with status %d\n", waitStatus.ExitStatus())
+					}
+					os.Exit(waitStatus.ExitStatus())
+				} else if waitStatus.Signaled() {
+					fmt.Fprintf(os.Stderr, "subprocess exited on %s\n", waitStatus.Signal())
+					os.Exit(1)
+				}
+			}
+		}
+		fmt.Fprintf(os.Stderr, "process exited with error: %v", err)
+		os.Exit(1)
+	}
+}
+
+// logNamespaceDiagnostics knows which namespaces we want to create.
+// Output debug messages when that differs from what we're being asked to do.
+func logNamespaceDiagnostics(spec *specs.Spec) {
+	sawMountNS := false
+	sawUserNS := false
+	sawUTSNS := false
+	for _, ns := range spec.Linux.Namespaces {
+		switch ns.Type {
+		case specs.CgroupNamespace:
+			if ns.Path != "" {
+				logrus.Debugf("unable to join cgroup namespace, sorry about that")
+			} else {
+				logrus.Debugf("unable to create cgroup namespace, sorry about that")
+			}
+		case specs.IPCNamespace:
+			if ns.Path != "" {
+				logrus.Debugf("unable to join IPC namespace, sorry about that")
+			} else {
+				logrus.Debugf("unable to create IPC namespace, sorry about that")
+			}
+		case specs.MountNamespace:
+			if ns.Path != "" {
+				logrus.Debugf("unable to join mount namespace %q, creating a new one", ns.Path)
+			}
+			sawMountNS = true
+		case specs.NetworkNamespace:
+			if ns.Path != "" {
+				logrus.Debugf("unable to join network namespace, sorry about that")
+			} else {
+				logrus.Debugf("unable to create network namespace, sorry about that")
+			}
+		case specs.PIDNamespace:
+			if ns.Path != "" {
+				logrus.Debugf("unable to join PID namespace, sorry about that")
+			} else {
+				logrus.Debugf("unable to create PID namespace, sorry about that")
+			}
+		case specs.UserNamespace:
+			if ns.Path != "" {
+				logrus.Debugf("unable to join user namespace %q, creating a new one", ns.Path)
+			}
+			sawUserNS = true
+		case specs.UTSNamespace:
+			if ns.Path != "" {
+				logrus.Debugf("unable to join UTS namespace %q, creating a new one", ns.Path)
+			}
+			sawUTSNS = true
+		}
+	}
+	if !sawMountNS {
+		logrus.Debugf("mount namespace not requested, but creating a new one anyway")
+	}
+	if !sawUserNS {
+		logrus.Debugf("user namespace not requested, but creating a new one anyway")
+	}
+	if !sawUTSNS {
+		logrus.Debugf("UTS namespace not requested, but creating a new one anyway")
+	}
+}
+
+// setApparmorProfile sets the apparmor profile for ourselves, and hopefully any child processes that we'll start.
+func setApparmorProfile(spec *specs.Spec) error {
+	if !apparmor.IsEnabled() || spec.Process.ApparmorProfile == "" {
+		return nil
+	}
+	if err := apparmor.ApplyProfile(spec.Process.ApparmorProfile); err != nil {
+		return errors.Wrapf(err, "error setting apparmor profile to %q", spec.Process.ApparmorProfile)
+	}
+	return nil
+}
+
+// setCapabilities sets capabilities for ourselves, to be more or less inherited by any processes that we'll start.
+func setCapabilities(spec *specs.Spec) error {
+	caps, err := capability.NewPid(0)
+	if err != nil {
+		return errors.Wrapf(err, "error reading capabilities of current process")
+	}
+	capMap := map[capability.CapType][]string{
+		capability.BOUNDING:    spec.Process.Capabilities.Bounding,
+		capability.EFFECTIVE:   spec.Process.Capabilities.Effective,
+		capability.INHERITABLE: spec.Process.Capabilities.Inheritable,
+		capability.PERMITTED:   spec.Process.Capabilities.Permitted,
+		capability.AMBIENT:     spec.Process.Capabilities.Ambient,
+	}
+	knownCaps := capability.List()
+	for capType, capList := range capMap {
+		caps.Clear(capType)
+		for _, capToSet := range capList {
+			cap := capability.CAP_LAST_CAP
+			for _, c := range knownCaps {
+				if strings.EqualFold("CAP_"+c.String(), capToSet) {
+					cap = c
+					break
+				}
+			}
+			if cap == capability.CAP_LAST_CAP {
+				return errors.Errorf("error mapping capability %q to a number", capToSet)
+			}
+			caps.Set(capType, cap)
+		}
+	}
+	for capType := range capMap {
+		if err = caps.Apply(capType); err != nil {
+			return errors.Wrapf(err, "error setting %s capabilities to %#v", capType.String(), capMap[capType])
+		}
+	}
+	return nil
+}
+
+// sets the resource limits for ourselves and any processes that
+// we'll start.
+func setRlimits(spec *specs.Spec) error {
+	if spec.Process == nil {
+		return nil
+	}
+	limitsMap := map[string]int{
+		"RLIMIT_AS":         unix.RLIMIT_AS,
+		"RLIMIT_CORE":       unix.RLIMIT_CORE,
+		"RLIMIT_CPU":        unix.RLIMIT_CPU,
+		"RLIMIT_DATA":       unix.RLIMIT_DATA,
+		"RLIMIT_FSIZE":      unix.RLIMIT_FSIZE,
+		"RLIMIT_LOCKS":      unix.RLIMIT_LOCKS,
+		"RLIMIT_MEMLOCK":    unix.RLIMIT_MEMLOCK,
+		"RLIMIT_MSGQUEUE":   unix.RLIMIT_MSGQUEUE,
+		"RLIMIT_NICE":       unix.RLIMIT_NICE,
+		"RLIMIT_NOFILE":     unix.RLIMIT_NOFILE,
+		"RLIMIT_NPROC":      unix.RLIMIT_NPROC,
+		"RLIMIT_RSS":        unix.RLIMIT_RSS,
+		"RLIMIT_RTPRIO":     unix.RLIMIT_RTPRIO,
+		"RLIMIT_RTTIME":     unix.RLIMIT_RTTIME,
+		"RLIMIT_SIGPENDING": unix.RLIMIT_SIGPENDING,
+		"RLIMIT_STACK":      unix.RLIMIT_STACK,
+	}
+	seen := make(map[int]struct{})
+	for _, limit := range spec.Process.Rlimits {
+		resource, recognized := limitsMap[strings.ToUpper(limit.Type)]
+		if !recognized {
+			return errors.Errorf("error parsing limit type %q", limit.Type)
+		}
+		if err := unix.Setrlimit(resource, &unix.Rlimit{Cur: limit.Soft, Max: limit.Hard}); err != nil {
+			return errors.Wrapf(err, "error setting %q limit to soft=%d,hard=%d", limit.Type, limit.Soft, limit.Hard)
+		}
+		seen[resource] = struct{}{}
+	}
+	return nil
+}
+
+// setupChrootBindMounts actually bind mounts things under the rootfs, and returns a
+// callback that will clean up its work.
+func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func() error, err error) {
+	var fs unix.Statfs_t
+	removes := []string{}
+	undoBinds = func() error {
+		if err2 := bind.UnmountMountpoints(spec.Root.Path, removes); err2 != nil {
+			logrus.Warnf("pkg/chroot: error unmounting %q: %v", spec.Root.Path, err2)
+			if err == nil {
+				err = err2
+			}
+		}
+		return err
+	}
+
+	// Now bind mount all of those things to be under the rootfs's location in this
+	// mount namespace.
+	commonFlags := uintptr(unix.MS_BIND | unix.MS_REC | unix.MS_PRIVATE)
+	bindFlags := commonFlags | unix.MS_NODEV
+	devFlags := commonFlags | unix.MS_NOEXEC | unix.MS_NOSUID | unix.MS_RDONLY
+	procFlags := devFlags | unix.MS_NODEV
+	sysFlags := devFlags | unix.MS_NODEV | unix.MS_RDONLY
+
+	// Bind /dev read-only.
+	subDev := filepath.Join(spec.Root.Path, "/dev")
+	if err := unix.Mount("/dev", subDev, "bind", devFlags, ""); err != nil {
+		if os.IsNotExist(err) {
+			err = os.Mkdir(subDev, 0700)
+			if err == nil {
+				err = unix.Mount("/dev", subDev, "bind", devFlags, "")
+			}
+		}
+		if err != nil {
+			return undoBinds, errors.Wrapf(err, "error bind mounting /dev from host into mount namespace")
+		}
+	}
+	// Make sure it's read-only.
+	if err = unix.Statfs(subDev, &fs); err != nil {
+		return undoBinds, errors.Wrapf(err, "error checking if directory %q was bound read-only", subDev)
+	}
+	if fs.Flags&unix.ST_RDONLY == 0 {
+		if err := unix.Mount(subDev, subDev, "bind", devFlags|unix.MS_REMOUNT, ""); err != nil {
+			return undoBinds, errors.Wrapf(err, "error remounting /dev in mount namespace read-only")
+		}
+	}
+	logrus.Debugf("bind mounted %q to %q", "/dev", filepath.Join(spec.Root.Path, "/dev"))
+
+	// Bind /proc read-write.
+	subProc := filepath.Join(spec.Root.Path, "/proc")
+	if err := unix.Mount("/proc", subProc, "bind", procFlags, ""); err != nil {
+		if os.IsNotExist(err) {
+			err = os.Mkdir(subProc, 0700)
+			if err == nil {
+				err = unix.Mount("/proc", subProc, "bind", procFlags, "")
+			}
+		}
+		if err != nil {
+			return undoBinds, errors.Wrapf(err, "error bind mounting /proc from host into mount namespace")
+		}
+	}
+	logrus.Debugf("bind mounted %q to %q", "/proc", filepath.Join(spec.Root.Path, "/proc"))
+
+	// Bind /sys read-only.
+	subSys := filepath.Join(spec.Root.Path, "/sys")
+	if err := unix.Mount("/sys", subSys, "bind", sysFlags, ""); err != nil {
+		if os.IsNotExist(err) {
+			err = os.Mkdir(subSys, 0700)
+			if err == nil {
+				err = unix.Mount("/sys", subSys, "bind", sysFlags, "")
+			}
+		}
+		if err != nil {
+			return undoBinds, errors.Wrapf(err, "error bind mounting /sys from host into mount namespace")
+		}
+	}
+	// Make sure it's read-only.
+	if err = unix.Statfs(subSys, &fs); err != nil {
+		return undoBinds, errors.Wrapf(err, "error checking if directory %q was bound read-only", subSys)
+	}
+	if fs.Flags&unix.ST_RDONLY == 0 {
+		if err := unix.Mount(subSys, subSys, "bind", sysFlags|unix.MS_REMOUNT, ""); err != nil {
+			return undoBinds, errors.Wrapf(err, "error remounting /sys in mount namespace read-only")
+		}
+	}
+	logrus.Debugf("bind mounted %q to %q", "/sys", filepath.Join(spec.Root.Path, "/sys"))
+
+	// Add /sys/fs/selinux to the set of masked paths, to ensure that we don't have processes
+	// attempting to interact with labeling, when they aren't allowed to do so.
+	spec.Linux.MaskedPaths = append(spec.Linux.MaskedPaths, "/sys/fs/selinux")
+	// Add /sys/fs/cgroup to the set of masked paths, to ensure that we don't have processes
+	// attempting to mess with cgroup configuration, when they aren't allowed to do so.
+	spec.Linux.MaskedPaths = append(spec.Linux.MaskedPaths, "/sys/fs/cgroup")
+
+	// Bind mount in everything we've been asked to mount.
+	for _, m := range spec.Mounts {
+		// Skip anything that we just mounted.
+		switch m.Destination {
+		case "/dev", "/proc", "/sys":
+			logrus.Debugf("already bind mounted %q on %q", m.Destination, filepath.Join(spec.Root.Path, m.Destination))
+			continue
+		default:
+			if strings.HasPrefix(m.Destination, "/dev/") {
+				continue
+			}
+			if strings.HasPrefix(m.Destination, "/proc/") {
+				continue
+			}
+			if strings.HasPrefix(m.Destination, "/sys/") {
+				continue
+			}
+		}
+		// Skip anything that isn't a bind or tmpfs mount.
+		if m.Type != "bind" && m.Type != "tmpfs" {
+			logrus.Debugf("skipping mount of type %q on %q", m.Type, m.Destination)
+			continue
+		}
+		// If the target is there, we can just mount it.
+		var srcinfo os.FileInfo
+		switch m.Type {
+		case "bind":
+			srcinfo, err = os.Stat(m.Source)
+			if err != nil {
+				return undoBinds, errors.Wrapf(err, "error examining %q for mounting in mount namespace", m.Source)
+			}
+		case "tmpfs":
+			srcinfo, err = os.Stat("/")
+			if err != nil {
+				return undoBinds, errors.Wrapf(err, "error examining / to use as a template for a tmpfs")
+			}
+		}
+		target := filepath.Join(spec.Root.Path, m.Destination)
+		if _, err := os.Stat(target); err != nil {
+			// If the target can't be stat()ted, check the error.
+			if !os.IsNotExist(err) {
+				return undoBinds, errors.Wrapf(err, "error examining %q for mounting in mount namespace", target)
+			}
+			// The target isn't there yet, so create it, and make a
+			// note to remove it later.
+			if srcinfo.IsDir() {
+				if err = os.Mkdir(target, 0111); err != nil {
+					return undoBinds, errors.Wrapf(err, "error creating mountpoint %q in mount namespace", target)
+				}
+				removes = append(removes, target)
+			} else {
+				var file *os.File
+				if file, err = os.OpenFile(target, os.O_WRONLY|os.O_CREATE, 0); err != nil {
+					return undoBinds, errors.Wrapf(err, "error creating mountpoint %q in mount namespace", target)
+				}
+				file.Close()
+				removes = append(removes, target)
+			}
+		}
+		requestFlags := bindFlags
+		expectedFlags := uintptr(0)
+		if util.StringInSlice("nodev", m.Options) {
+			requestFlags |= unix.MS_NODEV
+			expectedFlags |= unix.ST_NODEV
+		}
+		if util.StringInSlice("noexec", m.Options) {
+			requestFlags |= unix.MS_NOEXEC
+			expectedFlags |= unix.ST_NOEXEC
+		}
+		if util.StringInSlice("nosuid", m.Options) {
+			requestFlags |= unix.MS_NOSUID
+			expectedFlags |= unix.ST_NOSUID
+		}
+		if util.StringInSlice("ro", m.Options) {
+			requestFlags |= unix.MS_RDONLY
+			expectedFlags |= unix.ST_RDONLY
+		}
+		switch m.Type {
+		case "bind":
+			// Do the bind mount.
+			if err := unix.Mount(m.Source, target, "", requestFlags, ""); err != nil {
+				return undoBinds, errors.Wrapf(err, "error bind mounting %q from host to %q in mount namespace (%q)", m.Source, m.Destination, target)
+			}
+			logrus.Debugf("bind mounted %q to %q", m.Source, target)
+		case "tmpfs":
+			// Mount a tmpfs.
+			if err := mount.Mount(m.Source, target, m.Type, strings.Join(append(m.Options, "private"), ",")); err != nil {
+				return undoBinds, errors.Wrapf(err, "error mounting tmpfs to %q in mount namespace (%q, %q)", m.Destination, target, strings.Join(m.Options, ","))
+			}
+			logrus.Debugf("mounted a tmpfs to %q", target)
+		}
+		if err = unix.Statfs(target, &fs); err != nil {
+			return undoBinds, errors.Wrapf(err, "error checking if directory %q was bound read-only", subSys)
+		}
+		if uintptr(fs.Flags)&expectedFlags != expectedFlags {
+			if err := unix.Mount(target, target, "bind", requestFlags|unix.MS_REMOUNT, ""); err != nil {
+				return undoBinds, errors.Wrapf(err, "error remounting %q in mount namespace with expected flags")
+			}
+		}
+	}
+
+	// Set up any read-only paths that we need to.  If we're running inside
+	// of a container, some of these locations will already be read-only.
+	for _, roPath := range spec.Linux.ReadonlyPaths {
+		r := filepath.Join(spec.Root.Path, roPath)
+		target, err := filepath.EvalSymlinks(r)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// No target, no problem.
+				continue
+			}
+			return undoBinds, errors.Wrapf(err, "error checking %q for symlinks before marking it read-only", r)
+		}
+		// Check if the location is already read-only.
+		var fs unix.Statfs_t
+		if err = unix.Statfs(target, &fs); err != nil {
+			if os.IsNotExist(err) {
+				// No target, no problem.
+				continue
+			}
+			return undoBinds, errors.Wrapf(err, "error checking if directory %q is already read-only", target)
+		}
+		if fs.Flags&unix.ST_RDONLY != 0 {
+			continue
+		}
+		// Mount the location over itself, so that we can remount it as read-only.
+		roFlags := uintptr(unix.MS_NODEV | unix.MS_NOEXEC | unix.MS_NOSUID | unix.MS_RDONLY)
+		if err := unix.Mount(target, target, "", roFlags|unix.MS_BIND|unix.MS_REC, ""); err != nil {
+			if os.IsNotExist(err) {
+				// No target, no problem.
+				continue
+			}
+			return undoBinds, errors.Wrapf(err, "error bind mounting %q onto itself in preparation for making it read-only", target)
+		}
+		// Remount the location read-only.
+		if err = unix.Statfs(target, &fs); err != nil {
+			return undoBinds, errors.Wrapf(err, "error checking if directory %q was bound read-only", target)
+		}
+		if fs.Flags&unix.ST_RDONLY == 0 {
+			if err := unix.Mount(target, target, "", roFlags|unix.MS_BIND|unix.MS_REMOUNT, ""); err != nil {
+				return undoBinds, errors.Wrapf(err, "error remounting %q in mount namespace read-only", target)
+			}
+		}
+		// Check again.
+		if err = unix.Statfs(target, &fs); err != nil {
+			return undoBinds, errors.Wrapf(err, "error checking if directory %q was remounted read-only", target)
+		}
+		if fs.Flags&unix.ST_RDONLY == 0 {
+			return undoBinds, errors.Wrapf(err, "error verifying that %q in mount namespace was remounted read-only", target)
+		}
+	}
+
+	// Set up any masked paths that we need to.  If we're running inside of
+	// a container, some of these locations will already be read-only tmpfs
+	// filesystems or bind mounted to os.DevNull.  If we're not running
+	// inside of a container, and nobody else has done that, we'll do it.
+	for _, masked := range spec.Linux.MaskedPaths {
+		t := filepath.Join(spec.Root.Path, masked)
+		target, err := filepath.EvalSymlinks(t)
+		if err != nil {
+			target = t
+		}
+		// Get some info about the null device.
+		nullinfo, err := os.Stat(os.DevNull)
+		if err != nil {
+			return undoBinds, errors.Wrapf(err, "error examining %q for masking in mount namespace", os.DevNull)
+		}
+		// Get some info about the target.
+		targetinfo, err := os.Stat(target)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// No target, no problem.
+				continue
+			}
+			return undoBinds, errors.Wrapf(err, "error examining %q for masking in mount namespace", target)
+		}
+		if targetinfo.IsDir() {
+			// The target's a directory.  Check if it's a read-only filesystem.
+			var statfs unix.Statfs_t
+			if err = unix.Statfs(target, &statfs); err != nil {
+				return undoBinds, errors.Wrapf(err, "error checking if directory %q is a mountpoint", target)
+			}
+			isReadOnly := statfs.Flags&unix.MS_RDONLY != 0
+			// Check if any of the IDs we're mapping could read it.
+			isAccessible := true
+			var stat unix.Stat_t
+			if err = unix.Stat(target, &stat); err != nil {
+				return undoBinds, errors.Wrapf(err, "error checking permissions on directory %q", target)
+			}
+			isAccessible = false
+			if stat.Mode&unix.S_IROTH|unix.S_IXOTH != 0 {
+				isAccessible = true
+			}
+			if !isAccessible && stat.Mode&unix.S_IROTH|unix.S_IXOTH != 0 {
+				if len(spec.Linux.GIDMappings) > 0 {
+					for _, mapping := range spec.Linux.GIDMappings {
+						if stat.Gid >= mapping.ContainerID && stat.Gid < mapping.ContainerID+mapping.Size {
+							isAccessible = true
+							break
+						}
+					}
+				}
+			}
+			if !isAccessible && stat.Mode&unix.S_IRUSR|unix.S_IXUSR != 0 {
+				if len(spec.Linux.UIDMappings) > 0 {
+					for _, mapping := range spec.Linux.UIDMappings {
+						if stat.Uid >= mapping.ContainerID && stat.Uid < mapping.ContainerID+mapping.Size {
+							isAccessible = true
+							break
+						}
+					}
+				}
+			}
+			// Check if it's empty.
+			hasContent := false
+			directory, err := os.Open(target)
+			if err != nil {
+				if !os.IsPermission(err) {
+					return undoBinds, errors.Wrapf(err, "error opening directory %q", target)
+				}
+			} else {
+				names, err := directory.Readdirnames(0)
+				directory.Close()
+				if err != nil {
+					return undoBinds, errors.Wrapf(err, "error reading contents of directory %q", target)
+				}
+				hasContent = false
+				for _, name := range names {
+					switch name {
+					case ".", "..":
+						continue
+					default:
+						hasContent = true
+					}
+					if hasContent {
+						break
+					}
+				}
+			}
+			// The target's a directory, so mount a read-only tmpfs on it.
+			roFlags := uintptr(syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC | syscall.MS_RDONLY)
+			if !isReadOnly || (hasContent && isAccessible) {
+				if err = unix.Mount("none", target, "tmpfs", roFlags, "size=0"); err != nil {
+					return undoBinds, errors.Wrapf(err, "error masking directory %q in mount namespace", target)
+				}
+				if err = unix.Statfs(target, &fs); err != nil {
+					return undoBinds, errors.Wrapf(err, "error checking if directory %q was mounted read-only in mount namespace", target)
+				}
+				if fs.Flags&unix.ST_RDONLY == 0 {
+					if err = unix.Mount(target, target, "", roFlags|syscall.MS_REMOUNT, ""); err != nil {
+						return undoBinds, errors.Wrapf(err, "error making sure directory %q in mount namespace is read only", target)
+					}
+				}
+			}
+		} else {
+			// The target's not a directory, so bind mount os.DevNull over it, unless it's already os.DevNull.
+			if !os.SameFile(nullinfo, targetinfo) {
+				if err = unix.Mount(os.DevNull, target, "", uintptr(syscall.MS_BIND|syscall.MS_RDONLY|syscall.MS_PRIVATE), ""); err != nil {
+					return undoBinds, errors.Wrapf(err, "error masking non-directory %q in mount namespace", target)
+				}
+			}
+		}
+	}
+	return undoBinds, nil
+}

--- a/chroot/run_test.go
+++ b/chroot/run_test.go
@@ -1,0 +1,442 @@
+// +build linux
+
+package chroot
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/containers/storage/pkg/reexec"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/projectatomic/buildah/tests/testreport/types"
+	"github.com/projectatomic/buildah/util"
+)
+
+const (
+	reportCommand = "testreport"
+)
+
+func TestMain(m *testing.M) {
+	if reexec.Init() {
+		return
+	}
+	os.Exit(m.Run())
+}
+
+func testMinimal(t *testing.T, modify func(g *generate.Generator, rootDir, bundleDir string), verify func(t *testing.T, report *types.TestReport)) {
+	g, err := generate.New("linux")
+	if err != nil {
+		t.Fatalf("generate.New(%q): %v", "linux", err)
+	}
+
+	tempDir, err := ioutil.TempDir("", "chroot-test")
+	if err != nil {
+		t.Fatalf("ioutil.TempDir(%q, %q): %v", "", "chrootTest", err)
+	}
+	defer os.RemoveAll(tempDir)
+	info, err := os.Stat(tempDir)
+	if err != nil {
+		t.Fatalf("error checking permissions on %q: %v", tempDir, err)
+	}
+	if err = os.Chmod(tempDir, info.Mode()|0111); err != nil {
+		t.Fatalf("error loosening permissions on %q: %v", tempDir, err)
+	}
+
+	rootDir := filepath.Join(tempDir, "root")
+	if err := os.Mkdir(rootDir, 0711); err != nil {
+		t.Fatalf("os.Mkdir(%q): %v", rootDir, err)
+	}
+
+	specPath := filepath.Join("..", "tests", reportCommand, reportCommand)
+	specBinarySource, err := os.Open(specPath)
+	if err != nil {
+		t.Fatalf("open(%q): %v", specPath, err)
+	}
+	defer specBinarySource.Close()
+	specBinary, err := os.OpenFile(filepath.Join(rootDir, reportCommand), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0711)
+	if err != nil {
+		t.Fatalf("open(%q): %v", filepath.Join(rootDir, reportCommand), err)
+	}
+	io.Copy(specBinary, specBinarySource)
+	specBinary.Close()
+
+	g.SetRootPath(rootDir)
+	g.SetProcessArgs([]string{"/" + reportCommand})
+
+	bundleDir := filepath.Join(tempDir, "bundle")
+	if err := os.Mkdir(bundleDir, 0700); err != nil {
+		t.Fatalf("os.Mkdir(%q): %v", bundleDir, err)
+	}
+
+	if modify != nil {
+		modify(&g, rootDir, bundleDir)
+	}
+
+	uid, gid, err := util.GetHostRootIDs(g.Spec())
+	if err != nil {
+		t.Fatalf("GetHostRootIDs: %v", err)
+	}
+	if err := os.Chown(rootDir, int(uid), int(gid)); err != nil {
+		t.Fatalf("os.Chown(%q): %v", rootDir, err)
+	}
+
+	output := new(bytes.Buffer)
+	if err := RunUsingChroot(g.Spec(), bundleDir, new(bytes.Buffer), output, output); err != nil {
+		t.Fatalf("run: %v: %s", err, output.String())
+	}
+
+	var report types.TestReport
+	if json.Unmarshal(output.Bytes(), &report) != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if verify != nil {
+		verify(t, &report)
+	}
+}
+
+func testNoop(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	testMinimal(t, nil, nil)
+}
+
+func testMinimalSkeleton(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	testMinimal(t,
+		func(g *generate.Generator, rootDir, bundleDir string) {
+		},
+		func(t *testing.T, report *types.TestReport) {
+		})
+}
+
+func TestProcessTerminal(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	for _, terminal := range []bool{false, true} {
+		testMinimal(t,
+			func(g *generate.Generator, rootDir, bundleDir string) {
+				g.SetProcessTerminal(terminal)
+			},
+			func(t *testing.T, report *types.TestReport) {
+				if report.Spec.Process.Terminal != terminal {
+					t.Fatalf("expected terminal = %v, got %v", terminal, report.Spec.Process.Terminal)
+				}
+			})
+	}
+}
+
+func TestProcessConsoleSize(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	for _, size := range [][2]uint{{80, 25}, {132, 50}} {
+		testMinimal(t,
+			func(g *generate.Generator, rootDir, bundleDir string) {
+				g.SetProcessTerminal(true)
+				g.SetProcessConsoleSize(size[0], size[1])
+			},
+			func(t *testing.T, report *types.TestReport) {
+				if report.Spec.Process.ConsoleSize.Width != size[0] {
+					t.Fatalf("expected console width = %v, got %v", size[0], report.Spec.Process.ConsoleSize.Width)
+				}
+				if report.Spec.Process.ConsoleSize.Height != size[1] {
+					t.Fatalf("expected console height = %v, got %v", size[1], report.Spec.Process.ConsoleSize.Height)
+				}
+			})
+	}
+}
+
+func TestProcessUser(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	for _, id := range []uint32{0, 1000} {
+		testMinimal(t,
+			func(g *generate.Generator, rootDir, bundleDir string) {
+				g.SetProcessUID(id)
+				g.SetProcessGID(id + 1)
+				g.AddProcessAdditionalGid(id + 2)
+			},
+			func(t *testing.T, report *types.TestReport) {
+				if report.Spec.Process.User.UID != id {
+					t.Fatalf("expected UID %v, got %v", id, report.Spec.Process.User.UID)
+				}
+				if report.Spec.Process.User.GID != id+1 {
+					t.Fatalf("expected GID %v, got %v", id+1, report.Spec.Process.User.GID)
+				}
+			})
+	}
+}
+
+func TestProcessEnv(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	e := fmt.Sprintf("PARENT_TEST_PID=%d", syscall.Getpid())
+	testMinimal(t,
+		func(g *generate.Generator, rootDir, bundleDir string) {
+			g.ClearProcessEnv()
+			g.AddProcessEnv("PARENT_TEST_PID", fmt.Sprintf("%d", syscall.Getpid()))
+		},
+		func(t *testing.T, report *types.TestReport) {
+			for _, ev := range report.Spec.Process.Env {
+				if ev == e {
+					return
+				}
+			}
+			t.Fatalf("expected environment variable %q", e)
+		})
+}
+
+func TestProcessCwd(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	testMinimal(t,
+		func(g *generate.Generator, rootDir, bundleDir string) {
+			if err := os.Mkdir(filepath.Join(rootDir, "/no-such-directory"), 0700); err != nil {
+				t.Fatalf("mkdir(%q): %v", filepath.Join(rootDir, "/no-such-directory"), err)
+			}
+			g.SetProcessCwd("/no-such-directory")
+		},
+		func(t *testing.T, report *types.TestReport) {
+			if report.Spec.Process.Cwd != "/no-such-directory" {
+				t.Fatalf("expected %q, got %q", "/no-such-directory", report.Spec.Process.Cwd)
+			}
+		})
+}
+
+func TestProcessCapabilities(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	testMinimal(t,
+		func(g *generate.Generator, rootDir, bundleDir string) {
+			g.ClearProcessCapabilities()
+		},
+		func(t *testing.T, report *types.TestReport) {
+			if len(report.Spec.Process.Capabilities.Permitted) != 0 {
+				t.Fatalf("expected no permitted capabilities, got %#v", report.Spec.Process.Capabilities.Permitted)
+			}
+		})
+	testMinimal(t,
+		func(g *generate.Generator, rootDir, bundleDir string) {
+			g.ClearProcessCapabilities()
+			g.AddProcessCapabilityEffective("CAP_IPC_LOCK")
+			g.AddProcessCapabilityPermitted("CAP_IPC_LOCK")
+			g.AddProcessCapabilityInheritable("CAP_IPC_LOCK")
+			g.AddProcessCapabilityBounding("CAP_IPC_LOCK")
+			g.AddProcessCapabilityAmbient("CAP_IPC_LOCK")
+		},
+		func(t *testing.T, report *types.TestReport) {
+			if len(report.Spec.Process.Capabilities.Permitted) != 1 {
+				t.Fatalf("expected one permitted capability, got %#v", report.Spec.Process.Capabilities.Permitted)
+			}
+			if report.Spec.Process.Capabilities.Permitted[0] != "CAP_IPC_LOCK" {
+				t.Fatalf("expected one capability CAP_IPC_LOCK, got %#v", report.Spec.Process.Capabilities.Permitted)
+			}
+		})
+}
+
+func TestProcessRlimits(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	for _, limit := range []int64{100 * 1024 * 1024 * 1024, 200 * 1024 * 1024 * 1024, syscall.RLIM_INFINITY} {
+		testMinimal(t,
+			func(g *generate.Generator, rootDir, bundleDir string) {
+				g.ClearProcessRlimits()
+				if limit != syscall.RLIM_INFINITY {
+					g.AddProcessRlimits("rlimit_as", uint64(limit), uint64(limit))
+				}
+			},
+			func(t *testing.T, report *types.TestReport) {
+				var rlim *specs.POSIXRlimit
+				for i := range report.Spec.Process.Rlimits {
+					if strings.ToUpper(report.Spec.Process.Rlimits[i].Type) == "RLIMIT_AS" {
+						rlim = &report.Spec.Process.Rlimits[i]
+					}
+				}
+				if limit == syscall.RLIM_INFINITY && !(rlim == nil || (int64(rlim.Soft) == syscall.RLIM_INFINITY && int64(rlim.Hard) == syscall.RLIM_INFINITY)) {
+					t.Fatalf("wasn't supposed to set limit on number of open files: %#v", rlim)
+				}
+				if limit != syscall.RLIM_INFINITY && rlim == nil {
+					t.Fatalf("was supposed to set limit on number of open files")
+				}
+				if rlim != nil {
+					if int64(rlim.Soft) != limit {
+						t.Fatalf("soft limit was set to %d, not %d", rlim.Soft, limit)
+					}
+					if int64(rlim.Hard) != limit {
+						t.Fatalf("hard limit was set to %d, not %d", rlim.Hard, limit)
+					}
+				}
+			})
+	}
+}
+
+func TestProcessNoNewPrivileges(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	for _, nope := range []bool{false, true} {
+		testMinimal(t,
+			func(g *generate.Generator, rootDir, bundleDir string) {
+				g.SetProcessNoNewPrivileges(nope)
+			},
+			func(t *testing.T, report *types.TestReport) {
+				if report.Spec.Process.NoNewPrivileges != nope {
+					t.Fatalf("expected no-new-prives to be %v, got %v", nope, report.Spec.Process.NoNewPrivileges)
+				}
+			})
+	}
+}
+
+func TestProcessOOMScoreAdj(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	for _, adj := range []int{0, 1, 2, 3} {
+		testMinimal(t,
+			func(g *generate.Generator, rootDir, bundleDir string) {
+				g.SetProcessOOMScoreAdj(adj)
+			},
+			func(t *testing.T, report *types.TestReport) {
+				adjusted := 0
+				if report.Spec.Process.OOMScoreAdj != nil {
+					adjusted = *report.Spec.Process.OOMScoreAdj
+				}
+				if adjusted != adj {
+					t.Fatalf("expected oom-score-adj to be %v, got %v", adj, adjusted)
+				}
+			})
+	}
+}
+
+func TestHostname(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	hostname := fmt.Sprintf("host%d", syscall.Getpid())
+	testMinimal(t,
+		func(g *generate.Generator, rootDir, bundleDir string) {
+			g.SetHostname(hostname)
+		},
+		func(t *testing.T, report *types.TestReport) {
+			if report.Spec.Hostname != hostname {
+				t.Fatalf("expected %q, got %q", hostname, report.Spec.Hostname)
+			}
+		})
+}
+
+func TestMounts(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	testMinimal(t,
+		func(g *generate.Generator, rootDir, bundleDir string) {
+			g.AddMount(specs.Mount{
+				Source:      "tmpfs",
+				Destination: "/was-not-there-before",
+				Type:        "tmpfs",
+				Options:     []string{"ro,size=0"},
+			})
+		},
+		func(t *testing.T, report *types.TestReport) {
+			found := false
+			for _, mount := range report.Spec.Mounts {
+				if mount.Destination == "/was-not-there-before" && mount.Type == "tmpfs" {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatal("added mount not found")
+			}
+		})
+}
+
+func TestLinuxIDMapping(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	testMinimal(t,
+		func(g *generate.Generator, rootDir, bundleDir string) {
+			g.ClearLinuxUIDMappings()
+			g.ClearLinuxGIDMappings()
+			g.AddLinuxUIDMapping(uint32(syscall.Getuid()), 0, 1)
+			g.AddLinuxGIDMapping(uint32(syscall.Getgid()), 0, 1)
+		},
+		func(t *testing.T, report *types.TestReport) {
+			if len(report.Spec.Linux.UIDMappings) != 1 {
+				t.Fatalf("expected 1 uid mapping, got %q", len(report.Spec.Linux.UIDMappings))
+			}
+			if report.Spec.Linux.UIDMappings[0].HostID != uint32(syscall.Getuid()) {
+				t.Fatalf("expected host uid mapping to be %d, got %d", syscall.Getuid(), report.Spec.Linux.UIDMappings[0].HostID)
+			}
+			if report.Spec.Linux.UIDMappings[0].ContainerID != 0 {
+				t.Fatalf("expected container uid mapping to be 0, got %d", report.Spec.Linux.UIDMappings[0].ContainerID)
+			}
+			if report.Spec.Linux.UIDMappings[0].Size != 1 {
+				t.Fatalf("expected container uid map size to be 1, got %d", report.Spec.Linux.UIDMappings[0].Size)
+			}
+			if report.Spec.Linux.GIDMappings[0].HostID != uint32(syscall.Getgid()) {
+				t.Fatalf("expected host uid mapping to be %d, got %d", syscall.Getgid(), report.Spec.Linux.GIDMappings[0].HostID)
+			}
+			if report.Spec.Linux.GIDMappings[0].ContainerID != 0 {
+				t.Fatalf("expected container gid mapping to be 0, got %d", report.Spec.Linux.GIDMappings[0].ContainerID)
+			}
+			if report.Spec.Linux.GIDMappings[0].Size != 1 {
+				t.Fatalf("expected container gid map size to be 1, got %d", report.Spec.Linux.GIDMappings[0].Size)
+			}
+		})
+}
+
+func TestLinuxIDMappingShift(t *testing.T) {
+	if syscall.Getuid() != 0 {
+		t.Skip("tests need to be run as root")
+	}
+	testMinimal(t,
+		func(g *generate.Generator, rootDir, bundleDir string) {
+			g.ClearLinuxUIDMappings()
+			g.ClearLinuxGIDMappings()
+			g.AddLinuxUIDMapping(uint32(syscall.Getuid())+1, 0, 1)
+			g.AddLinuxGIDMapping(uint32(syscall.Getgid())+1, 0, 1)
+		},
+		func(t *testing.T, report *types.TestReport) {
+			if len(report.Spec.Linux.UIDMappings) != 1 {
+				t.Fatalf("expected 1 uid mapping, got %q", len(report.Spec.Linux.UIDMappings))
+			}
+			if report.Spec.Linux.UIDMappings[0].HostID != uint32(syscall.Getuid()+1) {
+				t.Fatalf("expected host uid mapping to be %d, got %d", syscall.Getuid()+1, report.Spec.Linux.UIDMappings[0].HostID)
+			}
+			if report.Spec.Linux.UIDMappings[0].ContainerID != 0 {
+				t.Fatalf("expected container uid mapping to be 0, got %d", report.Spec.Linux.UIDMappings[0].ContainerID)
+			}
+			if report.Spec.Linux.UIDMappings[0].Size != 1 {
+				t.Fatalf("expected container uid map size to be 1, got %d", report.Spec.Linux.UIDMappings[0].Size)
+			}
+			if report.Spec.Linux.GIDMappings[0].HostID != uint32(syscall.Getgid()+1) {
+				t.Fatalf("expected host uid mapping to be %d, got %d", syscall.Getgid()+1, report.Spec.Linux.GIDMappings[0].HostID)
+			}
+			if report.Spec.Linux.GIDMappings[0].ContainerID != 0 {
+				t.Fatalf("expected container gid mapping to be 0, got %d", report.Spec.Linux.GIDMappings[0].ContainerID)
+			}
+			if report.Spec.Linux.GIDMappings[0].Size != 1 {
+				t.Fatalf("expected container gid map size to be 1, got %d", report.Spec.Linux.GIDMappings[0].Size)
+			}
+		})
+}

--- a/chroot/seccomp.go
+++ b/chroot/seccomp.go
@@ -1,0 +1,142 @@
+// +build linux,seccomp
+
+package chroot
+
+import (
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	libseccomp "github.com/seccomp/libseccomp-golang"
+	"github.com/sirupsen/logrus"
+)
+
+// setSeccomp sets the seccomp filter for ourselves and any processes that we'll start.
+func setSeccomp(spec *specs.Spec) error {
+	logrus.Debugf("setting seccomp configuration")
+	if spec.Linux.Seccomp == nil {
+		return nil
+	}
+	mapAction := func(specAction specs.LinuxSeccompAction) libseccomp.ScmpAction {
+		switch specAction {
+		case specs.ActKill:
+			return libseccomp.ActKill
+		case specs.ActTrap:
+			return libseccomp.ActTrap
+		case specs.ActErrno:
+			return libseccomp.ActErrno
+		case specs.ActTrace:
+			return libseccomp.ActTrace
+		case specs.ActAllow:
+			return libseccomp.ActAllow
+		}
+		return libseccomp.ActInvalid
+	}
+	mapArch := func(specArch specs.Arch) libseccomp.ScmpArch {
+		switch specArch {
+		case specs.ArchX86:
+			return libseccomp.ArchX86
+		case specs.ArchX86_64:
+			return libseccomp.ArchAMD64
+		case specs.ArchX32:
+			return libseccomp.ArchX32
+		case specs.ArchARM:
+			return libseccomp.ArchARM
+		case specs.ArchAARCH64:
+			return libseccomp.ArchARM64
+		case specs.ArchMIPS:
+			return libseccomp.ArchMIPS
+		case specs.ArchMIPS64:
+			return libseccomp.ArchMIPS64
+		case specs.ArchMIPS64N32:
+			return libseccomp.ArchMIPS64N32
+		case specs.ArchMIPSEL:
+			return libseccomp.ArchMIPSEL
+		case specs.ArchMIPSEL64:
+			return libseccomp.ArchMIPSEL64
+		case specs.ArchMIPSEL64N32:
+			return libseccomp.ArchMIPSEL64N32
+		case specs.ArchPPC:
+			return libseccomp.ArchPPC
+		case specs.ArchPPC64:
+			return libseccomp.ArchPPC64
+		case specs.ArchPPC64LE:
+			return libseccomp.ArchPPC64LE
+		case specs.ArchS390:
+			return libseccomp.ArchS390
+		case specs.ArchS390X:
+			return libseccomp.ArchS390X
+		case specs.ArchPARISC:
+			/* fallthrough */ /* for now */
+		case specs.ArchPARISC64:
+			/* fallthrough */ /* for now */
+		}
+		return libseccomp.ArchInvalid
+	}
+	mapOp := func(op specs.LinuxSeccompOperator) libseccomp.ScmpCompareOp {
+		switch op {
+		case specs.OpNotEqual:
+			return libseccomp.CompareNotEqual
+		case specs.OpLessThan:
+			return libseccomp.CompareLess
+		case specs.OpLessEqual:
+			return libseccomp.CompareLessOrEqual
+		case specs.OpEqualTo:
+			return libseccomp.CompareEqual
+		case specs.OpGreaterEqual:
+			return libseccomp.CompareGreaterEqual
+		case specs.OpGreaterThan:
+			return libseccomp.CompareGreater
+		case specs.OpMaskedEqual:
+			return libseccomp.CompareMaskedEqual
+		}
+		return libseccomp.CompareInvalid
+	}
+
+	filter, err := libseccomp.NewFilter(mapAction(spec.Linux.Seccomp.DefaultAction))
+	if err != nil {
+		return errors.Wrapf(err, "error creating seccomp filter with default action %q", spec.Linux.Seccomp.DefaultAction)
+	}
+	for _, arch := range spec.Linux.Seccomp.Architectures {
+		if err = filter.AddArch(mapArch(arch)); err != nil {
+			return errors.Wrapf(err, "error adding architecture %q(%q) to seccomp filter", arch, mapArch(arch))
+		}
+	}
+	for _, rule := range spec.Linux.Seccomp.Syscalls {
+		scnames := make(map[libseccomp.ScmpSyscall]string)
+		for _, name := range rule.Names {
+			scnum, err := libseccomp.GetSyscallFromName(name)
+			if err != nil {
+				logrus.Debugf("error mapping syscall %q to a syscall, ignoring %q rule for %q", name, rule.Action)
+				continue
+			}
+			scnames[scnum] = name
+		}
+		for scnum := range scnames {
+			if len(rule.Args) == 0 {
+				if err = filter.AddRule(scnum, mapAction(rule.Action)); err != nil {
+					return errors.Wrapf(err, "error adding a rule (%q:%q) to seccomp filter", scnames[scnum], rule.Action)
+				}
+				continue
+			}
+			var conditions []libseccomp.ScmpCondition
+			for _, arg := range rule.Args {
+				condition, err := libseccomp.MakeCondition(arg.Index, mapOp(arg.Op), arg.Value, arg.ValueTwo)
+				if err != nil {
+					return errors.Wrapf(err, "error building a seccomp condition %d:%v:%d:%d", arg.Index, arg.Op, arg.Value, arg.ValueTwo)
+				}
+				conditions = append(conditions, condition)
+			}
+			if err = filter.AddRuleConditional(scnum, mapAction(rule.Action), conditions); err != nil {
+				return errors.Wrapf(err, "error adding a conditional rule (%q:%q) to seccomp filter", scnames[scnum], rule.Action)
+			}
+		}
+	}
+	if err = filter.SetNoNewPrivsBit(spec.Process.NoNewPrivileges); err != nil {
+		return errors.Wrapf(err, "error setting no-new-privileges bit to %v", spec.Process.NoNewPrivileges)
+	}
+	err = filter.Load()
+	filter.Release()
+	if err != nil {
+		return errors.Wrapf(err, "error activating seccomp filter")
+	}
+	return nil
+}

--- a/chroot/seccomp_unsupported.go
+++ b/chroot/seccomp_unsupported.go
@@ -1,0 +1,15 @@
+// +build !linux !seccomp
+
+package chroot
+
+import (
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+)
+
+func setSeccomp(spec *specs.Spec) error {
+	if spec.Linux.Seccomp != nil {
+		return errors.New("configured a seccomp filter without seccomp support?")
+	}
+	return nil
+}

--- a/chroot/selinux.go
+++ b/chroot/selinux.go
@@ -1,0 +1,22 @@
+// +build linux,selinux
+
+package chroot
+
+import (
+	"github.com/opencontainers/runtime-spec/specs-go"
+	selinux "github.com/opencontainers/selinux/go-selinux"
+	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// setSelinuxLabel sets the process label for child processes that we'll start.
+func setSelinuxLabel(spec *specs.Spec) error {
+	logrus.Debugf("setting selinux label")
+	if spec.Process.SelinuxLabel != "" && selinux.EnforceMode() != selinux.Disabled {
+		if err := label.SetProcessLabel(spec.Process.SelinuxLabel); err != nil {
+			return errors.Wrapf(err, "error setting process label to %q", spec.Process.SelinuxLabel)
+		}
+	}
+	return nil
+}

--- a/chroot/selinux_unsupported.go
+++ b/chroot/selinux_unsupported.go
@@ -1,0 +1,18 @@
+// +build !linux !selinux
+
+package chroot
+
+import (
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+)
+
+func setSelinuxLabel(spec *specs.Spec) error {
+	if spec.Linux.MountLabel != "" {
+		return errors.New("configured an SELinux mount label without SELinux support?")
+	}
+	if spec.Process.SelinuxLabel != "" {
+		return errors.New("configured an SELinux process label without SELinux support?")
+	}
+	return nil
+}

--- a/chroot/unsupported.go
+++ b/chroot/unsupported.go
@@ -3,6 +3,9 @@
 package chroot
 
 import (
+	"io"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
 

--- a/chroot/unsupported.go
+++ b/chroot/unsupported.go
@@ -1,0 +1,12 @@
+// +build !linux
+
+package chroot
+
+import (
+	"github.com/pkg/errors"
+)
+
+// RunUsingChroot is not supported.
+func RunUsingChroot(spec *specs.Spec, bundlePath string, stdin io.Reader, stdout, stderr io.Writer) (err error) {
+	return errors.Errorf("--isolation chroot is not supported on this platform")
+}

--- a/chroot/util.go
+++ b/chroot/util.go
@@ -1,0 +1,15 @@
+// +build linux
+
+package chroot
+
+func dedupeStringSlice(slice []string) []string {
+	done := make([]string, 0, len(slice))
+	m := make(map[string]struct{})
+	for _, s := range slice {
+		if _, present := m[s]; !present {
+			m[s] = struct{}{}
+			done = append(done, s)
+		}
+	}
+	return done
+}

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -159,6 +159,14 @@ func maybeReexecUsingUserNamespace(c *cli.Context, evenForRoot bool) {
 	err = os.Setenv(startedInUserNS, "1")
 	bailOnError(err, "error setting %s=1 in environment", startedInUserNS)
 
+	// Set the default isolation type to use the "chroot" method.
+	if _, ok := os.LookupEnv("BUILDAH_ISOLATION"); !ok {
+		if err = os.Setenv("BUILDAH_ISOLATION", "chroot"); err != nil {
+			logrus.Errorf("error setting BUILDAH_ISOLATION=chroot in environment: %v", err)
+			os.Exit(1)
+		}
+	}
+
 	// Reuse our stdio.
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -17,6 +16,7 @@ import (
 	"github.com/projectatomic/buildah/unshare"
 	"github.com/projectatomic/buildah/util"
 	"github.com/sirupsen/logrus"
+	"github.com/syndtr/gocapability/capability"
 	"github.com/urfave/cli"
 )
 
@@ -42,133 +42,122 @@ type runnable interface {
 	Run() error
 }
 
+func bailOnError(err error, format string, a ...interface{}) {
+	if err != nil {
+		if format != "" {
+			logrus.Errorf("%s: %v", fmt.Sprintf(format, a...), err)
+		} else {
+			logrus.Errorf("%v", err)
+		}
+		cli.OsExiter(1)
+	}
+}
+
 func maybeReexecUsingUserNamespace(c *cli.Context, evenForRoot bool) {
 	// If we've already been through this once, no need to try again.
 	if os.Getenv(startedInUserNS) != "" {
 		return
 	}
 
-	// Figure out if we're already root, or "root", which is close enough,
-	// unless we've been explicitly told to do this even for root.
-	me, err := user.Current()
-	if err != nil {
-		logrus.Errorf("error determining current user: %v", err)
-		cli.OsExiter(1)
-	}
-	if me.Uid == "0" && !evenForRoot {
+	// If this is one of the commands that doesn't need this indirection, skip it.
+	switch c.Args()[0] {
+	case "help", "version":
 		return
 	}
+
+	// Figure out who we are.
+	me, err := user.Current()
+	bailOnError(err, "error determining current user")
 	uidNum, err := strconv.ParseUint(me.Uid, 10, 32)
-	if err != nil {
-		logrus.Errorf("error parsing current UID %s: %v", me.Uid, err)
-		cli.OsExiter(1)
-	}
+	bailOnError(err, "error parsing current UID %s", me.Uid)
 	gidNum, err := strconv.ParseUint(me.Gid, 10, 32)
-	if err != nil {
-		logrus.Errorf("error parsing current GID %s: %v", me.Gid, err)
-		cli.OsExiter(1)
-	}
+	bailOnError(err, "error parsing current GID %s", me.Gid)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	// Read the set of ID mappings that we're allowed to use.  Each range
-	// in /etc/subuid and /etc/subgid file is a starting ID and a range size.
-	uidmap, gidmap, err := util.GetSubIDMappings(me.Username, me.Username)
-	if err != nil {
-		logrus.Errorf("error reading allowed ID mappings: %v", err)
-		cli.OsExiter(1)
-	}
-	if len(uidmap) == 0 {
-		logrus.Warnf("Found no UID ranges set aside for user %q in /etc/subuid.", me.Username)
-	}
-	if len(gidmap) == 0 {
-		logrus.Warnf("Found no GID ranges set aside for user %q in /etc/subgid.", me.Username)
-	}
-
-	// Build modified maps that map us to uid/gid 0, and maps every other
-	// range increasingly.  In a namespace that uses this map, the invoking
-	// user will appear to be root.  This should let us create storage
-	// directories and access credentials under the invoking user's home
-	// directory.
-	uidmap2 := append([]specs.LinuxIDMapping{{HostID: uint32(uidNum), ContainerID: 0, Size: 1}}, uidmap...)
-	nextUID := uint32(1)
-	for i := range uidmap2[1:] {
-		uidmap2[i+1].ContainerID = nextUID
-		nextUID = nextUID + uidmap2[i+1].Size
-	}
-
-	gidmap2 := append([]specs.LinuxIDMapping{{HostID: uint32(gidNum), ContainerID: 0, Size: 1}}, gidmap...)
-	nextGID := uint32(1)
-	for i := range gidmap2[1:] {
-		gidmap2[i+1].ContainerID = nextGID
-		nextGID = nextGID + gidmap2[i+1].Size
-	}
-
-	// Map the uidmap and gidmap ranges, consecutively, starting at 0.
-	// When used to created a namespace inside of a namespace that uses the
-	// maps we've created above, they'll produce mappings which don't map
-	// in the invoking user.  This is more suitable for running commands in
-	// containers, so we'll want to use it as a default for any containers
-	// that we create.
-	umap := new(bytes.Buffer)
-	for i := range uidmap2 {
-		if i > 0 {
-			fmt.Fprintf(umap, ",")
+	// ID mappings to use to reexec ourselves.
+	var uidmap, gidmap []specs.LinuxIDMapping
+	if uidNum != 0 || evenForRoot {
+		// Read the set of ID mappings that we're allowed to use.  Each
+		// range in /etc/subuid and /etc/subgid file is a starting host
+		// ID and a range size.
+		uidmap, gidmap, err = util.GetSubIDMappings(me.Username, me.Username)
+		bailOnError(err, "error reading allowed ID mappings")
+		if len(uidmap) == 0 {
+			logrus.Warnf("Found no UID ranges set aside for user %q in /etc/subuid.", me.Username)
 		}
-		fmt.Fprintf(umap, "%d:%d:%d", uidmap2[i].ContainerID, uidmap2[i].ContainerID, uidmap2[i].Size)
-	}
-	gmap := new(bytes.Buffer)
-	for i := range gidmap2 {
-		if i > 0 {
-			fmt.Fprintf(gmap, ",")
+		if len(gidmap) == 0 {
+			logrus.Warnf("Found no GID ranges set aside for user %q in /etc/subgid.", me.Username)
 		}
-		fmt.Fprintf(gmap, "%d:%d:%d", gidmap2[i].ContainerID, gidmap2[i].ContainerID, gidmap2[i].Size)
+		// Map our UID and GID, then the subuid and subgid ranges,
+		// consecutively, starting at 0, to get the mappings to use for
+		// a copy of ourselves.
+		uidmap = append([]specs.LinuxIDMapping{{HostID: uint32(uidNum), ContainerID: 0, Size: 1}}, uidmap...)
+		gidmap = append([]specs.LinuxIDMapping{{HostID: uint32(gidNum), ContainerID: 0, Size: 1}}, gidmap...)
+		var rangeStart uint32
+		for i := range uidmap {
+			uidmap[i].ContainerID = rangeStart
+			rangeStart += uidmap[i].Size
+		}
+		rangeStart = 0
+		for i := range gidmap {
+			gidmap[i].ContainerID = rangeStart
+			rangeStart += gidmap[i].Size
+		}
+	} else {
+		// If we have CAP_SYS_ADMIN, then we don't need to create a new namespace in order to be able
+		// to use unshare(), so don't bother creating a new user namespace at this point.
+		capabilities, err := capability.NewPid(0)
+		bailOnError(err, "error reading the current capabilities sets")
+		if capabilities.Get(capability.EFFECTIVE, capability.CAP_SYS_ADMIN) {
+			return
+		}
+		// Read the set of ID mappings that we're currently using.
+		uidmap, gidmap, err = util.GetHostIDMappings("")
+		bailOnError(err, "error reading current ID mappings")
+		// Just reuse them.
+		for i := range uidmap {
+			uidmap[i].HostID = uidmap[i].ContainerID
+		}
+		for i := range gidmap {
+			gidmap[i].HostID = gidmap[i].ContainerID
+		}
 	}
 
-	// Add args to change the global defaults.
-	defaultStorageDriver := "vfs"
-	defaultRoot, err := util.UnsharedRootPath(me.HomeDir)
-	if err != nil {
-		logrus.Errorf("%v", err)
-		cli.OsExiter(1)
-	}
-	defaultRunroot, err := util.UnsharedRunrootPath(me.Uid)
-	if err != nil {
-		logrus.Errorf("%v", err)
-		cli.OsExiter(1)
-	}
 	var moreArgs []string
-	if !c.GlobalIsSet("storage-driver") || !c.GlobalIsSet("root") || !c.GlobalIsSet("runroot") || (!c.GlobalIsSet("userns-uid-map") && !c.GlobalIsSet("userns-gid-map")) {
-		logrus.Infof("Running without privileges, assuming arguments:")
-		if !c.GlobalIsSet("storage-driver") {
-			logrus.Infof(" --storage-driver %q", defaultStorageDriver)
-			moreArgs = append(moreArgs, "--storage-driver", defaultStorageDriver)
-		}
-		if !c.GlobalIsSet("root") {
-			logrus.Infof(" --root %q", defaultRoot)
-			moreArgs = append(moreArgs, "--root", defaultRoot)
-		}
-		if !c.GlobalIsSet("runroot") {
-			logrus.Infof(" --runroot %q", defaultRunroot)
-			moreArgs = append(moreArgs, "--runroot", defaultRunroot)
-		}
-		if !c.GlobalIsSet("userns-uid-map") && !c.GlobalIsSet("userns-gid-map") && umap.Len() > 0 && gmap.Len() > 0 {
-			logrus.Infof(" --userns-uid-map %q --userns-gid-map %q", umap.String(), gmap.String())
-			moreArgs = append(moreArgs, "--userns-uid-map", umap.String(), "--userns-gid-map", gmap.String())
+	// Add args to change the global defaults.
+	if uidNum != 0 {
+		if !c.GlobalIsSet("storage-driver") || !c.GlobalIsSet("root") || !c.GlobalIsSet("runroot") {
+			logrus.Infof("Running without privileges, assuming arguments:")
+			if !c.GlobalIsSet("storage-driver") {
+				defaultStorageDriver := "vfs"
+				logrus.Infof(" --storage-driver %q", defaultStorageDriver)
+				moreArgs = append(moreArgs, "--storage-driver", defaultStorageDriver)
+			}
+			if !c.GlobalIsSet("root") {
+				defaultRoot, err := util.UnsharedRootPath(me.HomeDir)
+				bailOnError(err, "")
+				logrus.Infof(" --root %q", defaultRoot)
+				moreArgs = append(moreArgs, "--root", defaultRoot)
+			}
+			if !c.GlobalIsSet("runroot") {
+				defaultRunroot, err := util.UnsharedRunrootPath(me.Uid)
+				bailOnError(err, "")
+				logrus.Infof(" --runroot %q", defaultRunroot)
+				moreArgs = append(moreArgs, "--runroot", defaultRunroot)
+			}
 		}
 	}
 
 	// Unlike most uses of reexec or unshare, we're using a name that
 	// _won't_ be recognized as a registered reexec handler, since we
 	// _want_ to fall through reexec.Init() to the normal main().
-	cmd := unshare.Command(append(append([]string{"buildah-unprivileged"}, moreArgs...), os.Args[1:]...)...)
+	cmd := unshare.Command(append(append([]string{"buildah-in-a-user-namespace"}, moreArgs...), os.Args[1:]...)...)
 
 	// If, somehow, we don't become UID 0 in our child, indicate that the child shouldn't try again.
-	if err = os.Setenv(startedInUserNS, "1"); err != nil {
-		logrus.Errorf("error setting %s=1 in environment: %v", startedInUserNS, err)
-		os.Exit(1)
-	}
+	err = os.Setenv(startedInUserNS, "1")
+	bailOnError(err, "error setting %s=1 in environment", startedInUserNS)
 
 	// Reuse our stdio.
 	cmd.Stdin = os.Stdin
@@ -177,10 +166,10 @@ func maybeReexecUsingUserNamespace(c *cli.Context, evenForRoot bool) {
 
 	// Set up a new user namespace with the ID mapping.
 	cmd.UnshareFlags = syscall.CLONE_NEWUSER
-	cmd.UseNewuidmap = true
-	cmd.UidMappings = uidmap2
-	cmd.UseNewgidmap = true
-	cmd.GidMappings = gidmap2
+	cmd.UseNewuidmap = uidNum != 0
+	cmd.UidMappings = uidmap
+	cmd.UseNewgidmap = uidNum != 0
+	cmd.GidMappings = gidmap
 	cmd.GidMappingsEnableSetgroups = true
 
 	// Finish up.

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM fedora
+RUN dnf -y update && dnf -y clean all
+RUN dnf -y install btrfs-progs-devel containers-common device-mapper-devel golang go-md2man gpgme-devel libassuan-devel libseccomp-devel make net-tools ostree-devel runc shadow-utils && dnf -y clean all
+COPY . /go/src/github.com/projectatomic/buildah
+RUN env GOPATH=/go make -C /go/src/github.com/projectatomic/buildah clean all install
+RUN sed -i -r -e 's,driver = ".*",driver = "vfs",g' /etc/containers/storage.conf
+ENV BUILDAH_ISOLATION chroot
+WORKDIR /root
+CMD /bin/bash

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -216,7 +216,9 @@ another process.
 **--isolation** *type*
 
 Controls what type of isolation is used when processing RUN instructions.
-Recognized types include *oci* (OCI-compatible runtime, the default).
+Recognized types include *oci* (OCI-compatible runtime, the default) and
+*chroot* (an internal wrapper that leans more toward chroot(1) than container
+technology).
 
 Note: You can also override the default isolation type by setting the
 BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -181,7 +181,9 @@ another process.
 **--isolation** *type*
 
 Controls what type of isolation will be used by default by `buildah run`.
-Recognized types include *oci* (OCI-compatible runtime, the default).
+Recognized types include *oci* (OCI-compatible runtime, the default) and
+*chroot* (an internal wrapper that leans more toward chroot(1) than container
+technology).
 
 Note: You can also override the default isolation type by setting the
 BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -66,7 +66,9 @@ process.
 **--isolation** *type*
 
 Controls what type of isolation is used for running the process.
-Recognized types include *oci* (OCI-compatible runtime, the default).
+Recognized types include *oci* (OCI-compatible runtime, the default) and
+*chroot* (an internal wrapper that leans more toward chroot(1) than container
+technology).
 
 Note: You can also override the default isolation type by setting the
 BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`

--- a/run.go
+++ b/run.go
@@ -29,6 +29,7 @@ import (
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah/bind"
+	"github.com/projectatomic/buildah/chroot"
 	"github.com/projectatomic/buildah/util"
 	"github.com/projectatomic/libpod/pkg/secrets"
 	"github.com/sirupsen/logrus"
@@ -40,7 +41,7 @@ const (
 	// DefaultWorkingDir is used if none was specified.
 	DefaultWorkingDir = "/"
 	// runUsingRuntimeCommand is a command we use as a key for reexec
-	runUsingRuntimeCommand = Package + "-runtime"
+	runUsingRuntimeCommand = Package + "-oci-runtime"
 )
 
 // TerminalPolicy takes the value DefaultTerminal, WithoutTerminal, or WithTerminal.
@@ -112,6 +113,9 @@ const (
 	IsolationDefault Isolation = iota
 	// IsolationOCI is a proper OCI runtime.
 	IsolationOCI
+	// IsolationChroot is a more chroot-like environment: less isolation,
+	// but with fewer requirements.
+	IsolationChroot
 )
 
 // String converts a Isolation into a string.
@@ -121,6 +125,8 @@ func (i Isolation) String() string {
 		return "IsolationDefault"
 	case IsolationOCI:
 		return "IsolationOCI"
+	case IsolationChroot:
+		return "IsolationChroot"
 	}
 	return fmt.Sprintf("unrecognized isolation type %d", i)
 }
@@ -129,10 +135,10 @@ func (i Isolation) String() string {
 type RunOptions struct {
 	// Hostname is the hostname we set for the running container.
 	Hostname string
-	// Isolation is either IsolationDefault or IsolationOCI.
+	// Isolation is either IsolationDefault, IsolationOCI, or IsolationChroot.
 	Isolation Isolation
-	// Runtime is the name of the command to run.  It should accept the same arguments
-	// that runc does, and produce similar output.
+	// Runtime is the name of the runtime to run.  It should accept the
+	// same arguments that runc does, and produce similar output.
 	Runtime string
 	// Args adds global arguments for the runtime.
 	Args []string
@@ -969,8 +975,8 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		return err
 	}
 	defer func() {
-		if err2 := b.Unmount(); err2 != nil {
-			logrus.Errorf("error unmounting container: %v", err2)
+		if err := b.Unmount(); err != nil {
+			logrus.Errorf("error unmounting container: %v", err)
 		}
 	}()
 	g.SetRootPath(mountPoint)
@@ -1069,6 +1075,8 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	switch isolation {
 	case IsolationOCI:
 		err = b.runUsingRuntimeSubproc(options, configureNetwork, configureNetworks, spec, mountPoint, path, Package+"-"+filepath.Base(path))
+	case IsolationChroot:
+		err = chroot.RunUsingChroot(spec, path, options.Stdin, options.Stdout, options.Stderr)
 	default:
 		err = errors.Errorf("don't know how to run this command")
 	}
@@ -1677,7 +1685,7 @@ func runCopyStdio(stdio *sync.WaitGroup, copyPipes bool, stdioPipe [][]int, copy
 			}
 			// If the descriptor was closed elsewhere, remove it from our list.
 			if pollFd.Revents&unix.POLLNVAL != 0 {
-				logrus.Debugf("error polling descriptor %d: closed?", pollFd.Fd)
+				logrus.Debugf("error polling descriptor %s: closed?", readDesc[int(pollFd.Fd)])
 				removes[int(pollFd.Fd)] = struct{}{}
 			}
 			// If the POLLIN flag isn't set, then there's no data to be read from this descriptor.

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -193,8 +193,14 @@ load helpers
 }
 
 @test "from cpu-period test" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
+  if ! which runc ; then
+    skip
+  fi
   cid=$(buildah from --cpu-period=5000 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
+  run buildah --debug=false run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
   echo $output
   [ "$status" -eq 0 ]
   [[ "$output" =~ "5000" ]]
@@ -202,8 +208,14 @@ load helpers
 }
 
 @test "from cpu-quota test" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
+  if ! which runc ; then
+    skip
+  fi
   cid=$(buildah from --cpu-quota=5000 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
+  run buildah --debug=false run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
   echo "$output"
   [ "$status" -eq 0 ]
   [[ "$output" =~ 5000 ]]
@@ -211,8 +223,14 @@ load helpers
 }
 
 @test "from cpu-shares test" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
+  if ! which runc ; then
+    skip
+  fi
   cid=$(buildah from --cpu-shares=2 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run buildah run $cid cat /sys/fs/cgroup/cpu/cpu.shares
+  run buildah --debug=false run $cid cat /sys/fs/cgroup/cpu/cpu.shares
   echo "$output"
   [ "$status" -eq 0 ]
   [[ "$output" =~ 2 ]]
@@ -220,8 +238,14 @@ load helpers
 }
 
 @test "from cpuset-cpus test" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
+  if ! which runc ; then
+    skip
+  fi
   cid=$(buildah from --cpuset-cpus=0 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run buildah run $cid cat /sys/fs/cgroup/cpuset/cpuset.cpus
+  run buildah --debug=false run $cid cat /sys/fs/cgroup/cpuset/cpuset.cpus
   echo "$output"
   [ "$status" -eq 0 ]
   [[ "$output" =~ 0 ]]
@@ -229,8 +253,14 @@ load helpers
 }
 
 @test "from cpuset-mems test" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
+  if ! which runc ; then
+    skip
+  fi
   cid=$(buildah from --cpuset-mems=0 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run buildah run $cid cat /sys/fs/cgroup/cpuset/cpuset.mems
+  run buildah --debug=false run $cid cat /sys/fs/cgroup/cpuset/cpuset.mems
   echo "$output"
   [ "$status" -eq 0 ]
   [[ "$output" =~ 0 ]]
@@ -238,8 +268,14 @@ load helpers
 }
 
 @test "from memory test" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
+  if ! which runc ; then
+    skip
+  fi
   cid=$(buildah from --memory=40m --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run buildah run $cid cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+  run buildah --debug=false run $cid cat /sys/fs/cgroup/memory/memory.limit_in_bytes
   echo $output
   [ "$status" -eq 0 ]
   [[ "$output" =~ 41943040 ]]
@@ -247,8 +283,11 @@ load helpers
 }
 
 @test "from volume test" {
+  if ! which runc ; then
+    skip
+  fi
   cid=$(buildah from --volume=${TESTDIR}:/myvol --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run buildah run $cid -- cat /proc/mounts
+  run buildah --debug=false run $cid -- cat /proc/mounts
   echo $output
   [ "$status" -eq 0 ]
   [[ "$output" =~ /myvol ]]
@@ -256,8 +295,11 @@ load helpers
 }
 
 @test "from volume ro test" {
+  if ! which runc ; then
+    skip
+  fi
   cid=$(buildah from --volume=${TESTDIR}:/myvol:ro --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run buildah run $cid -- cat /proc/mounts
+  run buildah --debug=false run $cid -- cat /proc/mounts
   echo $output
   [ "$status" -eq 0 ]
   [[ "$output" =~ /myvol ]]
@@ -265,8 +307,14 @@ load helpers
 }
 
 @test "from shm-size test" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
+  if ! which runc ; then
+    skip
+  fi
   cid=$(buildah from --shm-size=80m --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run buildah run $cid -- df -h
+  run buildah --debug=false run $cid -- df -h
   echo $output
   [ "$status" -eq 0 ]
   [[ "$output" =~ 80 ]]
@@ -274,6 +322,9 @@ load helpers
 }
 
 @test "from add-host test" {
+  if ! which runc ; then
+    skip
+  fi
   cid=$(buildah from --add-host=localhost:127.0.0.1 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   run buildah run $cid -- cat /etc/hosts
   echo $output

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -3,6 +3,9 @@
 load helpers
 
 @test "user-and-network-namespace" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
   mkdir -p $TESTDIR/no-cni-configs
   RUNOPTS="--cni-config-dir=${TESTDIR}/no-cni-configs ${RUNC_BINARY:+--runtime $RUNC_BINARY}"
   # Check if we're running in an environment that can even test this.
@@ -170,7 +173,9 @@ load helpers
     [ "$output" != "" ]
     case x"$map" in
     x)
-      [ "$output" == "$mynamespace" ]
+      if test "$BUILDAH_ISOLATION" != "chroot" ; then
+        [ "$output" == "$mynamespace" ]
+      fi
       ;;
     *)
       [ "$output" != "$mynamespace" ]
@@ -300,30 +305,51 @@ general_namespace() {
 }
 
 @test "ipc-namespace" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
   general_namespace ipc
 }
 
 @test "net-namespace" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
   general_namespace net
 }
 
 @test "network-namespace" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
   general_namespace net network
 }
 
 @test "pid-namespace" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
   general_namespace pid
 }
 
 @test "user-namespace" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
   general_namespace user userns
 }
 
 @test "uts-namespace" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
   general_namespace uts
 }
 
 @test "combination-namespaces" {
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+    skip
+  fi
   # mnt is always per-container, cgroup isn't a thing runc lets us configure
   for ipc in host container ; do
     for net in host container ; do

--- a/tests/selinux.bats
+++ b/tests/selinux.bats
@@ -13,21 +13,21 @@ load helpers
 
   # Create a container and read its context as a baseline.
   cid=$(buildah --debug=false from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
-  run buildah --debug=false run $cid sh -c 'tr \\0 \\n < /proc/1/attr/current'
+  run buildah --debug=false run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   echo "$output"
   [ "$status" -eq 0 ]
   [ "$output" != "" ]
   firstlabel="$output"
 
   # Ensure that we label the same container consistently across multiple "run" instructions.
-  run buildah --debug=false run $cid sh -c 'tr \\0 \\n < /proc/1/attr/current'
+  run buildah --debug=false run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   echo "$output"
   [ "$status" -eq 0 ]
   [ "$output" == "$firstlabel" ]
 
   # Ensure that different containers get different labels.
   cid1=$(buildah --debug=false from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
-  run buildah --debug=false run $cid1 sh -c 'tr \\0 \\n < /proc/1/attr/current'
+  run buildah --debug=false run $cid1 sh -c 'tr \\0 \\n < /proc/self/attr/current'
   echo "$output"
   [ "$status" -eq 0 ]
   [ "$output" != "$firstlabel" ]

--- a/tests/testreport/testreport.go
+++ b/tests/testreport/testreport.go
@@ -1,0 +1,460 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/containers/storage/pkg/mount"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"github.com/projectatomic/buildah/tests/testreport/types"
+	"github.com/sirupsen/logrus"
+	"github.com/syndtr/gocapability/capability"
+	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/sys/unix"
+)
+
+func getVersion(r *types.TestReport) error {
+	r.Spec.Version = fmt.Sprintf("%d.%d.%d%s", specs.VersionMajor, specs.VersionMinor, specs.VersionPatch, specs.VersionDev)
+	return nil
+}
+
+func getHostname(r *types.TestReport) error {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return errors.Wrapf(err, "error reading hostname")
+	}
+	r.Spec.Hostname = hostname
+	return nil
+}
+
+func getProcessTerminal(r *types.TestReport) error {
+	r.Spec.Process.Terminal = terminal.IsTerminal(unix.Stdin)
+	return nil
+}
+
+func getProcessConsoleSize(r *types.TestReport) error {
+	if terminal.IsTerminal(unix.Stdin) {
+		winsize, err := unix.IoctlGetWinsize(unix.Stdin, unix.TIOCGWINSZ)
+		if err != nil {
+			return errors.Wrapf(err, "error reading size of terminal on stdin")
+		}
+		if r.Spec.Process.ConsoleSize == nil {
+			r.Spec.Process.ConsoleSize = new(specs.Box)
+		}
+		r.Spec.Process.ConsoleSize.Height = uint(winsize.Row)
+		r.Spec.Process.ConsoleSize.Width = uint(winsize.Col)
+	}
+	return nil
+}
+
+func getProcessUser(r *types.TestReport) error {
+	r.Spec.Process.User.UID = uint32(unix.Getuid())
+	r.Spec.Process.User.GID = uint32(unix.Getgid())
+	groups, err := unix.Getgroups()
+	if err != nil {
+		return errors.Wrapf(err, "error reading supplemental groups list")
+	}
+	for _, gid := range groups {
+		r.Spec.Process.User.AdditionalGids = append(r.Spec.Process.User.AdditionalGids, uint32(gid))
+	}
+	return nil
+}
+
+func getProcessArgs(r *types.TestReport) error {
+	r.Spec.Process.Args = append([]string{}, os.Args...)
+	return nil
+}
+
+func getProcessEnv(r *types.TestReport) error {
+	r.Spec.Process.Env = append([]string{}, os.Environ()...)
+	return nil
+}
+
+func getProcessCwd(r *types.TestReport) error {
+	cwd := make([]byte, 8192)
+	n, err := unix.Getcwd(cwd)
+	if err != nil {
+		return errors.Wrapf(err, "error determining current working directory")
+	}
+	for n > 0 && cwd[n-1] == 0 {
+		n--
+	}
+	r.Spec.Process.Cwd = string(cwd[:n])
+	return nil
+}
+
+func getProcessCapabilities(r *types.TestReport) error {
+	capabilities, err := capability.NewPid(0)
+	if err != nil {
+		return errors.Wrapf(err, "error reading current capabilities")
+	}
+	if r.Spec.Process.Capabilities == nil {
+		r.Spec.Process.Capabilities = new(specs.LinuxCapabilities)
+	}
+	caplistMap := map[capability.CapType]*[]string{
+		capability.EFFECTIVE:   &r.Spec.Process.Capabilities.Effective,
+		capability.PERMITTED:   &r.Spec.Process.Capabilities.Permitted,
+		capability.INHERITABLE: &r.Spec.Process.Capabilities.Inheritable,
+		capability.BOUNDING:    &r.Spec.Process.Capabilities.Bounding,
+		capability.AMBIENT:     &r.Spec.Process.Capabilities.Ambient,
+	}
+	for capType, capList := range caplistMap {
+		for _, cap := range capability.List() {
+			if capabilities.Get(capType, cap) {
+				*capList = append(*capList, strings.ToUpper("cap_"+cap.String()))
+			}
+		}
+	}
+	return nil
+}
+
+func getProcessRLimits(r *types.TestReport) error {
+	limitsMap := map[string]int{
+		"RLIMIT_AS":         unix.RLIMIT_AS,
+		"RLIMIT_CORE":       unix.RLIMIT_CORE,
+		"RLIMIT_CPU":        unix.RLIMIT_CPU,
+		"RLIMIT_DATA":       unix.RLIMIT_DATA,
+		"RLIMIT_FSIZE":      unix.RLIMIT_FSIZE,
+		"RLIMIT_LOCKS":      unix.RLIMIT_LOCKS,
+		"RLIMIT_MEMLOCK":    unix.RLIMIT_MEMLOCK,
+		"RLIMIT_MSGQUEUE":   unix.RLIMIT_MSGQUEUE,
+		"RLIMIT_NICE":       unix.RLIMIT_NICE,
+		"RLIMIT_NOFILE":     unix.RLIMIT_NOFILE,
+		"RLIMIT_NPROC":      unix.RLIMIT_NPROC,
+		"RLIMIT_RSS":        unix.RLIMIT_RSS,
+		"RLIMIT_RTPRIO":     unix.RLIMIT_RTPRIO,
+		"RLIMIT_RTTIME":     unix.RLIMIT_RTTIME,
+		"RLIMIT_SIGPENDING": unix.RLIMIT_SIGPENDING,
+		"RLIMIT_STACK":      unix.RLIMIT_STACK,
+	}
+	for resourceName, resource := range limitsMap {
+		var rlim unix.Rlimit
+		if err := unix.Getrlimit(resource, &rlim); err != nil {
+			return errors.Wrapf(err, "error reading %s limit", resourceName)
+		}
+		if rlim.Cur == unix.RLIM_INFINITY && rlim.Max == unix.RLIM_INFINITY {
+			continue
+		}
+		rlimit := specs.POSIXRlimit{
+			Type: resourceName,
+			Soft: rlim.Cur,
+			Hard: rlim.Max,
+		}
+		found := false
+		for i := range r.Spec.Process.Rlimits {
+			if r.Spec.Process.Rlimits[i].Type == resourceName {
+				r.Spec.Process.Rlimits[i] = rlimit
+				found = true
+			}
+		}
+		if !found {
+			r.Spec.Process.Rlimits = append(r.Spec.Process.Rlimits, rlimit)
+		}
+	}
+	return nil
+}
+
+func getProcessNoNewPrivileges(r *types.TestReport) error {
+	// We'd scan /proc/self/status here, but the "NoNewPrivs" line wasn't added until 4.10,
+	// and we want to succeed on older kernels.
+	r1, _, err := unix.Syscall(unix.SYS_PRCTL, unix.PR_GET_NO_NEW_PRIVS, 0, 0)
+	if err != 0 {
+		return errors.Wrapf(err, "error reading no-new-privs bit")
+	}
+	r.Spec.Process.NoNewPrivileges = (r1 != 0)
+	return nil
+}
+
+func getProcessAppArmorProfile(r *types.TestReport) error {
+	// TODO
+	return nil
+}
+
+func getProcessOOMScoreAdjust(r *types.TestReport) error {
+	node := "/proc/self/oom_score_adj"
+	score, err := ioutil.ReadFile(node)
+	if err != nil {
+		return errors.Wrapf(err, "error reading %q", node)
+	}
+	fields := strings.Fields(string(score))
+	if len(fields) != 1 {
+		return errors.Wrapf(err, "badly formatted line %q in %q", string(score), node)
+	}
+	oom, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return errors.Wrapf(err, "error parsing %q in line %q in %q", fields[0], string(score), node)
+	}
+	if oom != 0 {
+		r.Spec.Process.OOMScoreAdj = &oom
+	}
+	return nil
+}
+
+func getProcessSeLinuxLabel(r *types.TestReport) error {
+	// TODO
+	return nil
+}
+
+func getProcess(r *types.TestReport) error {
+	if r.Spec.Process == nil {
+		r.Spec.Process = new(specs.Process)
+	}
+	if err := getProcessTerminal(r); err != nil {
+		return err
+	}
+	if err := getProcessConsoleSize(r); err != nil {
+		return err
+	}
+	if err := getProcessUser(r); err != nil {
+		return err
+	}
+	if err := getProcessArgs(r); err != nil {
+		return err
+	}
+	if err := getProcessEnv(r); err != nil {
+		return err
+	}
+	if err := getProcessCwd(r); err != nil {
+		return err
+	}
+	if err := getProcessCapabilities(r); err != nil {
+		return err
+	}
+	if err := getProcessRLimits(r); err != nil {
+		return err
+	}
+	if err := getProcessNoNewPrivileges(r); err != nil {
+		return err
+	}
+	if err := getProcessAppArmorProfile(r); err != nil {
+		return err
+	}
+	if err := getProcessOOMScoreAdjust(r); err != nil {
+		return err
+	}
+	if err := getProcessSeLinuxLabel(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getMounts(r *types.TestReport) error {
+	infos, err := mount.GetMounts()
+	if err != nil {
+		return errors.Wrapf(err, "reading current list of mounts")
+	}
+	for _, info := range infos {
+		mount := specs.Mount{
+			Destination: info.Mountpoint,
+			Type:        info.Fstype,
+			Source:      info.Source,
+			Options:     strings.Split(info.Opts, ","),
+		}
+		r.Spec.Mounts = append(r.Spec.Mounts, mount)
+	}
+	return nil
+}
+
+func getLinuxIDMappings(r *types.TestReport) error {
+	getIDMapping := func(node string) ([]specs.LinuxIDMapping, error) {
+		var mappings []specs.LinuxIDMapping
+		mapfile, err := os.Open(node)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error opening %q", node)
+		}
+		defer mapfile.Close()
+		scanner := bufio.NewScanner(mapfile)
+		for scanner.Scan() {
+			line := scanner.Text()
+			fields := strings.Fields(line)
+			if len(fields) != 3 {
+				return nil, errors.Wrapf(err, "badly formatted line %q in %q", line, node)
+			}
+			cid, err := strconv.ParseUint(fields[0], 10, 32)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error parsing %q in line %q in %q", fields[0], line, node)
+			}
+			hid, err := strconv.ParseUint(fields[1], 10, 32)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error parsing %q in line %q in %q", fields[1], line, node)
+			}
+			size, err := strconv.ParseUint(fields[2], 10, 32)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error parsing %q in line %q in %q", fields[2], line, node)
+			}
+			mappings = append(mappings, specs.LinuxIDMapping{ContainerID: uint32(cid), HostID: uint32(hid), Size: uint32(size)})
+		}
+		return mappings, nil
+	}
+	uidmap, err := getIDMapping("/proc/self/uid_map")
+	if err != nil {
+		return err
+	}
+	gidmap, err := getIDMapping("/proc/self/gid_map")
+	if err != nil {
+		return err
+	}
+	r.Spec.Linux.UIDMappings = uidmap
+	r.Spec.Linux.GIDMappings = gidmap
+	return nil
+}
+
+func getLinuxSysctl(r *types.TestReport) error {
+	if r.Spec.Linux.Sysctl == nil {
+		r.Spec.Linux.Sysctl = make(map[string]string)
+	}
+	walk := func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+		value, err := ioutil.ReadFile(path)
+		if err != nil {
+			if pe, ok := err.(*os.PathError); ok {
+				if errno, ok := pe.Err.(syscall.Errno); ok {
+					switch errno {
+					case syscall.EACCES, syscall.EINVAL, syscall.EIO, syscall.EPERM:
+						return nil
+					}
+				}
+			}
+			return errors.Wrapf(err, "error reading sysctl %q", path)
+		}
+		if strings.HasPrefix(path, "/proc/sys/") {
+			path = path[10:]
+		}
+		sysctl := strings.Replace(path, "/", ".", -1)
+		val := strings.TrimRight(string(value), "\r\n")
+		if strings.ContainsAny(val, "\r\n") {
+			val = string(value)
+		}
+		r.Spec.Linux.Sysctl[sysctl] = val
+		return nil
+	}
+	if err := filepath.Walk("/proc/sys", walk); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getLinuxResources(r *types.TestReport) error {
+	// TODO
+	return nil
+}
+
+func getLinuxCgroupsPath(r *types.TestReport) error {
+	// TODO
+	return nil
+}
+
+func getLinuxNamespaces(r *types.TestReport) error {
+	// TODO
+	return nil
+}
+
+func getLinuxDevices(r *types.TestReport) error {
+	// TODO
+	return nil
+}
+
+func getLinuxRootfsPropagation(r *types.TestReport) error {
+	// TODO
+	return nil
+}
+
+func getLinuxMaskedPaths(r *types.TestReport) error {
+	// TODO
+	return nil
+}
+
+func getLinuxReadOnlyPaths(r *types.TestReport) error {
+	// TODO
+	return nil
+}
+
+func getLinuxMountLabel(r *types.TestReport) error {
+	// TODO
+	return nil
+}
+
+func getLinuxIntelRdt(r *types.TestReport) error {
+	// TODO
+	return nil
+}
+
+func getLinux(r *types.TestReport) error {
+	if r.Spec.Linux == nil {
+		r.Spec.Linux = new(specs.Linux)
+	}
+	if err := getLinuxIDMappings(r); err != nil {
+		return err
+	}
+	if err := getLinuxSysctl(r); err != nil {
+		return err
+	}
+	if err := getLinuxResources(r); err != nil {
+		return err
+	}
+	if err := getLinuxCgroupsPath(r); err != nil {
+		return err
+	}
+	if err := getLinuxNamespaces(r); err != nil {
+		return err
+	}
+	if err := getLinuxDevices(r); err != nil {
+		return err
+	}
+	if err := getLinuxRootfsPropagation(r); err != nil {
+		return err
+	}
+	if err := getLinuxMaskedPaths(r); err != nil {
+		return err
+	}
+	if err := getLinuxReadOnlyPaths(r); err != nil {
+		return err
+	}
+	if err := getLinuxMountLabel(r); err != nil {
+		return err
+	}
+	if err := getLinuxIntelRdt(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	var r types.TestReport
+
+	if r.Spec == nil {
+		r.Spec = new(specs.Spec)
+	}
+	if err := getVersion(&r); err != nil {
+		logrus.Errorf("%v", err)
+		os.Exit(1)
+	}
+	if err := getProcess(&r); err != nil {
+		logrus.Errorf("%v", err)
+		os.Exit(1)
+	}
+	if err := getHostname(&r); err != nil {
+		logrus.Errorf("%v", err)
+		os.Exit(1)
+	}
+	if err := getMounts(&r); err != nil {
+		logrus.Errorf("%v", err)
+		os.Exit(1)
+	}
+	if err := getLinux(&r); err != nil {
+		logrus.Errorf("%v", err)
+		os.Exit(1)
+	}
+
+	json.NewEncoder(os.Stdout).Encode(r)
+}

--- a/tests/testreport/types/types.go
+++ b/tests/testreport/types/types.go
@@ -1,0 +1,10 @@
+package types
+
+import (
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// TestReport is an internal type used for testing.
+type TestReport struct {
+	Spec *specs.Spec
+}

--- a/tests/validate/gometalinter.sh
+++ b/tests/validate/gometalinter.sh
@@ -19,5 +19,5 @@ exec gometalinter.v1 \
 	--disable=gas \
 	--disable=aligncheck \
 	--cyclo-over=40 \
-	--deadline=600s \
+	--deadline=900s \
 	--tests "$@"

--- a/vendor/github.com/opencontainers/runc/libcontainer/apparmor/apparmor.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/apparmor/apparmor.go
@@ -1,0 +1,54 @@
+// +build apparmor,linux
+
+package apparmor
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+// IsEnabled returns true if apparmor is enabled for the host.
+func IsEnabled() bool {
+	if _, err := os.Stat("/sys/kernel/security/apparmor"); err == nil && os.Getenv("container") == "" {
+		if _, err = os.Stat("/sbin/apparmor_parser"); err == nil {
+			buf, err := ioutil.ReadFile("/sys/module/apparmor/parameters/enabled")
+			return err == nil && len(buf) > 1 && buf[0] == 'Y'
+		}
+	}
+	return false
+}
+
+func setprocattr(attr, value string) error {
+	// Under AppArmor you can only change your own attr, so use /proc/self/
+	// instead of /proc/<tid>/ like libapparmor does
+	path := fmt.Sprintf("/proc/self/attr/%s", attr)
+
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = fmt.Fprintf(f, "%s", value)
+	return err
+}
+
+// changeOnExec reimplements aa_change_onexec from libapparmor in Go
+func changeOnExec(name string) error {
+	value := "exec " + name
+	if err := setprocattr("exec", value); err != nil {
+		return fmt.Errorf("apparmor failed to apply profile: %s", err)
+	}
+	return nil
+}
+
+// ApplyProfile will apply the profile with the specified name to the process after
+// the next exec.
+func ApplyProfile(name string) error {
+	if name == "" {
+		return nil
+	}
+
+	return changeOnExec(name)
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/apparmor/apparmor_disabled.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/apparmor/apparmor_disabled.go
@@ -1,0 +1,20 @@
+// +build !apparmor !linux
+
+package apparmor
+
+import (
+	"errors"
+)
+
+var ErrApparmorNotEnabled = errors.New("apparmor: config provided but apparmor not supported")
+
+func IsEnabled() bool {
+	return false
+}
+
+func ApplyProfile(name string) error {
+	if name != "" {
+		return ErrApparmorNotEnabled
+	}
+	return nil
+}


### PR DESCRIPTION
Add an `IsolationChroot` that trades flexibility and isolation for being able to do what it does in a host environment that's already been isolated to the point where we're not allowed to set up some of that isolation (using the host's cgroup, ipc, network, and pid namespaces, which generally means we don't have privileges for configuring cgroups, and we can't control things like networking and the size of /dev/shm), producing a result that leans more toward chroot(1) than runc(1) does.
