### PR TITLE
Fix handling of --registries-conf

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -34,8 +34,9 @@ func main() {
 			Usage: "print debugging information",
 		},
 		cli.StringFlag{
-			Name:  "registries-conf",
-			Usage: "path to registries.conf file (not usually used)",
+			Name:   "registries-conf",
+			Usage:  "path to registries.conf file (not usually used)",
+			EnvVar: "REGISTRIES_CONFIG_PATH",
 		},
 		cli.StringFlag{
 			Name:  "registries-conf-dir",

--- a/pull.go
+++ b/pull.go
@@ -167,14 +167,14 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 	}()
 
 	logrus.Debugf("copying %q to %q", spec, destName)
-	err = cp.Image(ctx, policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter, options.SystemContext, nil, ""))
+	err = cp.Image(ctx, policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter, sc, nil, ""))
 	if err == nil {
 		return destRef, nil
 	}
 
 	// If no image was found, we should handle.  Lets be nicer to the user and see if we can figure out why.
-	registryPath := sysregistries.RegistriesConfPath(&types.SystemContext{})
-	searchRegistries, err := getRegistries()
+	registryPath := sysregistries.RegistriesConfPath(sc)
+	searchRegistries, err := getRegistries(sc)
 	if err != nil {
 		return nil, err
 	}

--- a/util.go
+++ b/util.go
@@ -167,13 +167,8 @@ func (b *Builder) tarPath() func(path string) (io.ReadCloser, error) {
 }
 
 // getRegistries obtains the list of registries defined in the global registries file.
-func getRegistries() ([]string, error) {
-	registryConfigPath := ""
-	envOverride := os.Getenv("REGISTRIES_CONFIG_PATH")
-	if len(envOverride) > 0 {
-		registryConfigPath = envOverride
-	}
-	searchRegistries, err := sysregistries.GetRegistries(&types.SystemContext{SystemRegistriesConfPath: registryConfigPath})
+func getRegistries(sc *types.SystemContext) ([]string, error) {
+	searchRegistries, err := sysregistries.GetRegistries(sc)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse the registries.conf file")
 	}


### PR DESCRIPTION
Instead of ignoring the global --registries-conf option and using only $REGISTRIES_CONFIG_PATH, use it for the option default.