### PR TITLE
Add a --loglevel option to build-with-dockerfile

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -76,7 +76,7 @@ func main() {
 		},
 	}
 	app.Before = func(c *cli.Context) error {
-		logrus.SetLevel(logrus.ErrorLevel)
+		logrus.SetLevel(logrus.ErrorLevel + logrus.Level(c.Int("loglevel")))
 		if c.GlobalBool("debug") {
 			debug = true
 			logrus.SetLevel(logrus.DebugLevel)

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -388,6 +388,7 @@ return 1
      --iidfile
      --ipc
      --label
+     --loglevel
      -m
      --memory
      --memory-swap

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -223,6 +223,12 @@ BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`
 
 Add an image *label* (e.g. label=*value*) to the image metadata. Can be used multiple times.
 
+**--loglevel** *number*
+
+Adjust the logging level up or down.  Valid option values range from -2 to 3,
+with 3 being roughly equivalent to using the global *--debug* option, and
+values below 0 omitting even error messages which accompany fatal errors.
+
 **--layers** *bool-value*
 
 Cache intermediate images during the build process (Default is `false`).

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -139,6 +139,10 @@ var (
 			Name:  "logfile",
 			Usage: "log to `file` instead of stdout/stderr",
 		},
+		cli.IntFlag{
+			Name:  "loglevel",
+			Usage: "adjust logging level (range from -2 to 3)",
+		},
 		cli.BoolTFlag{
 			Name:  "pull",
 			Usage: "pull the image if not present",


### PR DESCRIPTION
Add a --loglevel option to build-with-dockerfile and use it to add a value from -2 to 3 to the default logrus LogError logging level.  This makes --loglevel 3 equivalent in effect to the global --debug option.

OpenShift defaults to appending --loglevel 0 (or --loglevel $BUILD_LOGLEVEL, if the variable is set) to the command for the builder container, and this lets us accept that.  