### PR TITLE
Don't pass a nil error to errors.Wrapf()

### DIFF
--- a/run.go
+++ b/run.go
@@ -749,7 +749,7 @@ func setupNamespaces(g *generate.Generator, namespaceOptions NamespaceOptions, i
 	// If we've got mappings, we're going to have to create a user namespace.
 	if len(idmapOptions.UIDMap) > 0 || len(idmapOptions.GIDMap) > 0 || configureUserns {
 		if hostPidns {
-			return false, nil, false, errors.Wrapf(err, "unable to mix host PID namespace with user namespace")
+			return false, nil, false, errors.New("unable to mix host PID namespace with user namespace")
 		}
 		if err := g.AddOrReplaceLinuxNamespace(specs.UserNamespace, ""); err != nil {
 			return false, nil, false, errors.Wrapf(err, "error adding new %q namespace for run", string(specs.UserNamespace))


### PR DESCRIPTION
Don't pass a `nil` error value to `errors.Wrapf()` when we want to report an error, since it's documented as returning `nil` for that case.