### PR TITLE
Avoid a stall in runCollectOutput()

### DIFF
--- a/run.go
+++ b/run.go
@@ -1212,7 +1212,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetwork
 	// Figure out how we're doing stdio handling, and create pipes and sockets.
 	var stdio sync.WaitGroup
 	var consoleListener *net.UnixListener
-	var errorFds []int
+	var errorFds, closeBeforeReadingErrorFds []int
 	stdioPipe := make([][]int, 3)
 	copyConsole := false
 	copyPipes := false
@@ -1244,6 +1244,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetwork
 				return 1, err
 			}
 			errorFds = []int{stdioPipe[unix.Stdout][0], stdioPipe[unix.Stderr][0]}
+			closeBeforeReadingErrorFds = []int{stdioPipe[unix.Stdout][1], stdioPipe[unix.Stderr][1]}
 			// Set stdio to our pipes.
 			getCreateStdio = func() (io.ReadCloser, io.WriteCloser, io.WriteCloser) {
 				stdin := os.NewFile(uintptr(stdioPipe[unix.Stdin][0]), "/dev/stdin")
@@ -1290,7 +1291,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetwork
 	// Actually create the container.
 	err = create.Run()
 	if err != nil {
-		return 1, errors.Wrapf(err, "error creating container for %v: %s", spec.Process.Args, runCollectOutput(errorFds...))
+		return 1, errors.Wrapf(err, "error creating container for %v: %s", spec.Process.Args, runCollectOutput(errorFds, closeBeforeReadingErrorFds))
 	}
 	defer func() {
 		err2 := del.Run()
@@ -1412,7 +1413,10 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetwork
 	return wstatus, nil
 }
 
-func runCollectOutput(fds ...int) string {
+func runCollectOutput(fds, closeBeforeReadingFds []int) string {
+	for _, fd := range closeBeforeReadingFds {
+		unix.Close(fd)
+	}
 	var b bytes.Buffer
 	buf := make([]byte, 8192)
 	for _, fd := range fds {

--- a/tests/validate/gometalinter.sh
+++ b/tests/validate/gometalinter.sh
@@ -19,5 +19,5 @@ exec gometalinter.v1 \
 	--disable=gas \
 	--disable=aligncheck \
 	--cyclo-over=40 \
-	--deadline=480s \
+	--deadline=600s \
 	--tests "$@"


### PR DESCRIPTION
Before calling runCollectOutput() to read error information from pipes, make sure we've closed our handles to the writing ends of the pipes.