### PR TITLE
image filter test: use kubernetes/pause as a "since"

### DIFF
--- a/tests/images.bats
+++ b/tests/images.bats
@@ -29,10 +29,11 @@ load helpers
 }
 
 @test "images filter test" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json kubernetes/pause)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run buildah --debug=false images --filter since=alpine
-  [ $(wc -l <<< "$output") -eq 2 ]
+  run buildah --debug=false images --noheading --filter since=kubernetes/pause
+  echo "$output"
+  [ $(wc -l <<< "$output") -eq 1 ]
   [ "${status}" -eq 0 ]
   buildah rm -a
   buildah rmi -a -f


### PR DESCRIPTION
Use `kubernetes/pause`, which is not expected to be updated regularly, as a reference image for the "since" filter, instead of `alpine`, which is updated regularly, and which therefore can be newer than `busybox`.  (I was tempted to use references with digests to make a permanent fix, but that would also implicitly hard code an architecture.)