### PR TITLE
bash completion: remove shebang

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # bash completion file for buildah command
 #
 # This script provides completion of:


### PR DESCRIPTION
Address rpmlint warning by removing the shebang as the completion script
isn't meant to be an executable.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>