### PR TITLE
Fix volume cache issue with buildah bud --layers

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5,11 +5,11 @@ load helpers
 @test "bud with --layers and --no-cache flags" {
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 5 ]
+  [ $(wc -l <<< "$output") -eq 6 ]
   [ "${status}" -eq 0 ]
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 6 ]
+  [ $(wc -l <<< "$output") -eq 7 ]
   [ "${status}" -eq 0 ]
   run buildah inspect --format "{{.Docker.ContainerConfig.Env}}" test2
   echo "$output"
@@ -18,23 +18,23 @@ load helpers
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 8 ]
+  [ $(wc -l <<< "$output") -eq 9 ]
   [ "${status}" -eq 0 ]
 
   mkdir -p ${TESTSDIR}/bud/use-layers/mount/subdir
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test4 -f Dockerfile.3 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 10 ]
+  [ $(wc -l <<< "$output") -eq 11 ]
   [ "${status}" -eq 0 ]
   touch ${TESTSDIR}/bud/use-layers/mount/subdir/file.txt
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test5 -f Dockerfile.3 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 12 ]
+  [ $(wc -l <<< "$output") -eq 13 ]
   [ "${status}" -eq 0 ]
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --no-cache -t test6 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 15 ]
+  [ $(wc -l <<< "$output") -eq 16 ]
   [ "${status}" -eq 0 ]
 
   buildah rmi -a -f
@@ -49,7 +49,7 @@ load helpers
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --rm=false --layers -t test2 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false containers
-  [ $(wc -l <<< "$output") -eq 4 ]
+  [ $(wc -l <<< "$output") -eq 5 ]
   [ "${status}" -eq 0 ]
 
   buildah rm -a

--- a/tests/bud/use-layers/Dockerfile
+++ b/tests/bud/use-layers/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine
 RUN mkdir /hello
+VOLUME /var/lib/testdata
 RUN touch file.txt
 ENV foo=bar

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -18,7 +18,7 @@ load helpers
   [ $(wc -l <<< "$output") -eq 3 ]
   [ "${status}" -eq 0 ]
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 5 ]
+  [ $(wc -l <<< "$output") -eq 6 ]
 
   # create a no name image which should show up when doing buildah images without the --all flag
   buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/use-layers


### PR DESCRIPTION
buildah bud would fail at the next step after a VOLUME command
due to buildah trying to cache the volume contents and restore it
later, but the intermediate container used at the VOLUME step didn't
exist anymore.
Changed functionality to delete successful intermediate containers at
the end of the whole build process.

Signed-off-by: umohnani8 <umohnani@redhat.com>