### PR TITLE
Fix rename to also change container name in builder

### DIFF
--- a/cmd/buildah/rename.go
+++ b/cmd/buildah/rename.go
@@ -49,5 +49,6 @@ func renameCmd(c *cli.Context) error {
 	if err != nil {
 		return errors.Wrapf(err, "error renaming container %q to the name %q", oldName, newName)
 	}
-	return nil
+	builder.Container = newName
+	return builder.Save()
 }

--- a/tests/rename.bats
+++ b/tests/rename.bats
@@ -5,9 +5,17 @@ load helpers
 @test "rename" {
   new_name=test-container
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  old_name=$(buildah containers --format "{{.ContainerName}}")
   buildah rename ${cid} ${new_name}
-  run buildah --debug=false containers -f name=${new_name}
+
+  run buildah containers --format "{{.ContainerName}}" 
   [ "$status" -eq 0 ]
+  [[ "$output" =~ "test-container" ]]
+
+  run buildah --debug=false containers -f name=${old_name}
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "" ]]
+
   buildah rm ${new_name}
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Updates the rename functionality to also change the builder.container field to the new name.  Prior to this change  if you did `buildah containers` you'd still see the original container name.  If you added the `--all` param, then you'd see the new name.

Testing:
```
# buildah from alpine
alpine-working-container

# buildah containers
CONTAINER ID  BUILDER  IMAGE ID     IMAGE NAME                       CONTAINER NAME
d8eba3ece654     *     11cd0b38bc3c docker.io/library/alpine:latest  alpine-working-container

# buildah rename alpine-working-container tom

# buildah containers
CONTAINER ID  BUILDER  IMAGE ID     IMAGE NAME                       CONTAINER NAME
d8eba3ece654     *     11cd0b38bc3c docker.io/library/alpine:latest  tom

# buildah containers --all
CONTAINER ID  BUILDER  IMAGE ID     IMAGE NAME                       CONTAINER NAME
d8eba3ece654     *     11cd0b38bc3c docker.io/library/alpine:latest  tom
```