### PR TITLE
bud should not search context directory for Dockerfile

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -183,9 +183,8 @@ either a local file or an **http** or **https** URL.  If more than one
 Dockerfile is specified, *FROM* instructions will only be accepted from the
 first specified file.
 
-If a build context is not specified, and at least one Dockerfile is a
-local file, the directory in which it resides will be used as the build
-context.
+If a local file is specified as the Dockerfile and it does not exist, the
+context directory will be prepended to the local file value.
 
 If you specify `-f -`, the Dockerfile contents will be read from stdin.
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -1203,8 +1203,9 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options BuildOpt
 			}
 			data = resp.Body
 		} else {
-			if !filepath.IsAbs(dfile) {
-				logrus.Debugf("resolving local Dockerfile %q", dfile)
+			// If the Dockerfile isn't found try prepending the
+			// context directory to it.
+			if _, err := os.Stat(dfile); os.IsNotExist(err) {
 				dfile = filepath.Join(options.ContextDirectory, dfile)
 			}
 			logrus.Debugf("reading local Dockerfile %q", dfile)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

When `buildah bud` received a Dockerfile value with a relative path, it would prepend the context directory onto it.  In many cases this caused a failure and confusion.  Now the code first checks to see if the Dockerfile specified with the '--file' parameter exists.  If it does exist, bud continues with the processing.  If it does not exist, then it prepends the context directory and uses that.

Testing:
===========
```
# pwd
/root/container2

# buildah  bud -f ../container1/Dockerfile container2
STEP 1: FROM alpine
STEP 2: COMMIT containers-storage:[overlay@/var/lib/containers/storage+/var/run/containers/storage:overlay.override_kernel_check=true]@e259501bebc58b1859d702c6cc9e24fbe1543326c87240fe2b27747131335dfa
Getting image source signatures
Skipping fetch of repeat blob sha256:73046094a9b835e443af1a9d736fcfc11a994107500e474d0abf399499ed280c
Skipping fetch of repeat blob sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
Copying config sha256:55edbe131d4cf07c6fed2ccb9f5a92e5237c1336fe3c6281281653e1c7ce6438
 721 B / 721 B [============================================================] 0s
Writing manifest to image destination
Storing signatures
--> e259501bebc58b1859d702c6cc9e24fbe1543326c87240fe2b27747131335dfa

```