### PR TITLE
Makefile: use $(GO) env-var everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ tests/testreport/testreport: tests/testreport/testreport.go
 
 .PHONY: test-unit
 test-unit: tests/testreport/testreport
-	$(GO) test -v -tags "$(AUTOTAGS) $(TAGS)" -race $(shell go list ./... | grep -v vendor | grep -v tests | grep -v cmd)
+	$(GO) test -v -tags "$(AUTOTAGS) $(TAGS)" -race $(shell $(GO) list ./... | grep -v vendor | grep -v tests | grep -v cmd)
 	tmp=$(shell mktemp -d) ; \
 	mkdir -p $$tmp/root $$tmp/runroot; \
 	$(GO) test -v -tags "$(AUTOTAGS) $(TAGS)" ./cmd/buildah -args -root $$tmp/root -runroot $$tmp/runroot -storage-driver vfs -signature-policy $(shell pwd)/tests/policy.json -registries-conf $(shell pwd)/tests/registries.conf


### PR DESCRIPTION
One location was still using the hardcoded default binary.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>