### PR TITLE
rmi: Some bug fixes

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -83,8 +83,7 @@ load helpers
   buildah --debug inspect test1 | grep foo=bar
   buildah --debug  inspect test1 | grep random=hello
   buildah rm ${cid}
-  buildah rmi test
-  buildah rmi test1
+  buildah rmi -a -f
 }
 
 @test "bud-from-scratch" {
@@ -636,7 +635,7 @@ load helpers
   from_cid=$(buildah from ${from_target})
   cid=$(buildah from ${target})
   buildah rm ${from_cid} ${cid}
-  buildah rmi ${from_target} ${target}
+  buildah rmi -a -f
 }
 
 @test "bud with Dockerfile from valid URL" {

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -115,7 +115,8 @@ load helpers
   buildah rm -a
   run buildah --debug=false rmi alpine
   echo "$output"
-  [ "${status}" -eq 0 ]
+  [ "${status}" -eq 1 ]
+  [ $(wc -l <<< "$output") -eq 2 ]
   run buildah --debug=false images -q
   echo "$output"
   [ $(wc -l <<< "$output") -eq 1 ]
@@ -160,7 +161,8 @@ load helpers
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false rmi alpine
   echo "$output"
-  [ "${status}" -eq 0 ]
+  [ "${status}" -eq 1 ]
+  [ $(wc -l <<< "$output") -eq 2 ]
   run buildah --debug=false rmi test3
   echo "$output"
   [ "${status}" -eq 0 ]


### PR DESCRIPTION
1.When deleting multiple images, if one of them fails, the error should be saved and then continue

2.Display error message correctly
```
➜  buildah git:(rmi-fix) ✗ sudo buildah images
IMAGE ID             IMAGE NAME                                               CREATED AT             SIZE
e1ddd7948a1c         docker.io/library/busybox:latest                         Aug 1, 2018 06:20      1.38 MB
e1ddd7948a1c         localhost/zz:latest                                      Aug 1, 2018 06:20      1.38 MB
b32225dc1e44         <none>                                                   Aug 10, 2018 15:32     1.38 MB
➜  buildah git:(rmi-fix) ✗ sudo buildah rmi -f e1dd
➜  buildah git:(rmi-fix) ✗ sudo buildah images
IMAGE ID             IMAGE NAME                                               CREATED AT             SIZE
e1ddd7948a1c         docker.io/library/busybox:latest                         Aug 1, 2018 06:20      1.38 MB
e1ddd7948a1c         localhost/zz:latest                                      Aug 1, 2018 06:20      1.38 MB
b32225dc1e44         <none>                                                   Aug 10, 2018 15:32     1.38 MB
➜  buildah git:(rmi-fix) ✗ sudo ./buildah rmi -f e1dd
unable to delete "e1ddd7948a1c31709a23cc5b7dfe96e55fc364f90e1cebcde0773a1b5a30dcda" (cannot be forced) - image has dependent child images
```

3. Display the correct ID after deleting image
```
➜  buildah git:(rmi-fix) ✗ sudo buildah images
IMAGE ID             IMAGE NAME                                               CREATED AT             SIZE
e1ddd7948a1c         docker.io/library/busybox:latest                         Aug 1, 2018 06:20      1.38 MB
72de3f6fa63b         <none>                                                   Aug 10, 2018 15:40     1.38 MB
39873e6c428a         <none>                                                   Aug 10, 2018 15:40     1.38 MB
➜  buildah git:(rmi-fix) ✗ sudo buildah rmi 72d

➜  buildah git:(rmi-fix) ✗ sudo ./buildah rmi 398
39873e6c428a1b12e8680a240e16b7286544bdfcb423f8de2a09f6dc874c3002
```


Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>