### PR TITLE
unshare: make adjusting the OOM score optional

### DIFF
--- a/chroot/run.go
+++ b/chroot/run.go
@@ -520,9 +520,7 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 		cmd.Setsid = true
 		cmd.Ctty = ctty
 	}
-	if spec.Process.OOMScoreAdj != nil {
-		cmd.OOMScoreAdj = *spec.Process.OOMScoreAdj
-	}
+	cmd.OOMScoreAdj = spec.Process.OOMScoreAdj
 	cmd.ExtraFiles = append([]*os.File{preader}, cmd.ExtraFiles...)
 	cmd.Hook = func(int) error {
 		for _, f := range closeOnceRunning {

--- a/unshare/unshare.go
+++ b/unshare/unshare.go
@@ -33,7 +33,7 @@ type Cmd struct {
 	Setsid                     bool
 	Setpgrp                    bool
 	Ctty                       *os.File
-	OOMScoreAdj                int
+	OOMScoreAdj                *int
 	Hook                       func(pid int) error
 }
 
@@ -235,16 +235,18 @@ func (c *Cmd) Start() error {
 	}
 
 	// Adjust the process's OOM score.
-	oomScoreAdj, err := os.OpenFile(fmt.Sprintf("/proc/%s/oom_score_adj", pidString), os.O_TRUNC|os.O_WRONLY, 0)
-	if err != nil {
-		fmt.Fprintf(continueWrite, "error opening oom_score_adj: %v", err)
-		return errors.Wrapf(err, "error opening /proc/%s/oom_score_adj", pidString)
+	if c.OOMScoreAdj != nil {
+		oomScoreAdj, err := os.OpenFile(fmt.Sprintf("/proc/%s/oom_score_adj", pidString), os.O_TRUNC|os.O_WRONLY, 0)
+		if err != nil {
+			fmt.Fprintf(continueWrite, "error opening oom_score_adj: %v", err)
+			return errors.Wrapf(err, "error opening /proc/%s/oom_score_adj", pidString)
+		}
+		defer oomScoreAdj.Close()
+		if _, err := fmt.Fprintf(oomScoreAdj, "%d\n", *c.OOMScoreAdj); err != nil {
+			fmt.Fprintf(continueWrite, "error writing \"%d\" to oom_score_adj: %v", c.OOMScoreAdj, err)
+			return errors.Wrapf(err, "error writing \"%d\" to /proc/%s/oom_score_adj", c.OOMScoreAdj, pidString)
+		}
 	}
-	if _, err := fmt.Fprintf(oomScoreAdj, "%d\n", c.OOMScoreAdj); err != nil {
-		fmt.Fprintf(continueWrite, "error writing \"%d\" to oom_score_adj: %v", c.OOMScoreAdj, err)
-		return errors.Wrapf(err, "error writing \"%d\" to /proc/%s/oom_score_adj", c.OOMScoreAdj)
-	}
-	defer oomScoreAdj.Close()
 
 	// Run any additional setup that we want to do before the child starts running proper.
 	if c.Hook != nil {

--- a/unshare/unshare_test.go
+++ b/unshare/unshare_test.go
@@ -198,7 +198,7 @@ func TestUnshareOOMScoreAdj(t *testing.T) {
 		var report Report
 		buf := new(bytes.Buffer)
 		cmd := Command("report")
-		cmd.OOMScoreAdj = adj
+		cmd.OOMScoreAdj = &adj
 		cmd.Stdout = buf
 		cmd.Stderr = buf
 		err := cmd.Run()


### PR DESCRIPTION
The OOM score adjustment is an optional field in the runtime spec, so only try to set it in our unshare if it's set in the spec.  This _might_ help with a problem that @vbatts is running into attempting to use buildah inside of a kubernetes pod.