### PR TITLE
cmd/rm: restore the correct containerID display

### DIFF
--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -57,11 +57,12 @@ func rmCmd(c *cli.Context) error {
 		}
 
 		for _, builder := range builders {
+			id := builder.ContainerID
 			if err = builder.Delete(); err != nil {
 				lastError = util.WriteError(os.Stderr, errors.Wrapf(err, "%s %q", delContainerErrStr, builder.Container), lastError)
 				continue
 			}
-			fmt.Printf("%s\n", builder.ContainerID)
+			fmt.Printf("%s\n", id)
 		}
 	} else {
 		for _, name := range args {
@@ -70,11 +71,12 @@ func rmCmd(c *cli.Context) error {
 				lastError = util.WriteError(os.Stderr, errors.Wrapf(err, "%s %q", delContainerErrStr, name), lastError)
 				continue
 			}
+			id := builder.ContainerID
 			if err = builder.Delete(); err != nil {
 				lastError = util.WriteError(os.Stderr, errors.Wrapf(err, "%s %q", delContainerErrStr, name), lastError)
 				continue
 			}
-			fmt.Printf("%s\n", builder.ContainerID)
+			fmt.Printf("%s\n", id)
 		}
 
 	}


### PR DESCRIPTION
This code was modified in #963. At the time, I didn't notice that the ContainerID would be emptied after the [delete](https://github.com/projectatomic/buildah/blob/master/delete.go#L16) operation,so the ID displayed after deleting the container is empty.
Now the relevant code is restored. I am sorry for my negligence.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>