### PR TITLE
Use manifest from container/image

### DIFF
--- a/docker/types.go
+++ b/docker/types.go
@@ -15,15 +15,6 @@ import (
 const TypeLayers = "layers"
 
 // github.com/docker/distribution/manifest/schema2/manifest.go
-const V2S2MediaTypeManifest = "application/vnd.docker.distribution.manifest.v2+json"
-
-// github.com/docker/distribution/manifest/schema2/manifest.go
-const V2S2MediaTypeImageConfig = "application/vnd.docker.container.image.v1+json"
-
-// github.com/docker/distribution/manifest/schema2/manifest.go
-const V2S2MediaTypeLayer = "application/vnd.docker.image.rootfs.diff.tar.gzip"
-
-// github.com/docker/distribution/manifest/schema2/manifest.go
 const V2S2MediaTypeUncompressedLayer = "application/vnd.docker.image.rootfs.diff.tar"
 
 // github.com/moby/moby/image/rootfs.go

--- a/tests/imgtype/imgtype.go
+++ b/tests/imgtype/imgtype.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/containers/image/manifest"
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/image/types"
@@ -50,7 +51,7 @@ func main() {
 		expectedConfigType = v1.MediaTypeImageConfig
 	case buildah.Dockerv2ImageManifest:
 		expectedManifestType = *mtype
-		expectedConfigType = docker.V2S2MediaTypeImageConfig
+		expectedConfigType = manifest.DockerV2Schema2ConfigMediaType
 	case "*":
 		expectedManifestType = ""
 		expectedConfigType = ""


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Use the manifest definitions from container/images which is what Podman does.  Best to have one central definition used by all.  

Once approved I'll add the one missing definition to containers/image and will then vendor that in and update the todo after this gets merged.

This is a WIP as I've not tested thoroughly and I don't trust myself without a double check while on cold meds.