### PR TITLE
Remove an unused srcRef.NewImageSource in pullImage

### DIFF
--- a/pull.go
+++ b/pull.go
@@ -173,12 +173,6 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 		return nil, errors.Wrapf(err, "error parsing image name %q", destName)
 	}
 
-	img, err := srcRef.NewImageSource(ctx, sc)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error initializing %q as an image source", spec)
-	}
-	img.Close()
-
 	policy, err := signature.DefaultPolicy(sc)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error obtaining default signature policy")


### PR DESCRIPTION
- The result is not used anywhere
- In the common case of pulling from `docker://` this does not do anything notable (only sets up configuration, no network checks)
- ... but it can be pretty expensive for compressed archives, creating an uncompressed on-disk copy.
- `copy.Image` soon after the removed code calls `srcRef.NewImageSource` internally anyway.

This should not change behavior on success; it may change which error is reported if there is more than one reason for the pull to fail.