### PR TITLE
release v1.3: mention openSUSE

### DIFF
--- a/docs/release-announcements/v1.3.md
+++ b/docs/release-announcements/v1.3.md
@@ -2,7 +2,7 @@
 
 ![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
 
-We're pleased to announce the release of Buildah version 1.3 which is now available from GitHub for any Linux distro.  We are shipping this release on Fedora, RHEL 7, CentOS and Ubuntu in the near future.  
+We're pleased to announce the release of Buildah version 1.3 which is now available from GitHub for any Linux distro.  We are shipping this release on Fedora, RHEL 7, CentOS, openSUSE and Ubuntu in the near future.
 
 The Buildah project has continued to grow over the past several weeks, welcoming several new contributors to the mix.  The highlights of this release are Dockerfile handling improvements, added the `buildah pull` command, added the `buildah rename` command, updated ulimits settings, added isolation control and several other enhancements and bug fixes.
 
@@ -23,7 +23,7 @@ The new `buildah pull` command pulls an image without creating a container like 
 * Ulimits settings now match the settings we add to the Docker unit file.
 
 The maximum number of processes and the number of open files that Buildah will handle now match the same number that Docker handles.
- 
+
 * Added the ability to select the type of isolation to be used.
 
 By setting the new BUILDAH_ISOLATION environment variable or by using the new --isolation parameter found in the bud, from and run commands, one can select the type of isolation to use for running processes as part of the RUN instruction.  Recognized types include oci, rootless and chroot.  For more details, please refer to the `buildah bud`, `buildah from` and `buildah run` man pages.  These new isolations are being added to run buildah inside locked down containers.


### PR DESCRIPTION
Buildah v1.3 is already in openSUSE Tumbleweed, so let's put it on the
list of Buildah-shipping distributions.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>