### PR TITLE
docs: Follow man-pages(7) suggestions for SYNOPSIS

### DIFF
--- a/docs/buildah-add.md
+++ b/docs/buildah-add.md
@@ -4,7 +4,7 @@
 buildah\-add - Add the contents of a file, URL, or a directory to a container.
 
 ## SYNOPSIS
-**buildah** **add** **containerID** **SRC** [[...] **DEST**]
+**buildah add** [*options*] *container* *src* [[*src* ...] *dest*]
 
 ## DESCRIPTION
 Adds the contents of a file, URL, or a directory to a container's working

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -4,7 +4,11 @@
 buildah\-bud - Build an image using instructions from Dockerfiles.
 
 ## SYNOPSIS
-**buildah** **bud | build-using-dockerfile** [*options* [...]] **context**
+**buildah build-using-dockerfile** [*options*] *context*
+
+**buildah bud** [*options*] *context*
+
+**bud** is an alias for **build-using-dockerfile**.
 
 ## DESCRIPTION
 Builds an image using instructions from one or more Dockerfiles and a specified

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -4,12 +4,12 @@
 buildah\-commit - Create an image from a working container.
 
 ## SYNOPSIS
-**buildah** **commit** [*options* [...]] **containerID** **imageName**
+**buildah commit** [*options*] *container* *image*
 
 ## DESCRIPTION
 Writes a new image using the specified container's read-write layer and if it
-is based on an image, the layers of that image.  If *imageName* does not begin
-with a registry name component, *localhost* will be added to the name.
+is based on an image, the layers of that image.  If *image* does not begin
+with a registry name component, `localhost` will be added to the name.
 
 ## RETURN VALUE
 The image ID of the image that was created.  On error, 1 is returned and errno is returned.

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -4,7 +4,7 @@
 buildah\-config - Update image configuration settings.
 
 ## SYNOPSIS
-**buildah** **config** [*options* [...]] **containerID**
+**buildah config** [*options*] *container*
 
 ## DESCRIPTION
 Updates one or more of the settings kept for a container.

--- a/docs/buildah-containers.md
+++ b/docs/buildah-containers.md
@@ -4,7 +4,7 @@
 buildah\-containers - List the working containers and their base images.
 
 ## SYNOPSIS
-**buildah** **containers** [*options* [...]]
+**buildah containers** [*options*]
 
 ## DESCRIPTION
 Lists containers which appear to be Buildah working containers, their names and

--- a/docs/buildah-copy.md
+++ b/docs/buildah-copy.md
@@ -4,7 +4,7 @@
 buildah\-copy - Copies the contents of a file, URL, or directory into a container's working directory.
 
 ## SYNOPSIS
-**buildah** **copy** containerID **SRC** [[...] **DEST**]
+**buildah copy** *container* *src* [[*src* ...] *dest*]
 
 ## DESCRIPTION
 Copies the contents of a file, URL, or a directory to a container's working

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -4,7 +4,7 @@
 buildah\-from - Creates a new working container, either from scratch or using a specified image as a starting point.
 
 ## SYNOPSIS
-**buildah** **from** [*options* [...]] *imageName*
+**buildah from** [*options*] *image*
 
 ## DESCRIPTION
 Creates a working container based upon the specified image name.  If the

--- a/docs/buildah-images.md
+++ b/docs/buildah-images.md
@@ -4,7 +4,7 @@
 buildah\-images - List images in local storage.
 
 ## SYNOPSIS
-**buildah** **images** [*options* [...]] [*imageName*]
+**buildah images** [*options*] [*image*]
 
 ## DESCRIPTION
 Displays locally stored images, their names, sizes, created date and their IDs.

--- a/docs/buildah-inspect.md
+++ b/docs/buildah-inspect.md
@@ -4,7 +4,7 @@
 buildah\-inspect - Display information about working containers or images.
 
 ## SYNOPSIS
-**buildah** **inspect** [*options* [...] --] **ID**
+**buildah inspect** [*options*] [**--**] *object*
 
 ## DESCRIPTION
 Prints the low-level information on Buildah object(s) (e.g. container, images) identified by name or ID. By default, this will render all results in a
