### PR TITLE
Make buildah-from error message clear when flags are after arg

### DIFF
--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -160,6 +160,11 @@ func fromCmd(c *cli.Context) error {
 		return errors.Errorf("an image name (or \"scratch\") must be specified")
 	}
 	if len(args) > 1 {
+		for _, arg := range args {
+			if strings.HasPrefix(arg, "-") {
+				return errors.Errorf("%s should be set before the image name", arg)
+			}
+		}
 		return errors.Errorf("too many arguments specified")
 	}
 	if err := parse.ValidateFlags(c, fromFlags); err != nil {

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -2,6 +2,28 @@
 
 load helpers
 
+@test "from bad order of flags" {
+  run buildah from scratch -q
+  [ "$status" -eq 1 ]
+  [[ $output = *"-q should be set before the image name"* ]]
+
+  run buildah from scratch --pull
+  [ "$status" -eq 1 ]
+  [[ $output = *"--pull should be set before the image name"* ]]
+
+  run buildah from scratch --ulimit=1024
+  [ "$status" -eq 1 ]
+  [[ $output = *"--ulimit=1024 should be set before the image name"* ]]
+
+  run buildah from scratch --name container-name-irrelevant
+  [ "$status" -eq 1 ]
+  [[ $output = *"--name should be set before the image name"* ]]
+
+  run buildah from scratch --cred="fake fake" --name small
+  [ "$status" -eq 1 ]
+  [[ $output = *"--cred=fake fake should be set before the image name"* ]]
+}
+
 @test "commit-to-from-elsewhere" {
   elsewhere=${TESTDIR}/elsewhere-img
   mkdir -p ${elsewhere}


### PR DESCRIPTION
**NOTE**: this is my way to solve #940 - without setting `SkipArgOrder` to false(https://github.com/projectatomic/buildah/pull/944). Please let me know what you think.

The error message in buildah-from can be confusing when a flag is specified after the argument (image name).

For example, running the following: 

```bash
$ buildah from scratch -q
too many arguments specified
```

however only one argument was specified`scratch`. the reason we get this error is because anything that comes after "scratch" will be considered as an argument.

To fix this - check if every argument is a flag (flag starts with "-" e.g. "-q", "--ulimit").
If you find at least one argument that is a flag return a much clearer error message:

```
-q should be set before the image name
```

otherwise, return the old error.

closes #940 