### PR TITLE
Update vendor for urfave/cli back to master

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -33,12 +33,12 @@ tests:
   - podman pull alpine
   - podman login localhost:5000 --username testuser --password testpassword
   - podman tag alpine localhost:5000/my-alpine
-  - podman push localhost:5000/my-alpine
+  - podman push --creds=testuser:testpassword localhost:5000/my-alpine
   - podman ps --all
   - podman images
   - podman rmi docker.io/alpine
   - podman rmi localhost:5000/my-alpine
-  - podman pull localhost:5000/my-alpine
+  - podman pull --creds=testuser:testpassword localhost:5000/my-alpine
   - podman ps --all
   - podman images
   - podman rmi localhost:5000/my-alpine

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -295,6 +295,9 @@ load helpers
 }
 
 @test "from volume ro test" {
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
+    skip
+  fi
   if ! which runc ; then
     skip
   fi

--- a/vendor.conf
+++ b/vendor.conf
@@ -46,7 +46,7 @@ github.com/containers/libpod d20f3a51463ce75d139dd830e19a173906b0b0cb
 github.com/sirupsen/logrus master
 github.com/syndtr/gocapability master
 github.com/tchap/go-patricia master
-github.com/urfave/cli fix-short-opts-parsing https://github.com/vrothberg/cli
+github.com/urfave/cli 934abfb2f102315b5794e15ebc7949e4ca253920
 github.com/vbatts/tar-split v0.10.2
 github.com/xeipuuv/gojsonpointer master
 github.com/xeipuuv/gojsonreference master


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Stealing @vrothberg 's https://github.com/containers/libpod/pull/1310 commit for Buildah too.  Getting Buildah back on urfave/cli master after @vrothberg's short option commit was merged.  No changes to any files other than vendor.conf.

I've also added changes to .papr.yml to fix an authentication issue there with the local registry.