### PR TITLE
rename: Avoid renaming the same name as other containers

### DIFF
--- a/cmd/buildah/rename.go
+++ b/cmd/buildah/rename.go
@@ -45,6 +45,10 @@ func renameCmd(c *cli.Context) error {
 		return errors.Errorf("renaming a container with the same name as its current name")
 	}
 
+	if build, err := openBuilder(getContext(), store, newName); err == nil {
+		return errors.Errorf("The container name %q is already in use by container %q", newName, build.ContainerID)
+	}
+
 	err = store.SetNames(builder.ContainerID, []string{newName})
 	if err != nil {
 		return errors.Wrapf(err, "error renaming container %q to the name %q", oldName, newName)

--- a/tests/rename.bats
+++ b/tests/rename.bats
@@ -19,3 +19,24 @@ load helpers
   buildah rm ${new_name}
   [ "$status" -eq 0 ]
 }
+
+@test "rename same name as current name" {
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  run buildah --debug=false rename ${cid} ${cid}
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "" ]]
+
+  buildah rm $cid
+  buildah rmi -f alpine
+}
+
+@test "rename same name as other container name" {
+  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  run buildah --debug=false rename ${cid1} ${cid2}
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "" ]]
+
+  buildah rm $cid1 $cid2
+  buildah rmi -f alpine busybox
+}


### PR DESCRIPTION
After change:
```
➜  buildah git:(rename-fix) ✗ sudo buildah containers
CONTAINER ID  BUILDER  IMAGE ID     IMAGE NAME                       CONTAINER NAME
e173e4ed21d3     *                  scratch                          zz
2256d7709941     *     e1ddd7948a1c docker.io/library/busybox:latest busybox
➜  buildah git:(rename-fix) ✗ sudo ./buildah rename e173 busybox
The container name "busybox" is already in use by container "2256d7709941ebfc1de14d0fab2e0c4959d38df3c2c7455ada99f342975e8c21"
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>