### PR TITLE
buildah: no args is out of bounds

### DIFF
--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -60,6 +60,9 @@ func maybeReexecUsingUserNamespace(c *cli.Context, evenForRoot bool) {
 	}
 
 	// If this is one of the commands that doesn't need this indirection, skip it.
+	if c.NArg() == 0 {
+		return
+	}
 	switch c.Args()[0] {
 	case "help", "version":
 		return


### PR DESCRIPTION
```shell
[root@abfcfc8928df /]# buildah
panic: runtime error: index out of range

goroutine 1 [running]:
main.maybeReexecUsingUserNamespace(0xc4200f62c0, 0xc73d00)
        /home/vbatts/src/github.com/projectatomic/buildah/cmd/buildah/unshare.go:63 +0x179a
main.main.func1(0xc4200f62c0, 0xcb1d88, 0xc4202861c0)
        /home/vbatts/src/github.com/projectatomic/buildah/cmd/buildah/main.go:85 +0x9c
github.com/projectatomic/buildah/vendor/github.com/urfave/cli.(*App).Run(0xc4202861c0, 0xc42001e1b0, 0x1, 0x1, 0x0, 0x0)
        /home/vbatts/src/github.com/projectatomic/buildah/vendor/github.com/urfave/cli/app.go:244 +0x738
main.main()
        /home/vbatts/src/github.com/projectatomic/buildah/cmd/buildah/main.go:120 +0xe22
```

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>