### PR TITLE
allow buildah cross compile for a darwin target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ all: buildah imgtype docs
 buildah: *.go imagebuildah/*.go bind/*.go cmd/buildah/*.go docker/*.go pkg/cli/*.go pkg/parse/*.go unshare/*.c unshare/*.go util/*.go
 	$(GO) build $(LDFLAGS) -o buildah $(BUILDFLAGS) ./cmd/buildah
 
+darwin:
+	GOOS=darwin $(GO) build $(LDFLAGS) -o buildah.darwin -tags "containers_image_openpgp" ./cmd/buildah
+
 imgtype: *.go docker/*.go util/*.go tests/imgtype/imgtype.go
 	$(GO) build $(LDFLAGS) -o imgtype $(BUILDFLAGS) ./tests/imgtype/imgtype.go
 

--- a/cmd/buildah/unshare_unsupported.go
+++ b/cmd/buildah/unshare_unsupported.go
@@ -2,6 +2,10 @@
 
 package main
 
+import (
+	"github.com/urfave/cli"
+)
+
 var (
 	unshareCommand = cli.Command{
 		Name:           "unshare",

--- a/run.go
+++ b/run.go
@@ -1145,9 +1145,9 @@ func runUsingRuntimeMain() {
 		os.Exit(1)
 	}
 	// Set ourselves up to read the container's exit status.  We're doing this in a child process
-	// so that we won't mess with the setting in a caller of the library.
-	if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, uintptr(1), 0, 0, 0); err != nil {
-		fmt.Fprintf(os.Stderr, "prctl(PR_SET_CHILD_SUBREAPER, 1): %v\n", err)
+	// so that we won't mess with the setting in a caller of the library. This stubs to OS specific
+	// calls
+	if err := setChildProcess(); err != nil {
 		os.Exit(1)
 	}
 	// Run the container, start to finish.

--- a/run_linux.go
+++ b/run_linux.go
@@ -1,0 +1,17 @@
+// +build linux
+
+package buildah
+
+import (
+	"fmt"
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+func setChildProcess() error {
+	if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, uintptr(1), 0, 0, 0); err != nil {
+		fmt.Fprintf(os.Stderr, "prctl(PR_SET_CHILD_SUBREAPER, 1): %v\n", err)
+		return err
+	}
+	return nil
+}

--- a/run_unsupport.go
+++ b/run_unsupport.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package buildah
+
+import (
+	"github.com/pkg/errors"
+)
+
+func setChildProcess() error {
+	return errors.New("function not supported on non-linux systems")
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -41,7 +41,7 @@ github.com/ostreedev/ostree-go aeb02c6b6aa2889db3ef62f7855650755befd460
 github.com/pborman/uuid master
 github.com/pkg/errors master
 github.com/pquerna/ffjson d49c2bc1aa135aad0c6f4fc2056623ec78f5d5ac
-github.com/projectatomic/libpod 781eec27b52c842fc83c8b1c97fbf825065f3b0c
+github.com/projectatomic/libpod master
 github.com/sirupsen/logrus master
 github.com/syndtr/gocapability master
 github.com/tchap/go-patricia master

--- a/vendor/github.com/projectatomic/libpod/pkg/chrootuser/user.go
+++ b/vendor/github.com/projectatomic/libpod/pkg/chrootuser/user.go
@@ -8,6 +8,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	// ErrNoSuchUser indicates that the user provided by the caller does not
+	// exist in /etc/passws
+	ErrNoSuchUser = errors.New("user does not exist in /etc/passwd")
+)
+
 // GetUser will return the uid, gid of the user specified in the userspec
 // it will use the /etc/passwd and /etc/group files inside of the rootdir
 // to return this information.

--- a/vendor/github.com/projectatomic/libpod/pkg/chrootuser/user_linux.go
+++ b/vendor/github.com/projectatomic/libpod/pkg/chrootuser/user_linux.go
@@ -4,7 +4,6 @@ package chrootuser
 
 import (
 	"bufio"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -79,9 +78,6 @@ func openChrootedFile(rootdir, filename string) (*exec.Cmd, io.ReadCloser, error
 
 var (
 	lookupUser, lookupGroup sync.Mutex
-	// ErrNoSuchUser indicates that the user provided by the caller does not
-	// exist in /etc/passws
-	ErrNoSuchUser = errors.New("user does not exist in /etc/passwd")
 )
 
 type lookupPasswdEntry struct {

--- a/vendor/github.com/projectatomic/libpod/vendor.conf
+++ b/vendor/github.com/projectatomic/libpod/vendor.conf
@@ -10,14 +10,14 @@ github.com/containerd/cgroups 77e628511d924b13a77cebdc73b757a47f6d751b
 github.com/containerd/continuity master
 github.com/containernetworking/cni v0.6.0
 github.com/containernetworking/plugins 1fb94a4222eafc6f948eacdca9c9f2158b427e53
-github.com/containers/image ad33f7b73fbac0acf05b9e2cea021b61b4b0c3e0
-github.com/containers/storage 4993aae31ced3971f5b72f28c4e3fe38c34fa634
+github.com/containers/image 5144ced37a1b21b63c6ef605e56811e29a687528
+github.com/containers/storage 51f1f85c2b7863b2fd361471f05b937fd8059124
 github.com/coreos/go-systemd v14
 github.com/cri-o/ocicni master
 github.com/cyphar/filepath-securejoin v0.2.1
 github.com/davecgh/go-spew v1.1.0
 github.com/docker/distribution 7a8efe719e55bbfaff7bc5718cdf0ed51ca821df
-github.com/docker/docker b8571fd81c7d2223c9ecbf799c693e3ef1daaea9
+github.com/docker/docker 86f080cff0914e9694068ed78d503701667c4c00
 github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
 github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
 github.com/docker/go-units v0.3.2
@@ -49,12 +49,13 @@ github.com/opencontainers/image-spec v1.0.0
 github.com/opencontainers/runc 6e15bc3f92fd4c58b3285e8f27eaeb6b22d62920
 github.com/opencontainers/runtime-spec v1.0.0
 github.com/opencontainers/runtime-tools 625e2322645b151a7cbb93a8b42920933e72167f
-github.com/opencontainers/selinux b29023b86e4a69d1b46b7e7b4e2b6fda03f0b9cd
+github.com/opencontainers/selinux 3b2399ec5682aea5c9160d44fa53387d7e65ccf5
 github.com/ostreedev/ostree-go master
 github.com/pkg/errors v0.8.0
 github.com/pmezard/go-difflib 792786c7400a136282c1664665ae0a8db921c6c2
 github.com/pquerna/ffjson d49c2bc1aa135aad0c6f4fc2056623ec78f5d5ac
 github.com/seccomp/libseccomp-golang v0.9.0
+github.com/seccomp/containers-golang master
 github.com/sirupsen/logrus v1.0.0
 github.com/spf13/pflag 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 github.com/stretchr/testify 4d4bfba8f1d1027c4fdbe371823030df51419987
@@ -70,7 +71,7 @@ github.com/xeipuuv/gojsonreference master
 github.com/xeipuuv/gojsonschema  master
 golang.org/x/crypto 81e90905daefcd6fd217b62423c0908922eadb30
 golang.org/x/net c427ad74c6d7a814201695e9ffde0c5d400a7674
-golang.org/x/sys 9aade4d3a3b7e6d876cd3823ad20ec45fc035402
+golang.org/x/sys master
 golang.org/x/text f72d8390a633d5dfb0cc84043294db9f6c935756
 golang.org/x/time f51c12702a4d776e4c1fa9b0fabab841babae631
 google.golang.org/grpc v1.0.4 https://github.com/grpc/grpc-go
@@ -88,7 +89,7 @@ k8s.io/kube-openapi 275e2ce91dec4c05a4094a7b1daee5560b555ac9 https://github.com/
 k8s.io/utils 258e2a2fa64568210fbd6267cf1d8fd87c3cb86e https://github.com/kubernetes/utils
 github.com/mrunalp/fileutils master
 github.com/varlink/go master
-github.com/projectatomic/buildah f90b6c0fff687c3f1453475ef4f4b1fd5727fd36
+github.com/projectatomic/buildah cf753ee6fe1f606c4456d2d76690534f8170d9a3
 github.com/Nvveen/Gotty master
 github.com/fsouza/go-dockerclient master
 github.com/openshift/imagebuilder master


### PR DESCRIPTION
the goal here is to allow ourselves to cross compile buildah for a darwin
target.  we are doing this to eventually protect from regressions that could
creep into buildah so we don't dig ourselves a deeper hole.

the simplified and non-variable approach to the make darwin was done with
intent to keep this simple until we can exploit things a little more.

once this PR merges, i will create a CI test that will test for regressions
on a make darwin.  we should also be doing a gofmt with a darwin target so the
!linux|darwin tagged files are also checked for completeness.  initially the
test can be optional for passing with the long-term idea that it be made
a firm requirement at the buildah maintainers behest.

Signed-off-by: baude <bbaude@redhat.com>