### PR TITLE
cmd: remove SkipArgReorder

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -35,13 +35,12 @@ var (
 	}
 
 	copyCommand = cli.Command{
-		Name:           "copy",
-		Usage:          "Copy content into the container",
-		Description:    copyDescription,
-		Flags:          addAndCopyFlags,
-		Action:         copyCmd,
-		ArgsUsage:      "CONTAINER-NAME-OR-ID [FILE | DIRECTORY | URL] [[...] DESTINATION]",
-		SkipArgReorder: true,
+		Name:        "copy",
+		Usage:       "Copy content into the container",
+		Description: copyDescription,
+		Flags:       addAndCopyFlags,
+		Action:      copyCmd,
+		ArgsUsage:   "CONTAINER-NAME-OR-ID [FILE | DIRECTORY | URL] [[...] DESTINATION]",
 	}
 )
 

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -24,7 +24,6 @@ var (
 		Flags:                  append(buildahcli.BudFlags, buildahcli.FromAndBudFlags...),
 		Action:                 budCmd,
 		ArgsUsage:              "CONTEXT-DIRECTORY | URL",
-		SkipArgReorder:         true,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -79,7 +79,6 @@ var (
 		Flags:                  commitFlags,
 		Action:                 commitCmd,
 		ArgsUsage:              "CONTAINER-NAME-OR-ID IMAGE",
-		SkipArgReorder:         true,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -103,7 +103,6 @@ var (
 		Flags:                  configFlags,
 		Action:                 configCmd,
 		ArgsUsage:              "CONTAINER-NAME-OR-ID",
-		SkipArgReorder:         true,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -85,7 +85,6 @@ var (
 		Flags:                  containersFlags,
 		Action:                 containersCmd,
 		ArgsUsage:              " ",
-		SkipArgReorder:         true,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -63,13 +63,12 @@ var (
 	fromDescription = "Creates a new working container, either from scratch or using a specified\n   image as a starting point"
 
 	fromCommand = cli.Command{
-		Name:           "from",
-		Usage:          "Create a working container based on an image",
-		Description:    fromDescription,
-		Flags:          append(fromFlags, buildahcli.FromAndBudFlags...),
-		Action:         fromCmd,
-		ArgsUsage:      "IMAGE",
-		SkipArgReorder: true,
+		Name:        "from",
+		Usage:       "Create a working container based on an image",
+		Description: fromDescription,
+		Flags:       append(fromFlags, buildahcli.FromAndBudFlags...),
+		Action:      fromCmd,
+		ArgsUsage:   "IMAGE",
 	}
 )
 

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -86,7 +86,6 @@ var (
 		Flags:                  imagesFlags,
 		Action:                 imagesCmd,
 		ArgsUsage:              "[imageName]",
-		SkipArgReorder:         true,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -39,7 +39,6 @@ var (
 		Flags:                  inspectFlags,
 		Action:                 inspectCmd,
 		ArgsUsage:              "CONTAINER-OR-IMAGE",
-		SkipArgReorder:         true,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -18,13 +18,12 @@ var (
 		},
 	}
 	mountCommand = cli.Command{
-		Name:                   "mount",
-		Usage:                  "Mount a working container's root filesystem",
-		Description:            mountDescription,
-		Action:                 mountCmd,
-		ArgsUsage:              "[CONTAINER-NAME-OR-ID [...]]",
-		Flags:                  mountFlags,
-		SkipArgReorder:         true,
+		Name:        "mount",
+		Usage:       "Mount a working container's root filesystem",
+		Description: mountDescription,
+		Action:      mountCmd,
+		ArgsUsage:   "[CONTAINER-NAME-OR-ID [...]]",
+		Flags:       mountFlags,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -47,13 +47,12 @@ An image can be pulled using its tag or digest. If a tag is not
 specified, the image with the 'latest' tag (if it exists) is pulled.`
 
 	pullCommand = cli.Command{
-		Name:           "pull",
-		Usage:          "Pull an image from the specified location",
-		Description:    pullDescription,
-		Flags:          append(pullFlags),
-		Action:         pullCmd,
-		ArgsUsage:      "IMAGE",
-		SkipArgReorder: true,
+		Name:        "pull",
+		Usage:       "Pull an image from the specified location",
+		Description: pullDescription,
+		Flags:       append(pullFlags),
+		Action:      pullCmd,
+		ArgsUsage:   "IMAGE",
 	}
 )
 

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -72,7 +72,6 @@ var (
 		Flags:                  pushFlags,
 		Action:                 pushCmd,
 		ArgsUsage:              "IMAGE DESTINATION",
-		SkipArgReorder:         true,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/rename.go
+++ b/cmd/buildah/rename.go
@@ -14,7 +14,6 @@ var (
 		Description:            renameDescription,
 		Action:                 renameCmd,
 		ArgsUsage:              "CONTAINER-NAME-OR-ID CONTAINER-NAME",
-		SkipArgReorder:         true,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -19,14 +19,13 @@ var (
 		},
 	}
 	rmCommand = cli.Command{
-		Name:                   "rm",
-		Aliases:                []string{"delete"},
-		Usage:                  "Remove one or more working containers",
-		Description:            rmDescription,
-		Action:                 rmCmd,
-		ArgsUsage:              "CONTAINER-NAME-OR-ID [...]",
-		Flags:                  rmFlags,
-		SkipArgReorder:         true,
+		Name:        "rm",
+		Aliases:     []string{"delete"},
+		Usage:       "Remove one or more working containers",
+		Description: rmDescription,
+		Action:      rmCmd,
+		ArgsUsage:   "CONTAINER-NAME-OR-ID [...]",
+		Flags:       rmFlags,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -34,13 +34,12 @@ var (
 		},
 	}
 	rmiCommand = cli.Command{
-		Name:                   "rmi",
-		Usage:                  "removes one or more images from local storage",
-		Description:            rmiDescription,
-		Action:                 rmiCmd,
-		ArgsUsage:              "IMAGE-NAME-OR-ID [...]",
-		Flags:                  rmiFlags,
-		SkipArgReorder:         true,
+		Name:        "rmi",
+		Usage:       "removes one or more images from local storage",
+		Description: rmiDescription,
+		Action:      rmiCmd,
+		ArgsUsage:   "IMAGE-NAME-OR-ID [...]",
+		Flags:       rmiFlags,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -64,7 +64,6 @@ var (
 		Flags:                  append(append(runFlags, userFlags...), buildahcli.NamespaceFlags...),
 		Action:                 runCmd,
 		ArgsUsage:              "CONTAINER-NAME-OR-ID COMMAND [ARGS [...]]",
-		SkipArgReorder:         true,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/tag.go
+++ b/cmd/buildah/tag.go
@@ -15,7 +15,6 @@ var (
 		Description:            tagDescription,
 		Action:                 tagCmd,
 		ArgsUsage:              "IMAGE-NAME [IMAGE-NAME ...]",
-		SkipArgReorder:         true,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/umount.go
+++ b/cmd/buildah/umount.go
@@ -17,14 +17,13 @@ var (
 		},
 	}
 	umountCommand = cli.Command{
-		Name:                   "umount",
-		Aliases:                []string{"unmount"},
-		Usage:                  "Unmounts the root file system on the specified working containers",
-		Description:            "Unmounts the root file system on the specified working containers",
-		Action:                 umountCmd,
-		ArgsUsage:              "[CONTAINER-NAME-OR-ID [...]]",
-		Flags:                  umountFlags,
-		SkipArgReorder:         true,
+		Name:        "umount",
+		Aliases:     []string{"unmount"},
+		Usage:       "Unmounts the root file system on the specified working containers",
+		Description: "Unmounts the root file system on the specified working containers",
+		Action:      umountCmd,
+		ArgsUsage:   "[CONTAINER-NAME-OR-ID [...]]",
+		Flags:       umountFlags,
 		UseShortOptionHandling: true,
 	}
 )

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -29,12 +29,11 @@ const (
 var (
 	unshareDescription = "Runs a command in a modified user namespace"
 	unshareCommand     = cli.Command{
-		Name:           "unshare",
-		Usage:          "Run a command in a modified user namespace",
-		Description:    unshareDescription,
-		Action:         unshareCmd,
-		ArgsUsage:      "[COMMAND [ARGS [...]]]",
-		SkipArgReorder: true,
+		Name:        "unshare",
+		Usage:       "Run a command in a modified user namespace",
+		Description: unshareDescription,
+		Action:      unshareCmd,
+		ArgsUsage:   "[COMMAND [ARGS [...]]]",
 	}
 )
 

--- a/cmd/buildah/version.go
+++ b/cmd/buildah/version.go
@@ -53,6 +53,5 @@ var versionCommand = cli.Command{
 	Name:                   "version",
 	Usage:                  "Display the Buildah Version Information",
 	Action:                 versionCmd,
-	SkipArgReorder:         true,
 	UseShortOptionHandling: true,
 }


### PR DESCRIPTION
Fixes #940 

Before:
```
➜  buildah git:(from-issue) ✗ sudo buildah from scratch --name builder 
too many arguments specified
```
After:
```
➜  buildah git:(from-issue) ✗ sudo ./buildah from scratch --name builder 
builder
➜  buildah git:(from-issue) ✗ sudo buildah containers    
CONTAINER ID  BUILDER  IMAGE ID     IMAGE NAME                       CONTAINER NAME
e173e4ed21d3     *                  scratch                          builder

```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>