### PR TITLE
Return policy error on pull

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,18 @@
+package buildah
+
+// GenericPullError is an explanatory text for rejecting a pull of an image.
+type GenericPullError struct {
+	message string
+}
+
+// NewGenericPullError is used to create a new GenericPullError
+func NewGenericPullError(message string) GenericPullError {
+	return GenericPullError{
+		message: message,
+	}
+}
+
+// Error returns the message from a GenericPullError
+func (e GenericPullError) Error() string {
+	return e.message
+}

--- a/new.go
+++ b/new.go
@@ -149,7 +149,13 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 			pulledImg, pulledReference, err := pullAndFindImage(ctx, store, image, options, systemContext)
 			if err != nil {
 				logrus.Debugf("unable to pull and read image %q: %v", image, err)
-				continue
+				switch err := errors.Cause(err).(type) {
+				case GenericPullError:
+					logrus.Debugf("GenericPullError: %v", err.Error())
+					continue
+				default:
+					return nil, nil, err
+				}
 			}
 			ref = pulledReference
 			img = pulledImg
@@ -195,7 +201,13 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 			pulledImg, pulledReference, err := pullAndFindImage(ctx, store, image, options, systemContext)
 			if err != nil {
 				logrus.Debugf("unable to pull and read image %q: %v", image, err)
-				continue
+				switch err := errors.Cause(err).(type) {
+				case GenericPullError:
+					logrus.Debugf("GenericPullError: %v", err.Error())
+					continue
+				default:
+					return nil, nil, err
+				}
 			}
 			ref = pulledReference
 			img = pulledImg

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -28,7 +28,7 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   buildah rm $cid
 
-  newcid=$(buildah from new-image)
+  newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json new-image)
   newroot=$(buildah mount $newcid)
   test -s $newroot/randomfile
   cmp ${TESTDIR}/randomfile $newroot/randomfile
@@ -75,7 +75,7 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   buildah rm $cid
 
-  newcid=$(buildah from new-image)
+  newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json new-image)
   newroot=$(buildah mount $newcid)
   test -s $newroot/random1
   cmp ${TESTDIR}/random1 $newroot/random1

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -58,7 +58,7 @@ load helpers
   buildah rmi $iid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   buildah rm $cid
-  newcid=$(buildah from new-image)
+  newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json new-image)
   newroot=$(buildah mount $newcid)
   test -s $newroot/randomfile
   cmp ${TESTDIR}/randomfile $newroot/randomfile
@@ -73,7 +73,7 @@ load helpers
   buildah unmount $newcid
   buildah rm $newcid
 
-  othernewcid=$(buildah from other-new-image)
+  othernewcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json other-new-image)
   othernewroot=$(buildah mount $othernewcid)
   test -s $othernewroot/randomfile
   cmp ${TESTDIR}/randomfile $othernewroot/randomfile
@@ -81,7 +81,7 @@ load helpers
   cmp ${TESTDIR}/other-randomfile $othernewroot/other-randomfile
   buildah rm $othernewcid
 
-  anothernewcid=$(buildah from another-new-image)
+  anothernewcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json another-new-image)
   anothernewroot=$(buildah mount $anothernewcid)
   test -s $anothernewroot/randomfile
   cmp ${TESTDIR}/randomfile $anothernewroot/randomfile
@@ -89,7 +89,7 @@ load helpers
   cmp ${TESTDIR}/other-randomfile $anothernewroot/other-randomfile
   buildah rm $anothernewcid
 
-  yetanothernewcid=$(buildah from yet-another-new-image)
+  yetanothernewcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json yet-another-new-image)
   yetanothernewroot=$(buildah mount $yetanothernewcid)
   test -s $yetanothernewroot/randomfile
   cmp ${TESTDIR}/randomfile $yetanothernewroot/randomfile
@@ -97,7 +97,7 @@ load helpers
   cmp ${TESTDIR}/other-randomfile $yetanothernewroot/other-randomfile
   buildah delete $yetanothernewcid
 
-  newcid=$(buildah from new-image)
+  newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json new-image)
   buildah commit --rm --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:remove-container-image
   run buildah mount $newcid
   [ "$status" -ne 0 ]

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -375,9 +375,9 @@ load helpers
   [ "$status" -eq 0 ]
   cid=$(buildah from ${target})
   buildah rm ${cid}
-  cid=$(buildah from library/${target2})
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json library/${target2})
   buildah rm ${cid}
-  cid=$(buildah from ${target3}:latest)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target3}:latest)
   buildah rm ${cid}
   buildah rmi -f $(buildah --debug=false images -q)
   run buildah --debug=false images -q
