### PR TITLE
Add Release Announcements directory

### DIFF
--- a/docs/release-announcements/README.md
+++ b/docs/release-announcements/README.md
@@ -1,0 +1,27 @@
+![buildah logo](../../logos/buildah-logo_large.png)
+
+# Buildah Release Announcements
+
+
+**[Buildah v1.3 RA](v1.3.md) - August 7, 2018**
+
+Features: Dockerfile handling improvements, added the `buildah pull` command, added the `buildah rename` command, updated ulimits settings, added isolation control and other enhancements and bug fixes.
+
+**[Buildah v1.2 RA](v1.2.md) - July 14, 2018**
+
+Features: Added ability to control image layers when building an image, CVE’s Fixes, the initial support for user namespace handling and other enhancements and bug fixes.
+
+**[Buildah v1.1 RA](v1.1.md) - June 12, 2018**
+
+Features: OnBuild support for Dockerfiles, label support for the `buildah bud` command and other enhancements and bug fixes.
+
+
+**[Buildah Alpha v0.16 RA](v0.16.md) - April 2, 2018**
+
+Features: SHELL command support in Dockerfiles, added support for three transports for `buildah from`, added the ability to pull compressed docker-archive files and other enhancements and bug fixes.
+
+**[Buildah Alpha v0.12 RA](v0.12.md) - February 21, 2018**
+
+Features: Set the default certificate directory to /etc/containers/certs.d, improved lookups for a variety of image name formats, added pruning capabilty to the rmi command, provided authentication to `buildah bud` and other enhancements and bug fixes.
+
+## Buildah == Simplicity

