### PR TITLE
Fix rmi to remove intermediate images associated with an image

### DIFF
--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -108,9 +108,7 @@ load helpers
   run buildah --debug=false images -q
   [ "$status" -eq 0 ]
   [ "$output" != "" ]
-  for id in $output ; do
-    buildah rmi $id
-  done
+  buildah rmi -a
   run buildah --debug=false images -q
   [ "$status" -eq 0 ]
   [ "$output" == "" ]

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -159,7 +159,7 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
+  buildah rmi -a
   run buildah --debug=false images -q
   echo "$output"
   [ "$status" -eq 0 ]
@@ -179,7 +179,7 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
+  buildah rmi -a
   run buildah --debug=false images -q
   echo "$output"
   [ "$status" -eq 0 ]
@@ -197,7 +197,7 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
+  buildah rmi -a
   run buildah --debug=false images -q
   echo "$output"
   [ "$status" -eq 0 ]
@@ -213,7 +213,7 @@ load helpers
   run test -s $root/etc/passwd
   [ "$status" -eq 0 ]
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
+  buildah rmi -a
   run buildah --debug=false images -q
   echo "$output"
   [ "$status" -eq 0 ]
@@ -266,7 +266,7 @@ load helpers
   run test -s $root/vol/anothervolfile
   [ "$status" -ne 0 ]
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
+  buildah rmi -a
   run buildah --debug=false images -q
   echo "$output"
   [ "$status" -eq 0 ]
@@ -402,7 +402,7 @@ load helpers
   [ "$status" -eq 0 ]
   [ "$output" = 41ed ]
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
+  buildah rmi -a
   run buildah --debug=false images -q
   echo "$output"
   [ "$status" -eq 0 ]
@@ -417,7 +417,7 @@ load helpers
   cmp $root/Dockerfile1.alpine ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.alpine
   cmp $root/Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.withfrom
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
+  buildah rmi -a
   run buildah --debug=false images -q
   echo "$output"
   [ "$status" -eq 0 ]
@@ -435,7 +435,7 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   [ "$output" = kilroy ]
-  buildah rmi $(buildah --debug=false images -q)
+  buildah rmi -a
   run buildah --debug=false images -q
   echo "$output"
   [ "$status" -eq 0 ]
@@ -471,7 +471,7 @@ load helpers
   [ "$status" -eq 0 ]
   [ "$output" = '["/bin/bash" "-c"]' ]
   buildah rm ${ctr}
-  buildah rmi $(buildah --debug=false images -q)
+  buildah rmi -a
   run buildah --debug=false images -q
   echo "$output"
   [ "$status" -eq 0 ]

--- a/tests/validate/gometalinter.sh
+++ b/tests/validate/gometalinter.sh
@@ -19,5 +19,5 @@ exec gometalinter.v1 \
 	--disable=gas \
 	--disable=aligncheck \
 	--cyclo-over=40 \
-	--deadline=900s \
+	--deadline=2000s \
 	--tests "$@"


### PR DESCRIPTION
buildah rmi now removes cached images associated with an image
when the image is removed only if the cached image is not required
by another image.
If an image is a parent and has a name then untag, otherwise return
an error stating the image can't be remoed as it has dependent
child images.

Signed-off-by: umohnani8 <umohnani@redhat.com>