### PR TITLE
preprocess ".in" suffixed Dockerfiles

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -16,6 +16,8 @@ build context directory.
 
 The build context directory can be specified as the http(s) URL of an archive, git repository or Dockerfile.
 
+Dockerfiles ending with a ".in" suffix will be preprocessed via CPP(1).  This can be useful to decompose Dockerfiles into several reusable parts that can be used via CPP's **#include** directive.  Notice, a Dockerfile.in file can still be used by other tools when manually preprocessing them via `cpp -E`.
+
 When the URL is an archive, the contents of the URL is downloaded to a temporary location and extracted before execution.
 
 When the URL is an Dockerfile, the Dockerfile is downloaded to a temporary location.
@@ -598,4 +600,4 @@ buildah bud --no-cache --rm=false -t imageName .
 registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
-buildah(1), podman-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7)
+buildah(1), CPP(1), podman-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -811,3 +811,18 @@ load helpers
   [ "$status" -eq 0 ]
   [ "$output" = "" ]
 }
+
+@test "bud with preprocessor" {
+  target=alpine-image
+  run buildah -debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Decomposed.in ${TESTSDIR}/bud/preprocess
+  echo "$output"
+  [ "$status" -eq 0 ]
+  echo "$output"
+}
+
+@test "bud with preprocessor error" {
+  target=alpine-image
+  run buildah -debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Error.in ${TESTSDIR}/bud/preprocess
+  echo "$output"
+  [ "$status" -eq 1 ]
+}

--- a/tests/bud/preprocess/Decomposed.in
+++ b/tests/bud/preprocess/Decomposed.in
@@ -1,0 +1,7 @@
+FROM alpine:latest
+
+#include "common"
+
+RUNHELLO
+
+#include "install-base"

--- a/tests/bud/preprocess/Error.in
+++ b/tests/bud/preprocess/Error.in
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+#include "common"
+
+#error

--- a/tests/bud/preprocess/common
+++ b/tests/bud/preprocess/common
@@ -1,0 +1,3 @@
+#define RUNHELLO RUN echo "Hello world!"
+
+RUN touch /etc/hello-world.txt

--- a/tests/bud/preprocess/install-base
+++ b/tests/bud/preprocess/install-base
@@ -1,0 +1,3 @@
+RUN apk update
+
+RUN apk add git curl


### PR DESCRIPTION
Use CPP(1) on any input Dockerfile with a ".in" suffix.  This allows to
decompose Dockerfiles and make them reusable via the `#include`
directive.  Notice that those Dockerfiles can still be used by other
tools by manually running `cpp -E` on them.

This change affects both, the `imagebuild.BuildDockerfiles(...)` API and
buildah-bud.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>