### PR TITLE
Don't bother with --no-pivot for rootless isolation

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -219,11 +219,11 @@ another process.
 Controls what type of isolation is used for running processes as part of `RUN`
 instructions.  Recognized types include *oci* (OCI-compatible runtime, the
 default), *rootless* (OCI-compatible runtime invoked using a modified
-configuration and its --rootless flag enabled, with *--no-new-keyring
---no-pivot* added to its *create* invocation, with network and UTS namespaces
-disabled, and IPC, PID, and user namespaces enabled; the default for
-unprivileged users), and *chroot* (an internal wrapper that leans more toward
-chroot(1) than container technology).
+configuration and its --rootless flag enabled, with *--no-new-keyring* added to
+its *create* invocation, with network and UTS namespaces disabled, and IPC,
+PID, and user namespaces enabled; the default for unprivileged users), and
+*chroot* (an internal wrapper that leans more toward chroot(1) than container
+technology).
 
 Note: You can also override the default isolation type by setting the
 BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -183,7 +183,7 @@ another process.
 Controls what type of isolation is used for running processes under `buildah
 run`.  Recognized types include *oci* (OCI-compatible runtime, the default),
 *rootless* (OCI-compatible runtime invoked using a modified configuration and
-its --rootless flag enabled, with *--no-new-keyring --no-pivot* added to its
+its --rootless flag enabled, with *--no-new-keyring* added to its
 *create* invocation, with network and UTS namespaces disabled, and IPC, PID,
 and user namespaces enabled; the default for unprivileged users), and *chroot*
 (an internal wrapper that leans more toward chroot(1) than container

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -68,7 +68,7 @@ process.
 Controls what type of isolation is used for running the process.  Recognized
 types include *oci* (OCI-compatible runtime, the default), *rootless*
 (OCI-compatible runtime invoked using a modified configuration and its
---rootless flag enabled, with *--no-new-keyring --no-pivot* added to its
+--rootless flag enabled, with *--no-new-keyring* added to its
 *create* invocation, with network and UTS namespaces disabled, and IPC, PID,
 and user namespaces enabled; the default for unprivileged users), and *chroot*
 (an internal wrapper that leans more toward chroot(1) than container

--- a/run.go
+++ b/run.go
@@ -1094,7 +1094,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 			}
 		}
 		options.Args = append(options.Args, rootlessFlag...)
-		err = b.runUsingRuntimeSubproc(options, configureNetwork, configureNetworks, []string{"--no-new-keyring", "--no-pivot"}, spec, mountPoint, path, Package+"-"+filepath.Base(path))
+		err = b.runUsingRuntimeSubproc(options, configureNetwork, configureNetworks, []string{"--no-new-keyring"}, spec, mountPoint, path, Package+"-"+filepath.Base(path))
 	default:
 		err = errors.Errorf("don't know how to run this command")
 	}


### PR DESCRIPTION
When running outside of a container, --no-pivot isn't necessary, and when running inside of a container, it's not enough to solve any of the difficulties we're seeing there.  It may trigger an EPERM for unshare()
calls inside of the container that we launch, and we don't want that, so drop it, for now at least.