@@ -21,9 +21,9 @@ Users of this option should be familiar with the [*text/template*
 package](https://golang.org/pkg/text/template/) in the Go standard library, and
 of internals of Buildah's implementation.
 
-**--type** *container* | *image*
+**--type** **container** | **image**
 
-Specify whether the ID is that of a container or an image.
+Specify whether *object* is a container or an image.
 
 ## EXAMPLE
 

--- a/docs/buildah-mount.md
+++ b/docs/buildah-mount.md
@@ -4,9 +4,7 @@
 buildah\-mount - Mount a working container's root filesystem.
 
 ## SYNOPSIS
-**buildah** **mount**
-
-**buildah** **mount** [**containerID** [...]]
+**buildah mount** [*container* ...]
 
 ## DESCRIPTION
 Mounts the specified container's root file system in a location which can be

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -4,7 +4,7 @@
 buildah\-push - Push an image from local storage to elsewhere.
 
 ## SYNOPSIS
-**buildah** **push** [*options* [...]] **imageID** [**destination**]
+**buildah push** [*options*] *image* [*destination*]
 
 ## DESCRIPTION
 Pushes an image from local storage to a specified destination, decompressing

--- a/docs/buildah-rm.md
+++ b/docs/buildah-rm.md
@@ -4,7 +4,7 @@
 buildah\-rm - Removes one or more working containers.
 
 ## SYNOPSIS
-**buildah** **rm** **containerID [...]**
+**buildah rm** *container* ...
 
 ## DESCRIPTION
 Removes one or more working containers, unmounting them if necessary.

--- a/docs/buildah-rmi.md
+++ b/docs/buildah-rmi.md
@@ -4,7 +4,7 @@
 buildah\-rmi - Removes one or more images.
 
 ## SYNOPSIS
-**buildah** **rmi** **imageID [...]**
+**buildah rmi** *image* ...
 
 ## DESCRIPTION
 Removes one or more locally stored images.

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -4,7 +4,7 @@
 buildah\-run - Run a command inside of the container.
 
 ## SYNOPSIS
-**buildah** **run** [*options* [...] --] **containerID** **command**
+**buildah run** [*options*] [**--**] *container* *command*
 
 ## DESCRIPTION
 Launches a container and runs the specified command in that container using the

--- a/docs/buildah-tag.md
+++ b/docs/buildah-tag.md
@@ -4,7 +4,7 @@
 buildah\-tag - Add additional names to local images.
 
 ## SYNOPSIS
-**buildah** **tag** **name** **new-name** [...]
+**buildah tag** *name* *new-name* ...
 
 ## DESCRIPTION
 Adds additional names to locally-stored images.

--- a/docs/buildah-umount.md
+++ b/docs/buildah-umount.md
@@ -4,7 +4,7 @@
 buildah\-umount - Unmount the root file system on the specified working containers.
 
 ## SYNOPSIS
-**buildah** **umount** **containerID [...]**
+**buildah umount** *container* ...
 
 ## DESCRIPTION
 Unmounts the root file system on the specified working containers.

--- a/docs/buildah-unshare.md
+++ b/docs/buildah-unshare.md
@@ -4,7 +4,7 @@
 buildah\-unshare - Run a command inside of a modified user namespace.
 
 ## SYNOPSIS
-**buildah** **unshare** [*options* [...] --] [**command**]
+**buildah unshare** [*options*] [**--**] [*command*]
 
 ## DESCRIPTION
 Launches a process (by default, *$SHELL*) in a new user namespace.  The user

--- a/docs/buildah-version.md
+++ b/docs/buildah-version.md
@@ -4,8 +4,7 @@
 buildah\-version - Display the Buildah Version Information.
 
 ## SYNOPSIS
-**buildah version**
-[**--help**|**-h**]
+**buildah version** [*options*]
 
 ## DESCRIPTION
 Shows the following information: Version, Go Version, Image Spec, Runtime Spec, CNI Spec, libcni Version, Git Commit, Build Time, OS, and Architecture.


### PR DESCRIPTION
[`man-pages(7)`][1] has:

> For commands, this shows the syntax of the command and its arguments (including options); boldface is used for as-is text and italics are used to indicate replaceable arguments. Brackets (`[]`) surround optional arguments, vertical bars (`|`) separate choices, and ellipses (`...`) can be repeated.

I've adjusted our SYNOPSIS entries to match that formatting, and generally tried to make them more consistent with the precedent set by the man-pages project.  Outside of the SYNOPSIS entry, I prefer using `backticks` for literals, although in some places I've left the **bolding** to keep things visually similar to a nearby SYNOPSIS entry.

I've also simplified a few placeholders, e.g. "containerID" -> "container", because I didn't think the additional bit was providing much additional context.  If there is ambiguity about the representation, it should be addressed in the DESCRIPTION instead of with an "ID" or "Name" suffix.

I've also proposed very similar changes for libpod in projectatomic/libpod#1027.

[1]: http://man7.org/linux/man-pages/man7/man-pages.7.html