### PR TITLE
Switch to sysregistriesv2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -4,7 +4,7 @@ github.com/BurntSushi/toml master
 github.com/containerd/continuity master
 github.com/containernetworking/cni v0.6.0
 github.com/seccomp/containers-golang master
-github.com/containers/image 134f99bed228d6297dc01d152804f6f09f185418
+github.com/containers/image 216acb1bcd2c1abef736ee322e17147ee2b7d76c
 github.com/containers/storage 17c7d1fee5603ccf6dd97edc14162fc1510e7e23
 github.com/docker/distribution 5f6282db7d65e6d72ad7c2cc66310724a57be716
 github.com/docker/docker b8571fd81c7d2223c9ecbf799c693e3ef1daaea9

--- a/vendor/github.com/containers/image/copy/copy.go
+++ b/vendor/github.com/containers/image/copy/copy.go
@@ -604,7 +604,6 @@ func computeDiffID(stream io.Reader, decompressor compression.DecompressorFunc) 
 		if err != nil {
 			return "", err
 		}
-		defer s.Close()
 		stream = s
 	}
 
@@ -674,12 +673,10 @@ func (c *copier) copyBlobFromStream(ctx context.Context, srcStream io.Reader, sr
 		inputInfo.Size = -1
 	} else if canModifyBlob && c.dest.DesiredLayerCompression() == types.Decompress && isCompressed {
 		logrus.Debugf("Blob will be decompressed")
-		s, err := decompressor(destStream)
+		destStream, err = decompressor(destStream)
 		if err != nil {
 			return types.BlobInfo{}, err
 		}
-		defer s.Close()
-		destStream = s
 		inputInfo.Digest = ""
 		inputInfo.Size = -1
 	} else {

--- a/vendor/github.com/containers/image/docker/docker_client.go
+++ b/vendor/github.com/containers/image/docker/docker_client.go
@@ -449,9 +449,6 @@ func (c *dockerClient) getBearerToken(ctx context.Context, realm, service, scope
 	}
 	authReq = authReq.WithContext(ctx)
 	getParams := authReq.URL.Query()
-	if c.username != "" {
-		getParams.Add("account", c.username)
-	}
 	if service != "" {
 		getParams.Add("service", service)
 	}

--- a/vendor/github.com/containers/image/docker/tarfile/src.go
+++ b/vendor/github.com/containers/image/docker/tarfile/src.go
@@ -3,6 +3,7 @@ package tarfile
 import (
 	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"io"
@@ -42,7 +43,8 @@ type layerInfo struct {
 //       the source of an image.
 // 	To do for both the NewSourceFromFile and NewSourceFromStream functions
 
-// NewSourceFromFile returns a tarfile.Source for the specified path.
+// NewSourceFromFile returns a tarfile.Source for the specified path
+// NewSourceFromFile supports both conpressed and uncompressed input
 func NewSourceFromFile(path string) (*Source, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -50,24 +52,19 @@ func NewSourceFromFile(path string) (*Source, error) {
 	}
 	defer file.Close()
 
-	// If the file is already not compressed we can just return the file itself
-	// as a source. Otherwise we pass the stream to NewSourceFromStream.
-	stream, isCompressed, err := compression.AutoDecompress(file)
+	reader, err := gzip.NewReader(file)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error detecting compression for file %q", path)
-	}
-	defer stream.Close()
-	if !isCompressed {
 		return &Source{
 			tarPath: path,
 		}, nil
 	}
-	return NewSourceFromStream(stream)
+	defer reader.Close()
+
+	return NewSourceFromStream(reader)
 }
 
-// NewSourceFromStream returns a tarfile.Source for the specified inputStream,
-// which can be either compressed or uncompressed. The caller can close the
-// inputStream immediately after NewSourceFromFile returns.
+// NewSourceFromStream returns a tarfile.Source for the specified inputStream, which must be uncompressed.
+// The caller can close the inputStream immediately after NewSourceFromFile returns.
 func NewSourceFromStream(inputStream io.Reader) (*Source, error) {
 	// FIXME: use SystemContext here.
 	// Save inputStream to a temporary file
@@ -84,20 +81,8 @@ func NewSourceFromStream(inputStream io.Reader) (*Source, error) {
 		}
 	}()
 
-	// In order to be compatible with docker-load, we need to support
-	// auto-decompression (it's also a nice quality-of-life thing to avoid
-	// giving users really confusing "invalid tar header" errors).
-	uncompressedStream, _, err := compression.AutoDecompress(inputStream)
-	if err != nil {
-		return nil, errors.Wrap(err, "Error auto-decompressing input")
-	}
-	defer uncompressedStream.Close()
-
-	// Copy the plain archive to the temporary file.
-	//
-	// TODO: This can take quite some time, and should ideally be cancellable
-	//       using a context.Context.
-	if _, err := io.Copy(tarCopyFile, uncompressedStream); err != nil {
+	// TODO: This can take quite some time, and should ideally be cancellable using a context.Context.
+	if _, err := io.Copy(tarCopyFile, inputStream); err != nil {
 		return nil, errors.Wrapf(err, "error copying contents to temporary file %q", tarCopyFile.Name())
 	}
 	succeeded = true
@@ -307,25 +292,7 @@ func (s *Source) prepareLayerData(tarManifest *ManifestItem, parsedConfig *manif
 			return nil, err
 		}
 		if li, ok := unknownLayerSizes[h.Name]; ok {
-			// Since GetBlob will decompress layers that are compressed we need
-			// to do the decompression here as well, otherwise we will
-			// incorrectly report the size. Pretty critical, since tools like
-			// umoci always compress layer blobs. Obviously we only bother with
-			// the slower method of checking if it's compressed.
-			uncompressedStream, isCompressed, err := compression.AutoDecompress(t)
-			if err != nil {
-				return nil, errors.Wrapf(err, "Error auto-decompressing %s to determine its size", h.Name)
-			}
-			defer uncompressedStream.Close()
-
-			uncompressedSize := h.Size
-			if isCompressed {
-				uncompressedSize, err = io.Copy(ioutil.Discard, uncompressedStream)
-				if err != nil {
-					return nil, errors.Wrapf(err, "Error reading %s to find its size", h.Name)
-				}
-			}
-			li.size = uncompressedSize
+			li.size = h.Size
 			delete(unknownLayerSizes, h.Name)
 		}
 	}
@@ -379,22 +346,16 @@ func (s *Source) GetManifest(ctx context.Context, instanceDigest *digest.Digest)
 	return s.generatedManifest, manifest.DockerV2Schema2MediaType, nil
 }
 
-// uncompressedReadCloser is an io.ReadCloser that closes both the uncompressed stream and the underlying input.
-type uncompressedReadCloser struct {
+type readCloseWrapper struct {
 	io.Reader
-	underlyingCloser   func() error
-	uncompressedCloser func() error
+	closeFunc func() error
 }
 
-func (r uncompressedReadCloser) Close() error {
-	var res error
-	if err := r.uncompressedCloser(); err != nil {
-		res = err
+func (r readCloseWrapper) Close() error {
+	if r.closeFunc != nil {
+		return r.closeFunc()
 	}
-	if err := r.underlyingCloser(); err != nil && res == nil {
-		res = err
-	}
-	return res
+	return nil
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
@@ -408,16 +369,10 @@ func (s *Source) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadClose
 	}
 
 	if li, ok := s.knownLayers[info.Digest]; ok { // diffID is a digest of the uncompressed tarball,
-		underlyingStream, err := s.openTarComponent(li.path)
+		stream, err := s.openTarComponent(li.path)
 		if err != nil {
 			return nil, 0, err
 		}
-		closeUnderlyingStream := true
-		defer func() {
-			if closeUnderlyingStream {
-				underlyingStream.Close()
-			}
-		}()
 
 		// In order to handle the fact that digests != diffIDs (and thus that a
 		// caller which is trying to verify the blob will run into problems),
@@ -431,17 +386,22 @@ func (s *Source) GetBlob(ctx context.Context, info types.BlobInfo) (io.ReadClose
 		// be verifing a "digest" which is not the actual layer's digest (but
 		// is instead the DiffID).
 
-		uncompressedStream, _, err := compression.AutoDecompress(underlyingStream)
+		decompressFunc, reader, err := compression.DetectCompression(stream)
 		if err != nil {
-			return nil, 0, errors.Wrapf(err, "Error auto-decompressing blob %s", info.Digest)
+			return nil, 0, errors.Wrapf(err, "Detecting compression in blob %s", info.Digest)
 		}
 
-		newStream := uncompressedReadCloser{
-			Reader:             uncompressedStream,
-			underlyingCloser:   underlyingStream.Close,
-			uncompressedCloser: uncompressedStream.Close,
+		if decompressFunc != nil {
+			reader, err = decompressFunc(reader)
+			if err != nil {
+				return nil, 0, errors.Wrapf(err, "Decompressing blob %s stream", info.Digest)
+			}
 		}
-		closeUnderlyingStream = false
+
+		newStream := readCloseWrapper{
+			Reader:    reader,
+			closeFunc: stream.Close,
+		}
 
 		return newStream, li.size, nil
 	}

--- a/vendor/github.com/containers/image/image/docker_schema1.go
+++ b/vendor/github.com/containers/image/image/docker_schema1.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
@@ -24,12 +25,8 @@ func manifestSchema1FromManifest(manifestBlob []byte) (genericManifest, error) {
 }
 
 // manifestSchema1FromComponents builds a new manifestSchema1 from the supplied data.
-func manifestSchema1FromComponents(ref reference.Named, fsLayers []manifest.Schema1FSLayers, history []manifest.Schema1History, architecture string) (genericManifest, error) {
-	m, err := manifest.Schema1FromComponents(ref, fsLayers, history, architecture)
-	if err != nil {
-		return nil, err
-	}
-	return &manifestSchema1{m: m}, nil
+func manifestSchema1FromComponents(ref reference.Named, fsLayers []manifest.Schema1FSLayers, history []manifest.Schema1History, architecture string) genericManifest {
+	return &manifestSchema1{m: manifest.Schema1FromComponents(ref, fsLayers, history, architecture)}
 }
 
 func (m *manifestSchema1) serialize() ([]byte, error) {
@@ -67,7 +64,7 @@ func (m *manifestSchema1) OCIConfig(ctx context.Context) (*imgspecv1.Image, erro
 // The Digest field is guaranteed to be provided; Size may be -1.
 // WARNING: The list may contain duplicates, and they are semantically relevant.
 func (m *manifestSchema1) LayerInfos() []types.BlobInfo {
-	return manifestLayerInfosToBlobInfos(m.m.LayerInfos())
+	return m.m.LayerInfos()
 }
 
 // EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
@@ -151,12 +148,12 @@ func (m *manifestSchema1) UpdatedImage(ctx context.Context, options types.Manife
 
 // Based on github.com/docker/docker/distribution/pull_v2.go
 func (m *manifestSchema1) convertToManifestSchema2(uploadedLayerInfos []types.BlobInfo, layerDiffIDs []digest.Digest) (genericManifest, error) {
-	if len(m.m.ExtractedV1Compatibility) == 0 {
-		// What would this even mean?! Anyhow, the rest of the code depends on FSLayers[0] and ExtractedV1Compatibility[0] existing.
+	if len(m.m.History) == 0 {
+		// What would this even mean?! Anyhow, the rest of the code depends on fsLayers[0] and history[0] existing.
 		return nil, errors.Errorf("Cannot convert an image with 0 history entries to %s", manifest.DockerV2Schema2MediaType)
 	}
-	if len(m.m.ExtractedV1Compatibility) != len(m.m.FSLayers) {
-		return nil, errors.Errorf("Inconsistent schema 1 manifest: %d history entries, %d fsLayers entries", len(m.m.ExtractedV1Compatibility), len(m.m.FSLayers))
+	if len(m.m.History) != len(m.m.FSLayers) {
+		return nil, errors.Errorf("Inconsistent schema 1 manifest: %d history entries, %d fsLayers entries", len(m.m.History), len(m.m.FSLayers))
 	}
 	if uploadedLayerInfos != nil && len(uploadedLayerInfos) != len(m.m.FSLayers) {
 		return nil, errors.Errorf("Internal error: uploaded %d blobs, but schema1 manifest has %d fsLayers", len(uploadedLayerInfos), len(m.m.FSLayers))
@@ -168,10 +165,14 @@ func (m *manifestSchema1) convertToManifestSchema2(uploadedLayerInfos []types.Bl
 	// Build a list of the diffIDs for the non-empty layers.
 	diffIDs := []digest.Digest{}
 	var layers []manifest.Schema2Descriptor
-	for v1Index := len(m.m.ExtractedV1Compatibility) - 1; v1Index >= 0; v1Index-- {
-		v2Index := (len(m.m.ExtractedV1Compatibility) - 1) - v1Index
+	for v1Index := len(m.m.History) - 1; v1Index >= 0; v1Index-- {
+		v2Index := (len(m.m.History) - 1) - v1Index
 
-		if !m.m.ExtractedV1Compatibility[v1Index].ThrowAway {
+		var v1compat manifest.Schema1V1Compatibility
+		if err := json.Unmarshal([]byte(m.m.History[v1Index].V1Compatibility), &v1compat); err != nil {
+			return nil, errors.Wrapf(err, "Error decoding history entry %d", v1Index)
+		}
+		if !v1compat.ThrowAway {
 			var size int64
 			if uploadedLayerInfos != nil {
 				size = uploadedLayerInfos[v2Index].Size

--- a/vendor/github.com/containers/image/image/docker_schema2.go
+++ b/vendor/github.com/containers/image/image/docker_schema2.go
@@ -18,17 +18,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// GzippedEmptyLayer is a gzip-compressed version of an empty tar file (1024 NULL bytes)
+// gzippedEmptyLayer is a gzip-compressed version of an empty tar file (1024 NULL bytes)
 // This comes from github.com/docker/distribution/manifest/schema1/config_builder.go; there is
 // a non-zero embedded timestamp; we could zero that, but that would just waste storage space
 // in registries, so let’s use the same values.
-var GzippedEmptyLayer = []byte{
+var gzippedEmptyLayer = []byte{
 	31, 139, 8, 0, 0, 9, 110, 136, 0, 255, 98, 24, 5, 163, 96, 20, 140, 88,
 	0, 8, 0, 0, 255, 255, 46, 175, 181, 239, 0, 4, 0, 0,
 }
 
-// GzippedEmptyLayerDigest is a digest of GzippedEmptyLayer
-const GzippedEmptyLayerDigest = digest.Digest("sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4")
+// gzippedEmptyLayerDigest is a digest of gzippedEmptyLayer
+const gzippedEmptyLayerDigest = digest.Digest("sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4")
 
 type manifestSchema2 struct {
 	src        types.ImageSource // May be nil if configBlob is not nil
@@ -95,7 +95,11 @@ func (m *manifestSchema2) ConfigBlob(ctx context.Context) ([]byte, error) {
 		if m.src == nil {
 			return nil, errors.Errorf("Internal error: neither src nor configBlob set in manifestSchema2")
 		}
-		stream, _, err := m.src.GetBlob(ctx, manifest.BlobInfoFromSchema2Descriptor(m.m.ConfigDescriptor))
+		stream, _, err := m.src.GetBlob(ctx, types.BlobInfo{
+			Digest: m.m.ConfigDescriptor.Digest,
+			Size:   m.m.ConfigDescriptor.Size,
+			URLs:   m.m.ConfigDescriptor.URLs,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -117,7 +121,7 @@ func (m *manifestSchema2) ConfigBlob(ctx context.Context) ([]byte, error) {
 // The Digest field is guaranteed to be provided; Size may be -1.
 // WARNING: The list may contain duplicates, and they are semantically relevant.
 func (m *manifestSchema2) LayerInfos() []types.BlobInfo {
-	return manifestLayerInfosToBlobInfos(m.m.LayerInfos())
+	return m.m.LayerInfos()
 }
 
 // EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
@@ -249,16 +253,16 @@ func (m *manifestSchema2) convertToManifestSchema1(ctx context.Context, dest typ
 		if historyEntry.EmptyLayer {
 			if !haveGzippedEmptyLayer {
 				logrus.Debugf("Uploading empty layer during conversion to schema 1")
-				info, err := dest.PutBlob(ctx, bytes.NewReader(GzippedEmptyLayer), types.BlobInfo{Digest: GzippedEmptyLayerDigest, Size: int64(len(GzippedEmptyLayer))}, false)
+				info, err := dest.PutBlob(ctx, bytes.NewReader(gzippedEmptyLayer), types.BlobInfo{Digest: gzippedEmptyLayerDigest, Size: int64(len(gzippedEmptyLayer))}, false)
 				if err != nil {
 					return nil, errors.Wrap(err, "Error uploading empty layer")
 				}
-				if info.Digest != GzippedEmptyLayerDigest {
-					return nil, errors.Errorf("Internal error: Uploaded empty layer has digest %#v instead of %s", info.Digest, GzippedEmptyLayerDigest)
+				if info.Digest != gzippedEmptyLayerDigest {
+					return nil, errors.Errorf("Internal error: Uploaded empty layer has digest %#v instead of %s", info.Digest, gzippedEmptyLayerDigest)
 				}
 				haveGzippedEmptyLayer = true
 			}
-			blobDigest = GzippedEmptyLayerDigest
+			blobDigest = gzippedEmptyLayerDigest
 		} else {
 			if nonemptyLayerIndex >= len(m.m.LayersDescriptors) {
 				return nil, errors.Errorf("Invalid image configuration, needs more than the %d distributed layers", len(m.m.LayersDescriptors))
@@ -304,10 +308,7 @@ func (m *manifestSchema2) convertToManifestSchema1(ctx context.Context, dest typ
 	}
 	history[0].V1Compatibility = string(v1Config)
 
-	m1, err := manifestSchema1FromComponents(dest.Reference().DockerReference(), fsLayers, history, imageConfig.Architecture)
-	if err != nil {
-		return nil, err // This should never happen, we should have created all the components correctly.
-	}
+	m1 := manifestSchema1FromComponents(dest.Reference().DockerReference(), fsLayers, history, imageConfig.Architecture)
 	return memoryImageFromManifest(m1), nil
 }
 

--- a/vendor/github.com/containers/image/image/manifest.go
+++ b/vendor/github.com/containers/image/image/manifest.go
@@ -62,12 +62,3 @@ func manifestInstanceFromBlob(ctx context.Context, sys *types.SystemContext, src
 		return nil, fmt.Errorf("Unimplemented manifest MIME type %s", mt)
 	}
 }
-
-// manifestLayerInfosToBlobInfos extracts a []types.BlobInfo from a []manifest.LayerInfo.
-func manifestLayerInfosToBlobInfos(layers []manifest.LayerInfo) []types.BlobInfo {
-	blobs := make([]types.BlobInfo, len(layers))
-	for i, layer := range layers {
-		blobs[i] = layer.BlobInfo
-	}
-	return blobs
-}

--- a/vendor/github.com/containers/image/image/oci.go
+++ b/vendor/github.com/containers/image/image/oci.go
@@ -60,7 +60,11 @@ func (m *manifestOCI1) ConfigBlob(ctx context.Context) ([]byte, error) {
 		if m.src == nil {
 			return nil, errors.Errorf("Internal error: neither src nor configBlob set in manifestOCI1")
 		}
-		stream, _, err := m.src.GetBlob(ctx, manifest.BlobInfoFromOCI1Descriptor(m.m.Config))
+		stream, _, err := m.src.GetBlob(ctx, types.BlobInfo{
+			Digest: m.m.Config.Digest,
+			Size:   m.m.Config.Size,
+			URLs:   m.m.Config.URLs,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -97,7 +101,7 @@ func (m *manifestOCI1) OCIConfig(ctx context.Context) (*imgspecv1.Image, error) 
 // The Digest field is guaranteed to be provided; Size may be -1.
 // WARNING: The list may contain duplicates, and they are semantically relevant.
 func (m *manifestOCI1) LayerInfos() []types.BlobInfo {
-	return manifestLayerInfosToBlobInfos(m.m.LayerInfos())
+	return m.m.LayerInfos()
 }
 
 // EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.

--- a/vendor/github.com/containers/image/manifest/docker_schema1.go
+++ b/vendor/github.com/containers/image/manifest/docker_schema1.go
@@ -25,28 +25,25 @@ type Schema1History struct {
 
 // Schema1 is a manifest in docker/distribution schema 1.
 type Schema1 struct {
-	Name                     string                   `json:"name"`
-	Tag                      string                   `json:"tag"`
-	Architecture             string                   `json:"architecture"`
-	FSLayers                 []Schema1FSLayers        `json:"fsLayers"`
-	History                  []Schema1History         `json:"history"` // Keep this in sync with ExtractedV1Compatibility!
-	ExtractedV1Compatibility []Schema1V1Compatibility `json:"-"`       // Keep this in sync with History! Does not contain the full config (Schema2V1Image)
-	SchemaVersion            int                      `json:"schemaVersion"`
-}
-
-type schema1V1CompatibilityContainerConfig struct {
-	Cmd []string
+	Name          string            `json:"name"`
+	Tag           string            `json:"tag"`
+	Architecture  string            `json:"architecture"`
+	FSLayers      []Schema1FSLayers `json:"fsLayers"`
+	History       []Schema1History  `json:"history"`
+	SchemaVersion int               `json:"schemaVersion"`
 }
 
 // Schema1V1Compatibility is a v1Compatibility in docker/distribution schema 1.
 type Schema1V1Compatibility struct {
-	ID              string                                `json:"id"`
-	Parent          string                                `json:"parent,omitempty"`
-	Comment         string                                `json:"comment,omitempty"`
-	Created         time.Time                             `json:"created"`
-	ContainerConfig schema1V1CompatibilityContainerConfig `json:"container_config,omitempty"`
-	Author          string                                `json:"author,omitempty"`
-	ThrowAway       bool                                  `json:"throwaway,omitempty"`
+	ID              string    `json:"id"`
+	Parent          string    `json:"parent,omitempty"`
+	Comment         string    `json:"comment,omitempty"`
+	Created         time.Time `json:"created"`
+	ContainerConfig struct {
+		Cmd []string
+	} `json:"container_config,omitempty"`
+	Author    string `json:"author,omitempty"`
+	ThrowAway bool   `json:"throwaway,omitempty"`
 }
 
 // Schema1FromManifest creates a Schema1 manifest instance from a manifest blob.
@@ -60,8 +57,11 @@ func Schema1FromManifest(manifest []byte) (*Schema1, error) {
 	if s1.SchemaVersion != 1 {
 		return nil, errors.Errorf("unsupported schema version %d", s1.SchemaVersion)
 	}
-	if err := s1.initialize(); err != nil {
-		return nil, err
+	if len(s1.FSLayers) != len(s1.History) {
+		return nil, errors.New("length of history not equal to number of layers")
+	}
+	if len(s1.FSLayers) == 0 {
+		return nil, errors.New("no FSLayers in manifest")
 	}
 	if err := s1.fixManifestLayers(); err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func Schema1FromManifest(manifest []byte) (*Schema1, error) {
 }
 
 // Schema1FromComponents creates an Schema1 manifest instance from the supplied data.
-func Schema1FromComponents(ref reference.Named, fsLayers []Schema1FSLayers, history []Schema1History, architecture string) (*Schema1, error) {
+func Schema1FromComponents(ref reference.Named, fsLayers []Schema1FSLayers, history []Schema1History, architecture string) *Schema1 {
 	var name, tag string
 	if ref != nil { // Well, what to do if it _is_ nil? Most consumers actually don't use these fields nowadays, so we might as well try not supplying them.
 		name = reference.Path(ref)
@@ -78,7 +78,7 @@ func Schema1FromComponents(ref reference.Named, fsLayers []Schema1FSLayers, hist
 			tag = tagged.Tag()
 		}
 	}
-	s1 := Schema1{
+	return &Schema1{
 		Name:          name,
 		Tag:           tag,
 		Architecture:  architecture,
@@ -86,10 +86,6 @@ func Schema1FromComponents(ref reference.Named, fsLayers []Schema1FSLayers, hist
 		History:       history,
 		SchemaVersion: 1,
 	}
-	if err := s1.initialize(); err != nil {
-		return nil, err
-	}
-	return &s1, nil
 }
 
 // Schema1Clone creates a copy of the supplied Schema1 manifest.
@@ -98,51 +94,31 @@ func Schema1Clone(src *Schema1) *Schema1 {
 	return &copy
 }
 
-// initialize initializes ExtractedV1Compatibility and verifies invariants, so that the rest of this code can assume a minimally healthy manifest.
-func (m *Schema1) initialize() error {
-	if len(m.FSLayers) != len(m.History) {
-		return errors.New("length of history not equal to number of layers")
-	}
-	if len(m.FSLayers) == 0 {
-		return errors.New("no FSLayers in manifest")
-	}
-	m.ExtractedV1Compatibility = make([]Schema1V1Compatibility, len(m.History))
-	for i, h := range m.History {
-		if err := json.Unmarshal([]byte(h.V1Compatibility), &m.ExtractedV1Compatibility[i]); err != nil {
-			return errors.Wrapf(err, "Error parsing v2s1 history entry %d", i)
-		}
-	}
-	return nil
-}
-
 // ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
 func (m *Schema1) ConfigInfo() types.BlobInfo {
 	return types.BlobInfo{}
 }
 
-// LayerInfos returns a list of LayerInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
+// LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
 // The Digest field is guaranteed to be provided; Size may be -1.
 // WARNING: The list may contain duplicates, and they are semantically relevant.
-func (m *Schema1) LayerInfos() []LayerInfo {
-	layers := make([]LayerInfo, len(m.FSLayers))
+func (m *Schema1) LayerInfos() []types.BlobInfo {
+	layers := make([]types.BlobInfo, len(m.FSLayers))
 	for i, layer := range m.FSLayers { // NOTE: This includes empty layers (where m.History.V1Compatibility->ThrowAway)
-		layers[(len(m.FSLayers)-1)-i] = LayerInfo{
-			BlobInfo:   types.BlobInfo{Digest: layer.BlobSum, Size: -1},
-			EmptyLayer: m.ExtractedV1Compatibility[i].ThrowAway,
-		}
+		layers[(len(m.FSLayers)-1)-i] = types.BlobInfo{Digest: layer.BlobSum, Size: -1}
 	}
 	return layers
 }
 
 // UpdateLayerInfos replaces the original layers with the specified BlobInfos (size+digest+urls), in order (the root layer first, and then successive layered layers)
 func (m *Schema1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
-	// Our LayerInfos includes empty layers (where m.ExtractedV1Compatibility[].ThrowAway), so expect them to be included here as well.
+	// Our LayerInfos includes empty layers (where m.History.V1Compatibility->ThrowAway), so expect them to be included here as well.
 	if len(m.FSLayers) != len(layerInfos) {
 		return errors.Errorf("Error preparing updated manifest: layer count changed from %d to %d", len(m.FSLayers), len(layerInfos))
 	}
 	m.FSLayers = make([]Schema1FSLayers, len(layerInfos))
 	for i, info := range layerInfos {
-		// (docker push) sets up m.ExtractedV1Compatibility[].{Id,Parent} based on values of info.Digest,
+		// (docker push) sets up m.History.V1Compatibility->{Id,Parent} based on values of info.Digest,
 		// but (docker pull) ignores them in favor of computing DiffIDs from uncompressed data, except verifying the child->parent links and uniqueness.
 		// So, we don't bother recomputing the IDs in m.History.V1Compatibility.
 		m.FSLayers[(len(layerInfos)-1)-i].BlobSum = info.Digest
@@ -168,19 +144,31 @@ func (m *Schema1) Serialize() ([]byte, error) {
 // Note that even after this succeeds, m.FSLayers may contain duplicate entries
 // (for Dockerfile operations which change the configuration but not the filesystem).
 func (m *Schema1) fixManifestLayers() error {
-	// m.initialize() has verified that len(m.FSLayers) == len(m.History)
-	for _, compat := range m.ExtractedV1Compatibility {
-		if err := validateV1ID(compat.ID); err != nil {
+	type imageV1 struct {
+		ID     string
+		Parent string
+	}
+	// Per the specification, we can assume that len(m.FSLayers) == len(m.History)
+	imgs := make([]*imageV1, len(m.FSLayers))
+	for i := range m.FSLayers {
+		img := &imageV1{}
+
+		if err := json.Unmarshal([]byte(m.History[i].V1Compatibility), img); err != nil {
+			return err
+		}
+
+		imgs[i] = img
+		if err := validateV1ID(img.ID); err != nil {
 			return err
 		}
 	}
-	if m.ExtractedV1Compatibility[len(m.ExtractedV1Compatibility)-1].Parent != "" {
+	if imgs[len(imgs)-1].Parent != "" {
 		return errors.New("Invalid parent ID in the base layer of the image")
 	}
 	// check general duplicates to error instead of a deadlock
 	idmap := make(map[string]struct{})
 	var lastID string
-	for _, img := range m.ExtractedV1Compatibility {
+	for _, img := range imgs {
 		// skip IDs that appear after each other, we handle those later
 		if _, exists := idmap[img.ID]; img.ID != lastID && exists {
 			return errors.Errorf("ID %+v appears multiple times in manifest", img.ID)
@@ -189,13 +177,12 @@ func (m *Schema1) fixManifestLayers() error {
 		idmap[lastID] = struct{}{}
 	}
 	// backwards loop so that we keep the remaining indexes after removing items
-	for i := len(m.ExtractedV1Compatibility) - 2; i >= 0; i-- {
-		if m.ExtractedV1Compatibility[i].ID == m.ExtractedV1Compatibility[i+1].ID { // repeated ID. remove and continue
+	for i := len(imgs) - 2; i >= 0; i-- {
+		if imgs[i].ID == imgs[i+1].ID { // repeated ID. remove and continue
 			m.FSLayers = append(m.FSLayers[:i], m.FSLayers[i+1:]...)
 			m.History = append(m.History[:i], m.History[i+1:]...)
-			m.ExtractedV1Compatibility = append(m.ExtractedV1Compatibility[:i], m.ExtractedV1Compatibility[i+1:]...)
-		} else if m.ExtractedV1Compatibility[i].Parent != m.ExtractedV1Compatibility[i+1].ID {
-			return errors.Errorf("Invalid parent ID. Expected %v, got %v", m.ExtractedV1Compatibility[i+1].ID, m.ExtractedV1Compatibility[i].Parent)
+		} else if imgs[i].Parent != imgs[i+1].ID {
+			return errors.Errorf("Invalid parent ID. Expected %v, got %v", imgs[i+1].ID, imgs[i].Parent)
 		}
 	}
 	return nil
@@ -222,7 +209,7 @@ func (m *Schema1) Inspect(_ func(types.BlobInfo) ([]byte, error)) (*types.ImageI
 		DockerVersion: s1.DockerVersion,
 		Architecture:  s1.Architecture,
 		Os:            s1.OS,
-		Layers:        layerInfosToStrings(m.LayerInfos()),
+		Layers:        LayerInfosToStrings(m.LayerInfos()),
 	}
 	if s1.Config != nil {
 		i.Labels = s1.Config.Labels
@@ -253,7 +240,11 @@ func (m *Schema1) ToSchema2Config(diffIDs []digest.Digest) ([]byte, error) {
 	}
 	// Build the history.
 	convertedHistory := []Schema2History{}
-	for _, compat := range m.ExtractedV1Compatibility {
+	for _, h := range m.History {
+		compat := Schema1V1Compatibility{}
+		if err := json.Unmarshal([]byte(h.V1Compatibility), &compat); err != nil {
+			return nil, errors.Wrapf(err, "error decoding history information")
+		}
 		hitem := Schema2History{
 			Created:    compat.Created,
 			CreatedBy:  strings.Join(compat.ContainerConfig.Cmd, " "),

--- a/vendor/github.com/containers/image/manifest/docker_schema2.go
+++ b/vendor/github.com/containers/image/manifest/docker_schema2.go
@@ -18,16 +18,6 @@ type Schema2Descriptor struct {
 	URLs      []string      `json:"urls,omitempty"`
 }
 
-// BlobInfoFromSchema2Descriptor returns a types.BlobInfo based on the input schema 2 descriptor.
-func BlobInfoFromSchema2Descriptor(desc Schema2Descriptor) types.BlobInfo {
-	return types.BlobInfo{
-		Digest:    desc.Digest,
-		Size:      desc.Size,
-		URLs:      desc.URLs,
-		MediaType: desc.MediaType,
-	}
-}
-
 // Schema2 is a manifest in docker/distribution schema 2.
 type Schema2 struct {
 	SchemaVersion     int                 `json:"schemaVersion"`
@@ -181,18 +171,19 @@ func Schema2Clone(src *Schema2) *Schema2 {
 
 // ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
 func (m *Schema2) ConfigInfo() types.BlobInfo {
-	return BlobInfoFromSchema2Descriptor(m.ConfigDescriptor)
+	return types.BlobInfo{Digest: m.ConfigDescriptor.Digest, Size: m.ConfigDescriptor.Size}
 }
 
-// LayerInfos returns a list of LayerInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
+// LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
 // The Digest field is guaranteed to be provided; Size may be -1.
 // WARNING: The list may contain duplicates, and they are semantically relevant.
-func (m *Schema2) LayerInfos() []LayerInfo {
-	blobs := []LayerInfo{}
+func (m *Schema2) LayerInfos() []types.BlobInfo {
+	blobs := []types.BlobInfo{}
 	for _, layer := range m.LayersDescriptors {
-		blobs = append(blobs, LayerInfo{
-			BlobInfo:   BlobInfoFromSchema2Descriptor(layer),
-			EmptyLayer: false,
+		blobs = append(blobs, types.BlobInfo{
+			Digest: layer.Digest,
+			Size:   layer.Size,
+			URLs:   layer.URLs,
 		})
 	}
 	return blobs
@@ -236,7 +227,7 @@ func (m *Schema2) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*t
 		DockerVersion: s2.DockerVersion,
 		Architecture:  s2.Architecture,
 		Os:            s2.OS,
-		Layers:        layerInfosToStrings(m.LayerInfos()),
+		Layers:        LayerInfosToStrings(m.LayerInfos()),
 	}
 	if s2.Config != nil {
 		i.Labels = s2.Config.Labels

--- a/vendor/github.com/containers/image/manifest/manifest.go
+++ b/vendor/github.com/containers/image/manifest/manifest.go
@@ -50,10 +50,10 @@ var DefaultRequestedManifestMIMETypes = []string{
 type Manifest interface {
 	// ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
 	ConfigInfo() types.BlobInfo
-	// LayerInfos returns a list of LayerInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
+	// LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
 	// The Digest field is guaranteed to be provided; Size may be -1.
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
-	LayerInfos() []LayerInfo
+	LayerInfos() []types.BlobInfo
 	// UpdateLayerInfos replaces the original layers with the specified BlobInfos (size+digest+urls), in order (the root layer first, and then successive layered layers)
 	UpdateLayerInfos(layerInfos []types.BlobInfo) error
 
@@ -71,12 +71,6 @@ type Manifest interface {
 	// Serialize returns the manifest in a blob format.
 	// NOTE: Serialize() does not in general reproduce the original blob if this object was loaded from one, even if no modifications were made!
 	Serialize() ([]byte, error)
-}
-
-// LayerInfo is an extended version of types.BlobInfo for low-level users of Manifest.LayerInfos.
-type LayerInfo struct {
-	types.BlobInfo
-	EmptyLayer bool // The layer is an “empty”/“throwaway” one, and may or may not be physically represented in various transport / storage systems.  false if the manifest type does not have the concept.
 }
 
 // GuessMIMEType guesses MIME type of a manifest and returns it _if it is recognized_, or "" if unknown or unrecognized.
@@ -233,9 +227,9 @@ func FromBlob(manblob []byte, mt string) (Manifest, error) {
 	}
 }
 
-// layerInfosToStrings converts a list of layer infos, presumably obtained from a Manifest.LayerInfos()
+// LayerInfosToStrings converts a list of layer infos, presumably obtained from a Manifest.LayerInfos()
 // method call, into a format suitable for inclusion in a types.ImageInspectInfo structure.
-func layerInfosToStrings(infos []LayerInfo) []string {
+func LayerInfosToStrings(infos []types.BlobInfo) []string {
 	layers := make([]string, len(infos))
 	for i, info := range infos {
 		layers[i] = info.Digest.String()

--- a/vendor/github.com/containers/image/oci/layout/oci_dest.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_dest.go
@@ -18,10 +18,9 @@ import (
 )
 
 type ociImageDestination struct {
-	ref                      ociReference
-	index                    imgspecv1.Index
-	sharedBlobDir            string
-	acceptUncompressedLayers bool
+	ref           ociReference
+	index         imgspecv1.Index
+	sharedBlobDir string
 }
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
@@ -44,7 +43,6 @@ func newImageDestination(sys *types.SystemContext, ref ociReference) (types.Imag
 	d := &ociImageDestination{ref: ref, index: *index}
 	if sys != nil {
 		d.sharedBlobDir = sys.OCISharedBlobDirPath
-		d.acceptUncompressedLayers = sys.OCIAcceptUncompressedLayers
 	}
 
 	if err := ensureDirectoryExists(d.ref.dir); err != nil {
@@ -83,9 +81,6 @@ func (d *ociImageDestination) SupportsSignatures(ctx context.Context) error {
 }
 
 func (d *ociImageDestination) DesiredLayerCompression() types.LayerCompression {
-	if d.acceptUncompressedLayers {
-		return types.PreserveOriginal
-	}
 	return types.Compress
 }
 

--- a/vendor/github.com/containers/image/pkg/compression/compression.go
+++ b/vendor/github.com/containers/image/pkg/compression/compression.go
@@ -5,34 +5,28 @@ import (
 	"compress/bzip2"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 
 	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
-	"github.com/ulikunitz/xz"
 )
 
 // DecompressorFunc returns the decompressed stream, given a compressed stream.
-// The caller must call Close() on the decompressed stream (even if the compressed input stream does not need closing!).
-type DecompressorFunc func(io.Reader) (io.ReadCloser, error)
+type DecompressorFunc func(io.Reader) (io.Reader, error)
 
 // GzipDecompressor is a DecompressorFunc for the gzip compression algorithm.
-func GzipDecompressor(r io.Reader) (io.ReadCloser, error) {
+func GzipDecompressor(r io.Reader) (io.Reader, error) {
 	return gzip.NewReader(r)
 }
 
 // Bzip2Decompressor is a DecompressorFunc for the bzip2 compression algorithm.
-func Bzip2Decompressor(r io.Reader) (io.ReadCloser, error) {
-	return ioutil.NopCloser(bzip2.NewReader(r)), nil
+func Bzip2Decompressor(r io.Reader) (io.Reader, error) {
+	return bzip2.NewReader(r), nil
 }
 
 // XzDecompressor is a DecompressorFunc for the xz compression algorithm.
-func XzDecompressor(r io.Reader) (io.ReadCloser, error) {
-	r, err := xz.NewReader(r)
-	if err != nil {
-		return nil, err
-	}
-	return ioutil.NopCloser(r), nil
+func XzDecompressor(r io.Reader) (io.Reader, error) {
+	return nil, errors.New("Decompressing xz streams is not supported")
 }
 
 // compressionAlgos is an internal implementation detail of DetectCompression
@@ -70,25 +64,4 @@ func DetectCompression(input io.Reader) (DecompressorFunc, io.Reader, error) {
 	}
 
 	return decompressor, io.MultiReader(bytes.NewReader(buffer[:n]), input), nil
-}
-
-// AutoDecompress takes a stream and returns an uncompressed version of the
-// same stream.
-// The caller must call Close() on the returned stream (even if the input does not need,
-// or does not even support, closing!).
-func AutoDecompress(stream io.Reader) (io.ReadCloser, bool, error) {
-	decompressor, stream, err := DetectCompression(stream)
-	if err != nil {
-		return nil, false, errors.Wrapf(err, "Error detecting compression")
-	}
-	var res io.ReadCloser
-	if decompressor != nil {
-		res, err = decompressor(stream)
-		if err != nil {
-			return nil, false, errors.Wrapf(err, "Error initializing decompression")
-		}
-	} else {
-		res = ioutil.NopCloser(stream)
-	}
-	return res, decompressor != nil, nil
 }

--- a/vendor/github.com/containers/image/pkg/sysregistriesv2/system_registries_v2.go
+++ b/vendor/github.com/containers/image/pkg/sysregistriesv2/system_registries_v2.go
@@ -1,0 +1,369 @@
+package sysregistriesv2
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/BurntSushi/toml"
+	"github.com/containers/image/types"
+)
+
+// systemRegistriesConfPath is the path to the system-wide registry
+// configuration file and is used to add/subtract potential registries for
+// obtaining images.  You can override this at build time with
+// -ldflags '-X github.com/containers/image/sysregistries.systemRegistriesConfPath=$your_path'
+var systemRegistriesConfPath = builtinRegistriesConfPath
+
+// builtinRegistriesConfPath is the path to the registry configuration file.
+// DO NOT change this, instead see systemRegistriesConfPath above.
+const builtinRegistriesConfPath = "/etc/containers/registries.conf"
+
+// Mirror represents a mirror. Mirrors can be used as pull-through caches for
+// registries.
+type Mirror struct {
+	// The mirror's URL.
+	URL string `toml:"url"`
+	// If true, certs verification will be skipped and HTTP (non-TLS)
+	// connections will be allowed.
+	Insecure bool `toml:"insecure"`
+}
+
+// Registry represents a registry.
+type Registry struct {
+	// Serializable registry URL.
+	URL string `toml:"url"`
+	// The registry's mirrors.
+	Mirrors []Mirror `toml:"mirror"`
+	// If true, pulling from the registry will be blocked.
+	Blocked bool `toml:"blocked"`
+	// If true, certs verification will be skipped and HTTP (non-TLS)
+	// connections will be allowed.
+	Insecure bool `toml:"insecure"`
+	// If true, the registry can be used when pulling an unqualified image.
+	Search bool `toml:"unqualified-search"`
+	// Prefix is used for matching images, and to translate one namespace to
+	// another.  If `Prefix="example.com/bar"`, `URL="example.com/foo/bar"`
+	// and we pull from "example.com/bar/myimage:latest", the image will
+	// effectively be pulled from "example.com/foo/bar/myimage:latest".
+	// If no Prefix is specified, it defaults to the specified URL.
+	Prefix string `toml:"prefix"`
+}
+
+// backwards compatability to sysregistries v1
+type v1TOMLregistries struct {
+	Registries []string `toml:"registries"`
+}
+
+// tomlConfig is the data type used to unmarshal the toml config.
+type tomlConfig struct {
+	Registries []Registry `toml:"registry"`
+	// backwards compatability to sysregistries v1
+	V1Registries struct {
+		Search   v1TOMLregistries `toml:"search"`
+		Insecure v1TOMLregistries `toml:"insecure"`
+		Block    v1TOMLregistries `toml:"block"`
+	} `toml:"registries"`
+}
+
+// InvalidRegistries represents an invalid registry configurations.  An example
+// is when "registry.com" is defined multiple times in the configuration but
+// with conflicting security settings.
+type InvalidRegistries struct {
+	s string
+}
+
+// Error returns the error string.
+func (e *InvalidRegistries) Error() string {
+	return e.s
+}
+
+// parseURL parses the input string, performs some sanity checks and returns
+// the sanitized input string.  An error is returned in case parsing fails or
+// or if URI scheme or user is set.
+func parseURL(input string) (string, error) {
+	trimmed := strings.TrimRight(input, "/")
+
+	if trimmed == "" {
+		return "", &InvalidRegistries{s: "invalid URL: cannot be empty"}
+	}
+
+	// Ultimately, we expect input of the form example.com[/namespace/…], a prefix
+	// of a fully-expended reference (containers/image/docker/Reference.String()).
+	// c/image/docker/Reference does not currently provide such a parser.
+	// So, we use url.Parse("http://"+trimmed) below to ~verify the format, possibly
+	// letting some invalid input in, trading that off for a simpler parser.
+	//
+	// url.Parse("http://"+trimmed) is, sadly, too permissive, notably for
+	// trimmed == "http://example.com/…", url.Parse("http://http://example.com/…")
+	// is accepted and parsed as
+	// {Scheme: "http", Host: "http:", Path: "//example.com/…"}.
+	//
+	// So, first we do an explicit check for an unwanted scheme prefix:
+
+	// This will parse trimmed=="http://example.com/…" with Scheme: "http".  Perhaps surprisingly,
+	// it also succeeds for the input we want to accept, in different ways:
+	// "example.com" -> {Scheme:"", Opaque:"", Path:"example.com"}
+	// "example.com/repo" -> {Scheme:"", Opaque:"", Path:"example.com/repo"}
+	// "example.com:5000" -> {Scheme:"example.com", Opaque:"5000"}
+	// "example.com:5000/repo" -> {Scheme:"example.com", Opaque:"5000/repo"}
+	uri, err := url.Parse(trimmed)
+	if err != nil {
+		return "", &InvalidRegistries{s: fmt.Sprintf("invalid URL '%s': %v", input, err)}
+	}
+
+	// Check if a URI Scheme is set.
+	// Note that URLs that do not start with a slash after the scheme are
+	// interpreted as `scheme:opaque[?query][#fragment]`; see above for examples.
+	if uri.Scheme != "" && uri.Opaque == "" {
+		msg := fmt.Sprintf("invalid URL '%s': URI schemes are not supported", input)
+		return "", &InvalidRegistries{s: msg}
+	}
+
+	uri, err = url.Parse("http://" + trimmed)
+	if err != nil {
+		msg := fmt.Sprintf("invalid URL '%s': sanitized URL did not parse: %v", input, err)
+		return "", &InvalidRegistries{s: msg}
+	}
+
+	if uri.User != nil {
+		msg := fmt.Sprintf("invalid URL '%s': user/password are not supported", trimmed)
+		return "", &InvalidRegistries{s: msg}
+	}
+
+	return trimmed, nil
+}
+
+// getV1Registries transforms v1 registries in the config into an array of v2
+// registries of type Registry.
+func getV1Registries(config *tomlConfig) ([]Registry, error) {
+	regMap := make(map[string]*Registry)
+
+	getRegistry := func(url string) (*Registry, error) { // Note: _pointer_ to a long-lived object
+		var err error
+		url, err = parseURL(url)
+		if err != nil {
+			return nil, err
+		}
+		reg, exists := regMap[url]
+		if !exists {
+			reg = &Registry{
+				URL:     url,
+				Mirrors: []Mirror{},
+				Prefix:  url,
+			}
+			regMap[url] = reg
+		}
+		return reg, nil
+	}
+
+	for _, search := range config.V1Registries.Search.Registries {
+		reg, err := getRegistry(search)
+		if err != nil {
+			return nil, err
+		}
+		reg.Search = true
+	}
+	for _, blocked := range config.V1Registries.Block.Registries {
+		reg, err := getRegistry(blocked)
+		if err != nil {
+			return nil, err
+		}
+		reg.Blocked = true
+	}
+	for _, insecure := range config.V1Registries.Insecure.Registries {
+		reg, err := getRegistry(insecure)
+		if err != nil {
+			return nil, err
+		}
+		reg.Insecure = true
+	}
+
+	registries := []Registry{}
+	for _, reg := range regMap {
+		registries = append(registries, *reg)
+	}
+	return registries, nil
+}
+
+// postProcessRegistries checks the consistency of all registries (e.g., set
+// the Prefix to URL if not set) and applies conflict checks.  It returns an
+// array of cleaned registries and error in case of conflicts.
+func postProcessRegistries(regs []Registry) ([]Registry, error) {
+	var registries []Registry
+	regMap := make(map[string][]Registry)
+
+	for _, reg := range regs {
+		var err error
+
+		// make sure URL and Prefix are valid
+		reg.URL, err = parseURL(reg.URL)
+		if err != nil {
+			return nil, err
+		}
+
+		if reg.Prefix == "" {
+			reg.Prefix = reg.URL
+		} else {
+			reg.Prefix, err = parseURL(reg.Prefix)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// make sure mirrors are valid
+		for _, mir := range reg.Mirrors {
+			mir.URL, err = parseURL(mir.URL)
+			if err != nil {
+				return nil, err
+			}
+		}
+		registries = append(registries, reg)
+		regMap[reg.URL] = append(regMap[reg.URL], reg)
+	}
+
+	// Given a registry can be mentioned multiple times (e.g., to have
+	// multiple prefixes backed by different mirrors), we need to make sure
+	// there are no conflicts among them.
+	//
+	// Note: we need to iterate over the registries array to ensure a
+	// deterministic behavior which is not guaranteed by maps.
+	for _, reg := range registries {
+		others, _ := regMap[reg.URL]
+		for _, other := range others {
+			if reg.Insecure != other.Insecure {
+				msg := fmt.Sprintf("registry '%s' is defined multiple times with conflicting 'insecure' setting", reg.URL)
+
+				return nil, &InvalidRegistries{s: msg}
+			}
+			if reg.Blocked != other.Blocked {
+				msg := fmt.Sprintf("registry '%s' is defined multiple times with conflicting 'blocked' setting", reg.URL)
+				return nil, &InvalidRegistries{s: msg}
+			}
+		}
+	}
+
+	return registries, nil
+}
+
+// getConfigPath returns the system-registries config path if specified.
+// Otherwise, systemRegistriesConfPath is returned.
+func getConfigPath(ctx *types.SystemContext) string {
+	confPath := systemRegistriesConfPath
+	if ctx != nil {
+		if ctx.SystemRegistriesConfPath != "" {
+			confPath = ctx.SystemRegistriesConfPath
+		} else if ctx.RootForImplicitAbsolutePaths != "" {
+			confPath = filepath.Join(ctx.RootForImplicitAbsolutePaths, systemRegistriesConfPath)
+		}
+	}
+	return confPath
+}
+
+// configMutex is used to synchronize concurrent accesses to configCache.
+var configMutex = sync.Mutex{}
+
+// configCache caches already loaded configs with config paths as keys and is
+// used to avoid redudantly parsing configs. Concurrent accesses to the cache
+// are synchronized via configMutex.
+var configCache = make(map[string][]Registry)
+
+// GetRegistries loads and returns the registries specified in the config.
+func GetRegistries(ctx *types.SystemContext) ([]Registry, error) {
+	configPath := getConfigPath(ctx)
+
+	configMutex.Lock()
+	defer configMutex.Unlock()
+	// if the config has already been loaded, return the cached registries
+	if registries, inCache := configCache[configPath]; inCache {
+		return registries, nil
+	}
+
+	// load the config
+	config, err := loadRegistryConf(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	registries := config.Registries
+
+	// backwards compatibility for v1 configs
+	v1Registries, err := getV1Registries(config)
+	if err != nil {
+		return nil, err
+	}
+	if len(v1Registries) > 0 {
+		if len(registries) > 0 {
+			return nil, &InvalidRegistries{s: "mixing sysregistry v1/v2 is not supported"}
+		}
+		registries = v1Registries
+	}
+
+	registries, err = postProcessRegistries(registries)
+	if err != nil {
+		return nil, err
+	}
+
+	// populate the cache
+	configCache[configPath] = registries
+
+	return registries, err
+}
+
+// FindUnqualifiedSearchRegistries returns all registries that are configured
+// for unqualified image search (i.e., with Registry.Search == true).
+func FindUnqualifiedSearchRegistries(registries []Registry) []Registry {
+	unqualified := []Registry{}
+	for _, reg := range registries {
+		if reg.Search {
+			unqualified = append(unqualified, reg)
+		}
+	}
+	return unqualified
+}
+
+// FindRegistry returns the Registry with the longest prefix for ref.  If no
+// Registry prefixes the image, nil is returned.
+func FindRegistry(ref string, registries []Registry) *Registry {
+	reg := Registry{}
+	prefixLen := 0
+	for _, r := range registries {
+		if strings.HasPrefix(ref, r.Prefix) {
+			length := len(r.Prefix)
+			if length > prefixLen {
+				reg = r
+				prefixLen = length
+			}
+		}
+	}
+	if prefixLen != 0 {
+		return &reg
+	}
+	return nil
+}
+
+// Reads the global registry file from the filesystem. Returns a byte array.
+func readRegistryConf(configPath string) ([]byte, error) {
+	configBytes, err := ioutil.ReadFile(configPath)
+	return configBytes, err
+}
+
+// Used in unittests to parse custom configs without a types.SystemContext.
+var readConf = readRegistryConf
+
+// Loads the registry configuration file from the filesystem and then unmarshals
+// it.  Returns the unmarshalled object.
+func loadRegistryConf(configPath string) (*tomlConfig, error) {
+	config := &tomlConfig{}
+
+	configBytes, err := readConf(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = toml.Unmarshal(configBytes, &config)
+	return config, err
+}

--- a/vendor/github.com/containers/image/transports/alltransports/alltransports.go
+++ b/vendor/github.com/containers/image/transports/alltransports/alltransports.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/containers/image/directory"
 	_ "github.com/containers/image/docker"
 	_ "github.com/containers/image/docker/archive"
+	_ "github.com/containers/image/docker/daemon"
 	_ "github.com/containers/image/oci/archive"
 	_ "github.com/containers/image/oci/layout"
 	_ "github.com/containers/image/openshift"

--- a/vendor/github.com/containers/image/transports/alltransports/docker_daemon.go
+++ b/vendor/github.com/containers/image/transports/alltransports/docker_daemon.go
@@ -1,8 +1,0 @@
-// +build !containers_image_docker_daemon_stub
-
-package alltransports
-
-import (
-	// Register the docker-daemon transport
-	_ "github.com/containers/image/docker/daemon"
-)

--- a/vendor/github.com/containers/image/transports/alltransports/docker_daemon_stub.go
+++ b/vendor/github.com/containers/image/transports/alltransports/docker_daemon_stub.go
@@ -1,9 +1,0 @@
-// +build containers_image_docker_daemon_stub
-
-package alltransports
-
-import "github.com/containers/image/transports"
-
-func init() {
-	transports.Register(transports.NewStubTransport("docker-daemon"))
-}

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -364,8 +364,6 @@ type SystemContext struct {
 	OCIInsecureSkipTLSVerify bool
 	// If not "", use a shared directory for storing blobs rather than within OCI layouts
 	OCISharedBlobDirPath string
-	// Allow UnCompress image layer for OCI image layer
-	OCIAcceptUncompressedLayers bool
 
 	// === docker.Transport overrides ===
 	// If not "", a directory containing a CA certificate (ending with ".crt"),

--- a/vendor/github.com/containers/image/vendor.conf
+++ b/vendor/github.com/containers/image/vendor.conf
@@ -42,4 +42,3 @@ github.com/pquerna/ffjson master
 github.com/syndtr/gocapability master
 github.com/Microsoft/go-winio ab35fc04b6365e8fcb18e6e9e41ea4a02b10b175
 github.com/Microsoft/hcsshim eca7177590cdcbd25bbc5df27e3b693a54b53a6a
-github.com/ulikunitz/xz v0.5.4


### PR DESCRIPTION
Switch from using `github.com/containers/image/pkg/sysregistries` to using `github.com/containers/image/pkg/sysregistriesv2` to complete unqualified image names.  Keep v1 around because it'll tell us which configuration file to name in an error message if things don't work right.
