### PR TITLE
Let util.ResolveName() return parsing errors

### DIFF
--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -143,7 +143,10 @@ func commitCmd(c *cli.Context) error {
 
 	dest, err := alltransports.ParseImageName(image)
 	if err != nil {
-		candidates := util.ResolveName(image, "", systemContext, store)
+		candidates, err := util.ResolveName(image, "", systemContext, store)
+		if err != nil {
+			return errors.Wrapf(err, "error parsing target image name %q", image)
+		}
 		if len(candidates) == 0 {
 			return errors.Errorf("error parsing target image name %q", image)
 		}

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -725,7 +725,10 @@ func (b *Executor) resolveNameToImageRef() (types.ImageReference, error) {
 	if b.output != "" {
 		imageRef, err = alltransports.ParseImageName(b.output)
 		if err != nil {
-			candidates := util.ResolveName(b.output, "", b.systemContext, b.store)
+			candidates, err := util.ResolveName(b.output, "", b.systemContext, b.store)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error parsing target image name %q: %v", b.output)
+			}
 			if len(candidates) == 0 {
 				return nil, errors.Errorf("error parsing target image name %q", b.output)
 			}

--- a/new.go
+++ b/new.go
@@ -140,7 +140,11 @@ func newContainerIDMappingOptions(idmapOptions *IDMappingOptions) storage.IDMapp
 func resolveImage(ctx context.Context, systemContext *types.SystemContext, store storage.Store, options BuilderOptions) (types.ImageReference, *storage.Image, error) {
 	var ref types.ImageReference
 	var img *storage.Image
-	for _, image := range util.ResolveName(options.FromImage, options.Registry, systemContext, store) {
+	images, err := util.ResolveName(options.FromImage, options.Registry, systemContext, store)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "error parsing reference to image %q", options.FromImage)
+	}
+	for _, image := range images {
 		var err error
 		if len(image) >= minimumTruncatedIDLength {
 			if img, err = store.Image(image); err == nil && img != nil && strings.HasPrefix(img.ID, image) {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -826,6 +826,15 @@ load helpers
   echo "$output"
   [ "$status" -eq 1 ]
 }
+
+@test "bud-with-rejected-name" {
+  target=ThisNameShouldBeRejected
+  run buildah --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  echo "$output"
+  [ "$status" -eq 1 ]
+  [[ "${output}" =~ "must be lower" ]]
+}
+
 @test "bud with chmod copy" {
   imgName=alpine-image
   ctrName=alpine-chown

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -50,3 +50,11 @@ load helpers
   echo FROM
   buildah --storage-driver vfs --root ${TESTDIR}/root2 --runroot ${TESTDIR}/runroot2 from --signature-policy ${TESTSDIR}/policy.json newimage
 }
+
+@test "commit-rejected-name" {
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  run buildah --debug=false commit --signature-policy ${TESTSDIR}/policy.json $cid ThisNameShouldBeRejected
+  echo "$output"
+  [ "${status}" -ne 0 ]
+  [[ "${output}" =~ "must be lower" ]]
+}


### PR DESCRIPTION
Allow util.ResolveName() to return errors from libraries that it uses.