### PR TITLE
unshare: make adjusting the OOM score optional

### DIFF
--- a/chroot/run.go
+++ b/chroot/run.go
@@ -551,9 +551,7 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 		cmd.Setsid = true
 		cmd.Ctty = ctty
 	}
-	if spec.Process.OOMScoreAdj != nil {
-		cmd.OOMScoreAdj = *spec.Process.OOMScoreAdj
-	}
+	cmd.OOMScoreAdj = spec.Process.OOMScoreAdj
 	cmd.ExtraFiles = append([]*os.File{preader}, cmd.ExtraFiles...)
 	cmd.Hook = func(int) error {
 		for _, f := range closeOnceRunning {

--- a/unshare/unshare_test.go
+++ b/unshare/unshare_test.go
@@ -198,7 +198,7 @@ func TestUnshareOOMScoreAdj(t *testing.T) {
 		var report Report
 		buf := new(bytes.Buffer)
 		cmd := Command("report")
-		cmd.OOMScoreAdj = adj
+		cmd.OOMScoreAdj = &adj
 		cmd.Stdout = buf
 		cmd.Stderr = buf
 		err := cmd.Run()


### PR DESCRIPTION
The OOM score adjustment is an optional field in the runtime spec, so
only try to set it if it's set in the spec.

Signed-off-by: Nalin Dahyabhai <nalin@redhat.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>