### PR TITLE
Add --cidfile option to from

### DIFF
--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -24,6 +25,10 @@ var (
 			Name:  "cert-dir",
 			Value: "",
 			Usage: "use certificates at the specified path to access the registry",
+		},
+		cli.StringFlag{
+			Name:  "cidfile",
+			Usage: "write the container ID to the file",
 		},
 		cli.StringFlag{
 			Name:  "creds",
@@ -238,6 +243,12 @@ func fromCmd(c *cli.Context) error {
 		return err
 	}
 
+	if c.String("cidfile") != "" {
+		filePath := c.String("cidfile")
+		if err := ioutil.WriteFile(filePath, []byte(builder.ContainerID), 0644); err != nil {
+			return errors.Wrapf(err, "filed to write Container ID File %q", filePath)
+		}
+	}
 	fmt.Printf("%s\n", builder.Container)
 	return builder.Save()
 }

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -715,6 +715,7 @@ return 1
      --authfile
      --cert-dir
      --cgroup-parent
+     --cidfile
      --cni-config-dir
      --cni-plugin-path
      --cpu-period

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -83,6 +83,10 @@ The default certificates directory is _/etc/containers/certs.d_.
 
 Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
 
+**--cidfile** *ContainerIDFile*
+
+Write the container ID to the file.
+
 **--cni-config-dir**=*directory*
 
 Location of CNI configuration files which will dictate which plugins will be

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -287,3 +287,11 @@ load helpers
   cid=$(buildah from --name=${container_name} --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah --debug=false inspect --format '{{.Container}}' ${container_name}
 }
+
+@test "from cidfile test" {
+  buildah from --cidfile output.cid --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$(cat output.cid)
+  run buildah --debug=false containers -f id=${cid}
+  [ "$status" -eq 0 ]
+  buildah rm ${cid}
+}


### PR DESCRIPTION
Add --cidfile option which specifiles the file to write the container, when create a conatiner.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>