--- a/docs/release-announcements/v0.12.md
+++ b/docs/release-announcements/v0.12.md
@@ -1,0 +1,32 @@
+# Buildah Alpha version 0.12 Release Announcement
+
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
+
+We're pleased to announce the release of Buildah Alpha version 0.12 on both Fedora 26 and Fedora 27. As always, the latest Buildah can also be acquired from [GitHub](https://github.com/projectatomic/buildah) for any other Linux distribution.
+
+The Buildah project has been building some steam over the past several weeks, welcoming several new contributors to the mix, launching new functionality and creating a number of improvements and bug fixes. The major highlights for this release are:
+
+* Added better handling of error messages for Unknown Dockerfile instructions.
+* Set the default certificate directory to /etc/containers/certs.d.
+* Vendored in the latest containers/image and containers/Storage packages.
+* The build-using-dockerfile (bud) command now sets the images 'author' field to the value provided by MAINTAINER in the Dockerfile.
+* Return exit code 1 when 'buildah rmi' fails.
+* Improve lookups of a variety of image name formats.
+* Adds the --format and --filter parameters to the 'buildah containers' command.
+* Adds the --prune,-p option to the 'buidah rmi' command allowing dangling images to be pruned.
+* Adds the --authfile parameter to the 'buildah commit' command.
+* Fix the --runtime-flag for the 'buildah run' and 'buildah bud' commands when global flags are used.
+* The format parameter now overrides the quiet parameter for 'buildah images'.
+* Provide authentication parameters to the build-using-docker-file (bud) command.
+* Directory permissions are no longer overwritten when using the --chown parameter.
+* HTML character output to the terminal is no longer escaped.
+* The container name is now always set to the image's name.
+* The username or password are prompted for if they are not supplied with the --creds parameter.
+* Return a better error message when bad credentials are used to pull a private image.
+* Plus several small bug fixes.
+
+If you haven’t yet,  install Buildah from the Fedora repository and give it a spin.  We’re betting you'll find it’s an easy and quick way to build containers in your environment without a daemon being involved!
+
+If you haven't joined our community yet, don't wait any longer!  Come join us in [GitHub](https://github.com/projectatomic/buildah), where Open Source communities live.
+
+**Buildah == Simplicity**

--- a/docs/release-announcements/v0.16.md
+++ b/docs/release-announcements/v0.16.md
@@ -1,0 +1,45 @@
+# Buildah Alpha version 0.16 Release Announcement
+
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
+
+We're pleased to announce the release of Buildah Alpha version 0.16 which is now available from GitHub for any Linux distro.  We will be shipping this release on Fedora, CentOS and Ubuntu in the near future.
+
+The Buildah project has continued to grow over the past several weeks, welcoming several new contributors to the mix, launching new functionality and creating a number of improvements and bug fixes.  
+
+## The major highlights for this release are:
+
+ * Add support for the SHELL command in Dockerfiles.
+ * Change the time displayed by the image command to the locale time.
+ * Allow the --cmd parameter for the `buildah config` command to have commands as values.  I.e. `buildah config --cmd “--help” {containerID}`.
+ * Documentations added for the mounts.conf file. The mounts config allows you to mount content from the host into the container to be used during the build procedure, but does not get committed to the image.
+ * Fixed  a number of man pages to format correctly.
+ * The `buildah from` command now supports pulling images using the following three transports: docker-archive, oci-archive, and dir, as well as normal container registries and the docker daemon.
+ * If the user overrides the storage driver, the options will not be used from the default storage.conf file.
+ * Show the Config and Manifest as a JSON string in `buildah inspect` even when the  --format parameter is not set.
+ * Adds feature to pull compressed docker-archive files.
+ * Vendor in latest containers/image
+   * docker-archive generates docker legacy compatible images.
+   * Ensure the layer IDs in legacy docker/tarfile metadata are unique.
+   * docker-archive: repeated layers are symlinked in the tar file.
+   * sysregistries: remove all trailing slashes.
+   * Improve docker/* error messages.
+   * Fix failure to make auth directory.
+   * Create a new slice in Schema1.UpdateLayerInfos.
+   * Drop unused storageImageDestination.{image,systemContext}.
+   * Load a *storage.Image only once in storageImageSource.
+   * Support gzip for docker-archive files.
+   * Remove .tar extension from blob and config file names.
+   * ostree, src: support copy of compressed layers.
+   * ostree: re-pull layer if it misses uncompressed_digest|uncompressed_size.
+   * image: fix docker schema v1 -> OCI conversion.
+   * Add /etc/containers/certs.d as default certs directory.
+ * Plus several small bug fixes.
+
+## Try it Out.
+
+If you haven’t yet,  install Buildah from the Fedora repo or GitHub and give it a spin.  We’re betting you'll find it’s an easy and quick way to build containers in your environment without a daemon being involved!
+
+For those of you who contributed to this release, thank you very much for your contributions!  If you haven't joined our community yet, don't wait any longer!  Come join us in GitHub, where Open Source communities live.
+
+## Buildah == Simplicity
+

--- a/docs/release-announcements/v1.1.md
+++ b/docs/release-announcements/v1.1.md
@@ -1,0 +1,82 @@
+# Buildah version 1.1 Release Announcement
+
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
+
+We're pleased to announce the release of Buildah version 1.1 which is now available from GitHub for any Linux distro.  We are shipping this release on Fedora, RHEL 7, CentOS and Ubuntu in the near future.
+
+The Buildah project has continued to grow over the past several weeks, welcoming several new contributors to the mix, launching new functionality and creating a number of improvements and bug fixes.  
+
+## The major highlights for this release are:
+
+ * Drop capabilities if running container processes as non root
+ * Print Warning message if cmd will not be used based on entrypoint
+ * Add OnBuild support for Dockerfiles
+ * Add support for buildah bud --label
+ * Report errors on bad transports specification when pushing images
+ * Add registry errors for pull
+ * Give better messages to users when image can not be found
+ * Add environment variable to buildah --format
+ * Accept json array input for config entrypoint
+ * buildah bud now requires a context directory or URL
+ * buildah bud picks up ENV from base image
+ * Run: set supplemental group IDs
+ * Use CNI to configure container networks
+ * add/secrets/commit: Use mappings when setting permissions on added content
+ * Add CLI options for specifying namespace and cgroup setup
+ * Always set mappings when using user namespaces
+ * Read UID/GID mapping information from containers and images
+ * build-using-dockerfile: add --annotation
+ * Implement --squash for build-using-dockerfile and commit
+ * Manage "Run" containers more closely
+ * Handle /etc/hosts and /etc/resolv.conf properly in container
+ * Make "run --terminal" and "run -t" aliases for "run --tty"
+ * buildah push/from can push and pull images with no reference
+ * Attempt to download file from url, if fails assume Dockerfile
+ * builder-inspect: fix format option
+ * buildah-from: add effective value to mount propagation
+ * Documentation Changes
+ * Change freenode chan to buildah
+ * Add example CNI configurations
+ * Touch Up tutorial for run changes
+ * Update 01-intro.md tutorial
+ * Update troubleshooting with new run workaround
+ * Add console syntax highlighting to troubleshooting page
+ * Touchup man page short options across man pages
+ * Demo Changes
+   * Added demo dir and a demo.
+   * Added Docker compatibility demo 
+   * Added a bud demo and tidied up
+   * Update buildah scratch demo to support el7
+   * Quick fix on demo readme
+ * Test Changes
+   * Add tests for namespace control flags
+   * CI tests and minor fix for cache related noop flags
+   * Add cpu-shares short flag (-c) and cpu-shares CI tests
+   * Add buildah bud CI tests for ENV variables
+   * Additional bud CI tests
+   * Run integration tests under travis_wait in Travis
+   * Re-enable rpm .spec version check and new commit test
+   * Update to F28 and new run format in baseline test
+   * Add context dir to bud command in baseline test
+   * add test to inspect
+   * Test with Go 1.10, too
+   * rmi, rm: add test
+   * add mount test
+   * Fix SELinux test errors when SELinux is enabled
+ * Vendor changes
+   * Vendor in latest container/storage for devicemapper support
+   * Vendor github.com/onsi/ginkgo and github.com/onsi/gomega
+   * Vendor github.com/containernetworking/cni v0.6.0
+   * Update github.com/containers/storage
+   * Update github.com/projectatomic/libpod
+   * Vendor in latest containers/image
+ * Plus a number of smaller fixes.
+ 
+## Try it Out.
+
+If you haven’t yet, install Buildah from the Fedora repo or GitHub and give it a spin.  We’re betting you'll find it’s an easy and quick way to build containers in your environment without a daemon being involved!
+
+For those of you who contributed to this release, thank you very much for your contributions!  If you haven't joined our community yet, don't wait any longer!  Come join us in GitHub, where Open Source communities live.
+
+## Buildah == Simplicity
+

--- a/docs/release-announcements/v1.2.md
+++ b/docs/release-announcements/v1.2.md
@@ -1,0 +1,81 @@
+# Buildah version 1.2 Release Announcement
+
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
+
+We're pleased to announce the release of Buildah version 1.2 which is now available from GitHub for any Linux distro.  We are shipping this release on Fedora, RHEL 7, CentOS and Ubuntu in the near future.  
+
+The Buildah project has continued to grow over the past several weeks, welcoming several new contributors to the mix.  The highlights of this release are the added ability to control image layers when building an image, CVE’s Fixes, the initial support for user namespace handling and several other enhancements and bug fixes.
+
+## The major highlights for this release are:
+
+### Allow the user to control the layers of the image when the image is built with the ‘buildah bud’ command. 
+
+A container is comprised of a final readable/writeable layer and when the layers are cached, a number of intermediate read only layers.  The read only layers are created with each step in the Dockerfile and the final readable/writeable layer contains the intermediate layers.  Prior to these changes Buildah did not cache these intermediate read only layers.
+
+This release has a new environment variable ‘BUILDAH_LAYERS’ and a new ‘buildah bud’ --layers parameter.  When either is set to true, the image layers are cached during the ‘buildah bud’ processing and not discarded.  The disadvantage to retaining layers is the space that they use.  The advantage to retaining them is if you make a change to your Dockerfile, only the layers for that change and the ones following it will need to be regenerated.  
+
+The --nocache parameter has also been added to the ‘buildah bud’ command.  When this parameter is set to true the ‘buildah bud’ command ignores any existing layers and creates all of the image layers anew.
+
+### Added initial user namespace support.
+
+To isolate the container’s processes from running as root on the host machine, user namespaces are used by container technologies.  This allows the administrator to configure the containers processes that must run as root to remap the user to a less privileged user on the container’s host machine.  This remapping is handled in part by settings in the /etc/subuid and /etc/subgid files on the host machine.
+
+The changes for this release does not yet provide full support for user namespaces, but does set up the options to control the mapping with the --userns-uid-map and --userns-gid-map options.   Changes have also been made to prevent the container from modifying the /etc/host or /etc/resolv.conf files on the host.
+
+Also with this release if a user with a uid that’s not equal to zero creates a container, a namespace is now created based on the users uid and gid and the container will be reexec’d using that namespace.   In addition, the storage driver, storage root directory and storage state directory will all be created under alternate locations.  Please reference the buildah (1) man page for more details.  Further information will be published in upcoming blogs and additional changes are in progress to provide full support of user namespaces in future versions of Buildah.
+
+### CVE security issues with /proc/acpi and /proc/keys have been addressed.
+
+The /proc/acpi and /proc/keys were added to the list of blocked kernel files.  This prevents the container from manipulating these files on the container’s host.
+
+## Release Changes
+ * Added the ability to remove or retain image layers for ‘buildah bud’:
+   * Add --layers and --no-cache options to 'buildah bud'.
+   * Add --rm and --force-rm options to 'buildah bud'.
+   * Fixed the buildah bud --layers option.
+   * Added environment variable BUILDAH_LAYERS to control image layers creation.
+ * Added environment variable BUILDAH_RUNTIME to setup alternate runtimes.
+ * build-using-dockerfile: let -t include transports again.
+ * Block the use of /proc/acpi and /proc/keys from inside containers. These address potential CVE Security issues.
+ * Add --cidfile option to 'buildah from`.
+ * Add a --loglevel option to build-with-dockerfile.
+ * Begin supporting specification of user namespace for container separation:
+   * Allow --userns-uid-map/--userns-gid-map to be global options.
+   * If unprivileged, reexec in a user namespace.
+   * Force ownership of /etc/hosts and /etc/resolv.conf to 0:0.
+ * Recognize committing to second storage locations with 'buildah commit'.
+ * Add the --all option to 'buildah unmount' to unmount all mounted containers.
+ * When doing multiple mounts, output all pertinent errors, not just the last error.
+ * Implement basic recognition of the "--isolation" option for 'buildah from' and 'buildah run'.
+ * Fix ARGS parsing for run commands.
+ * When building a container the HTTP User-Agent is set to the Buildah version.
+ * Makefile: add the uninstall command.
+ * Support multiple inputs to 'buildah mount'.
+ * Use the right formatting when adding entries to /etc/hosts.
+ * A number of minor performance improvements for 'buildah run' and 'buildah bud'.
+ * Change RunOptions.Stdin/Stdout/Stderr to just be Reader/Writers.
+ * Use conversion code from containers/image instead of converting configs manually.
+ * Do not ignore any parsing errors during initialization.
+ * Explicitly handle "from scratch" images in Builder.initConfig.
+ * Fix parsing of OCI images.
+ * Don't ignore v2s1 history if docker_version is not set.
+ * Add --all,-a flags to 'buildah images'.
+ * Remove tty check from buildah images --format.
+ * Fix usage information for 'buildah images'.
+ * Documentation changes:
+   * Add registries.conf link to a few man pages.
+   * Add information about the configuration files to the install documentation.
+   * Follow man-pages(7) suggestions for SYNOPSIS in all man pages.
+   * Minor update to buildah config documentation for entrypoint.
+   * ONBUILD tutorial created.
+   * Touch up images man page.
+ * Plus a number of smaller fixes.
+
+## Try it Out.
+
+If you haven’t yet, install Buildah from the Fedora repo or GitHub and give it a spin.  We’re betting you'll find it’s an easy and quick way to build containers in your environment without a daemon being involved!
+
+For those of you who contributed to this release, thank you very much for your contributions!  If you haven't joined our community yet, don't wait any longer!  Come join us in GitHub, where Open Source communities live.
+
+## Buildah == Simplicity
+

--- a/docs/release-announcements/v1.3.md
+++ b/docs/release-announcements/v1.3.md
@@ -1,0 +1,60 @@
+# Buildah version 1.3 Release Announcement
+
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
+
+We're pleased to announce the release of Buildah version 1.3 which is now available from GitHub for any Linux distro.  We are shipping this release on Fedora, RHEL 7, CentOS and Ubuntu in the near future.  
+
+The Buildah project has continued to grow over the past several weeks, welcoming several new contributors to the mix.  The highlights of this release are Dockerfile handling improvements, added the `buildah pull` command, added the `buildah rename` command, updated ulimits settings, added isolation control and several other enhancements and bug fixes.
+
+## The major highlights for this release are:
+
+* Dockerfiles with a ‘.in’ suffix are preprocessed during the build process.
+
+CPP is now used by the ‘buildah bud’ command to preprocess any Dockerfile that has the ‘.in’ suffix.  This allows Dockerfiles to be decomposed and make them reusable via  CPP’s #include directive. Notice that those Dockerfiles can still be used by other tools by manually running cpp -E on them.  Stay tuned for an upcoming blog with an example.  (Many thanks to Valentin Rothberg for providing this functionality.)
+
+* Dockerfile input can come from stdin.
+
+If you use a dash ‘-’ as the argument to the `buildah bud --file` parameter, Dockerfile contents will be read from stdin.
+
+* Created a pull and rename command.
+
+The new `buildah pull` command pulls an image without creating a container like the `buildah from` command does.  The new `buildah rename` command renames a container.
+
+* Ulimits settings now match the settings we add to the Docker unit file.
+
+The maximum number of processes and the number of open files that Buildah will handle now match the same number that Docker handles.
+ 
+* Added the ability to select the type of isolation to be used.
+
+By setting the new BUILDAH_ISOLATION environment variable or by using the new --isolation parameter found in the bud, from and run commands, one can select the type of isolation to use for running processes as part of the RUN instruction.  Recognized types include oci, rootless and chroot.  For more details, please refer to the `buildah bud`, `buildah from` and `buildah run` man pages.  These new isolations are being added to run buildah inside locked down containers.
+
+## Release Changes
+* preprocess ".in" suffixed Dockerfiles.
+* Allow Dockerfile content to come from stdin.
+* Create buildah pull command.
+* Create buildah rename command.
+* Set the default ulimits to match Docker.
+* Set BUILDAH_ISOLATION=rootless when running unprivileged.
+* Add and implement IsolationOCIRootless.
+* Add a value for IsolationOCIRootless.
+* Fix rmi to remove intermediate images associated with an image.
+* Switch to github.com/containers/image/pkg/sysregistriesv2.
+* unshare: error message missed the pid.
+* bud should not search just the context directory for Dockerfile.
+* Add support for multiple Short options.
+* Fixed volume cache issue with buildah bud --layers.
+* Allow ping command without NET_RAW Capabilities.
+* usernamespace: assign additional IDs sequentially.
+* Remove default dev/pts which allows Buildah to be run as non-root.
+ * Documentation changes:
+   * Fix the the in buildah-config man page.
+* Updated the following packages to newer versions:  containers/image, containers/storage, runc, and urfave/cli.
+* Plus a number of smaller fixes.
+
+## Try it Out.
+
+If you haven’t yet, install Buildah from the Fedora repo or GitHub and give it a spin.  We’re betting you'll find it’s an easy and quick way to build containers in your environment without a daemon being involved!
+
+For those of you who contributed to this release, thank you very much for your contributions!  If you haven't joined our community yet, don't wait any longer!  Come join us in GitHub, where Open Source communities live.
+
+## Buildah == Simplicity


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Creates a release-announcements directory under the docs directory and populates it with the release announcements that I could dredge up.  It includes the latest v1.3 RA which @rhatdan approved in a google doc.

Would like  to push this through ASAP so we can send out notes via twitter and such. 