@@ -393,7 +393,7 @@ load helpers
   fi
   target=volume-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/volume-perms
-  cid=$(buildah from ${target})
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
   root=$(buildah mount ${cid})
   run test -s $root/vol/subvol/subvolfile
   [ "$status" -ne 0 ]
@@ -412,7 +412,7 @@ load helpers
 @test "bud-from-glob" {
   target=alpine-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile2.glob ${TESTSDIR}/bud/from-multiple-files
-  cid=$(buildah from ${target})
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
   root=$(buildah mount ${cid})
   cmp $root/Dockerfile1.alpine ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.alpine
   cmp $root/Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.withfrom
@@ -462,7 +462,7 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   [ "$output" = '["/bin/sh" "-c"]' ]
-  ctr=$(buildah from ${target})
+  ctr=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
   run buildah --debug=false config --shell "/bin/bash -c" ${ctr}
   echo "$output"
   [ "$status" -eq 0 ]
@@ -483,7 +483,7 @@ load helpers
   run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/symlink
   echo "$output"
   [ "$status" -eq 0 ]
-  cid=$(buildah from ${target})
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
   root=$(buildah mount ${cid})
   run ls $root/data/log
   echo "$output"
@@ -504,7 +504,7 @@ load helpers
   run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.relative-symlink ${TESTSDIR}/bud/symlink 
   echo "$output"
   [ "$status" -eq 0 ]
-  cid=$(buildah from ${target})
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
   root=$(buildah mount ${cid})
   run ls $root/log
   echo "$output"
@@ -523,7 +523,7 @@ load helpers
   run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/symlink/Dockerfile.multiple-symlinks ${TESTSDIR}/bud/symlink
   echo "$output"
   [ "$status" -eq 0 ]
-  cid=$(buildah from ${target})
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
   root=$(buildah mount ${cid})
   run ls $root/data/log
   echo "$output"
@@ -559,7 +559,7 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   [[ "$output" =~ "unique.test.string" ]]
-  cid=$(buildah from ${target})
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
   buildah rm ${cid}
   buildah rmi ${target}
 }
@@ -578,7 +578,7 @@ load helpers
   echo "$output"
   [[ "$output" =~ "unique.test.string" ]]
   [ "$status" -eq 0 ]
-  cid=$(buildah from ${target})
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
   buildah rm ${cid}
   buildah rmi ${target}
 }
@@ -597,7 +597,7 @@ load helpers
   echo "$output"
   [[ "$output" =~ "unique.test.string" ]]
   [ "$status" -eq 0 ]
-  cid=$(buildah from ${target})
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
   buildah rm ${cid}
   buildah rmi ${target}
 }
@@ -617,7 +617,7 @@ load helpers
   echo "$output"
   [[ "$output" =~ ":unique.test.string:" ]]
   [ "$status" -eq 0 ]
-  cid=$(buildah from ${target})
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
   buildah rm ${cid}
   buildah rmi ${target}
 }

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -48,5 +48,5 @@ load helpers
   echo COMMIT
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid "containers-storage:[vfs@${TESTDIR}/root2+${TESTDIR}/runroot2]newimage"
   echo FROM
-  buildah --storage-driver vfs --root ${TESTDIR}/root2 --runroot ${TESTDIR}/runroot2 from newimage
+  buildah --storage-driver vfs --root ${TESTDIR}/root2 --runroot ${TESTDIR}/runroot2 from --signature-policy ${TESTSDIR}/policy.json newimage
 }

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -44,7 +44,7 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   buildah rm $cid
 
-  newcid=$(buildah from new-image)
+  newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json new-image)
   newroot=$(buildah mount $newcid)
   test -s $newroot/randomfile
   cmp ${TESTDIR}/randomfile $newroot/randomfile


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

When a pull failed due to a signature policy violation, the error returned was:  
```
ERRO[0001] image "quay.io/tomsweeneyredhat/myalpine" not found in /etc/containers/registries.conf registries: image not known
```

The PolicyRequirementError that triggered the failure but itself was lost: 
```
Running image docker://quay.io/tomsweeneyredhat/myalpine:latest is rejected by policy.
```
With this change the failure now looks like:

```
# buildah from quay.io/tomsweeneyredhat/myalpine
Source image rejected: Running image docker://quay.io/tomsweeneyredhat/myalpine:latest is rejected by policy.
```
I'm a little leery about doing a return of the error instead of the continues.  I thought about doing a lastError thing, but that go messy too.  However if @nalind thinks that's the better way to go, I'll convert.

This addresses at least in part: #849 