### PR TITLE
rmi.storageImageID: fix Wrapf format warning

### DIFF
--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -295,7 +295,7 @@ func storageImageID(ctx context.Context, store storage.Store, id string) (types.
 		}
 		return nil, errors.Wrapf(err, "error confirming presence of storage image reference %q", transports.ImageName(ref))
 	}
-	return nil, errors.Wrapf(err, "error parsing %q as a storage image reference: %v", id)
+	return nil, errors.Wrapf(err, "error parsing %q as a storage image reference", id)
 }
 
 // Returns a list of all existing images


### PR DESCRIPTION
Golang tip got smarter and found the following issue:

    "Wrapf format %v reads arg #2, but call has 1 arg"

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>