### PR TITLE
Fix image function

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -32,6 +32,16 @@ type imageOutputParams struct {
 	Size      string
 }
 
+type imageOptions struct {
+	all       bool
+	digests   bool
+	format    string
+	json      bool
+	noHeading bool
+	truncate  bool
+	quiet     bool
+}
+
 type filterParams struct {
 	dangling         string
 	label            string
@@ -123,24 +133,17 @@ func imagesCmd(c *cli.Context) error {
 		return errors.Errorf("quiet and format are mutually exclusive")
 	}
 
-	quiet := c.Bool("quiet")
-	truncate := !c.Bool("no-trunc")
-	digests := c.Bool("digests")
-	hasTemplate := c.IsSet("format")
+	opts := imageOptions{
+		all:       c.Bool("all"),
+		digests:   c.Bool("digests"),
+		format:    c.String("format"),
+		json:      c.Bool("json"),
+		noHeading: c.Bool("noheading"),
+		truncate:  !c.Bool("notruncate"),
+		quiet:     c.Bool("quiet"),
+	}
 	ctx := getContext()
 
-	if c.IsSet("json") {
-		JSONImages := []jsonImage{}
-		for _, image := range images {
-			JSONImages = append(JSONImages, jsonImage{ID: image.ID, Names: image.Names})
-		}
-		data, err2 := json.MarshalIndent(JSONImages, "", "    ")
-		if err2 != nil {
-			return err2
-		}
-		fmt.Printf("%s\n", data)
-		return nil
-	}
 	var params *filterParams
 	if c.IsSet("filter") {
 		params, err = parseFilter(ctx, store, images, c.String("filter"))
@@ -149,11 +152,11 @@ func imagesCmd(c *cli.Context) error {
 		}
 	}
 
-	if len(images) > 0 && !c.Bool("noheading") && !quiet && !hasTemplate {
-		outputHeader(truncate, digests)
+	if len(images) > 0 && !opts.noHeading && !opts.quiet && opts.format == "" && !opts.json {
+		outputHeader(opts.truncate, opts.digests)
 	}
 
-	return outputImages(ctx, images, c.String("format"), store, params, name, hasTemplate, truncate, digests, quiet, c.Bool("all"))
+	return outputImages(ctx, images, store, params, name, opts)
 }
 
 func parseFilter(ctx context.Context, store storage.Store, images []storage.Image, filter string) (*filterParams, error) {
@@ -233,7 +236,7 @@ func outputHeader(truncate, digests bool) {
 	fmt.Printf("%-22s %s\n", "CREATED AT", "SIZE")
 }
 
-func outputImages(ctx context.Context, images []storage.Image, format string, store storage.Store, filters *filterParams, argName string, hasTemplate, truncate, digests, quiet, all bool) error {
+func outputImages(ctx context.Context, images []storage.Image, store storage.Store, filters *filterParams, argName string, opts imageOptions) error {
 	found := false
 	for _, image := range images {
 		createdTime := image.Created
@@ -254,7 +257,7 @@ func outputImages(ctx context.Context, images []storage.Image, format string, st
 		if err != nil {
 			logrus.Errorf("error checking if image is a parent %q: %v", image.ID, err)
 		}
-		if !all && len(image.Names) == 0 && isParent {
+		if !opts.all && len(image.Names) == 0 && isParent {
 			continue
 		}
 
@@ -274,10 +277,20 @@ func outputImages(ctx context.Context, images []storage.Image, format string, st
 			if !matchesFilter(ctx, image, store, name, filters) {
 				continue
 			}
-			if quiet {
+			if opts.quiet {
 				fmt.Printf("%-64s\n", image.ID)
 				// We only want to print each id once
 				break
+			}
+
+			if opts.json {
+				JSONImage := jsonImage{ID: image.ID, Names: image.Names}
+				data, err2 := json.MarshalIndent(JSONImage, "", "    ")
+				if err2 != nil {
+					return err2
+				}
+				fmt.Printf("%s\n", data)
+				continue
 			}
 
 			params := imageOutputParams{
@@ -287,14 +300,14 @@ func outputImages(ctx context.Context, images []storage.Image, format string, st
 				CreatedAt: createdTime.Format("Jan 2, 2006 15:04"),
 				Size:      formattedSize(size),
 			}
-			if hasTemplate {
-				if err := outputUsingTemplate(format, params); err != nil {
+			if opts.format != "" {
+				if err := outputUsingTemplate(opts.format, params); err != nil {
 					return err
 				}
 				continue
 			}
 
-			outputUsingFormatString(truncate, digests, params)
+			outputUsingFormatString(opts.truncate, opts.digests, params)
 		}
 	}
 

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -92,6 +92,20 @@ var (
 )
 
 func imagesCmd(c *cli.Context) error {
+	name := ""
+	args := c.Args()
+	if len(args) > 0 {
+		if c.Bool("all") {
+			return errors.Errorf("when using the --all switch, you may not pass any images names or IDs")
+		}
+
+		if len(args) == 1 {
+			name = args.Get(0)
+		} else {
+			return errors.New("'buildah images' requires at most 1 argument")
+		}
+	}
+
 	if err := parse.ValidateFlags(c, imagesFlags); err != nil {
 		return err
 	}
@@ -115,12 +129,6 @@ func imagesCmd(c *cli.Context) error {
 	hasTemplate := c.IsSet("format")
 	ctx := getContext()
 
-	name := ""
-	if len(c.Args()) == 1 {
-		name = c.Args().Get(0)
-	} else if len(c.Args()) > 1 {
-		return errors.New("'buildah images' requires at most 1 argument")
-	}
 	if c.IsSet("json") {
 		JSONImages := []jsonImage{}
 		for _, image := range images {

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -197,6 +197,11 @@ func TestOutputImagesQuietTruncated(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
+	opts := imageOptions{
+		truncate: true,
+		quiet:    true,
+	}
+
 	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
@@ -217,7 +222,7 @@ func TestOutputImagesQuietTruncated(t *testing.T) {
 
 	// Tests quiet and truncated output
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:1], "", store, nil, "", false, true, false, true, false)
+		return outputImages(getContext(), images[:1], store, nil, "", opts)
 	})
 	expectedOutput := fmt.Sprintf("%-64s\n", images[0].ID)
 	if err != nil {
@@ -231,6 +236,9 @@ func TestOutputImagesQuietNotTruncated(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
+	opts := imageOptions{
+		quiet: true,
+	}
 	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
@@ -251,7 +259,7 @@ func TestOutputImagesQuietNotTruncated(t *testing.T) {
 
 	// Tests quiet and non-truncated output
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:1], "", store, nil, "", false, false, false, true, false)
+		return outputImages(getContext(), images[:1], store, nil, "", opts)
 	})
 	expectedOutput := fmt.Sprintf("%-64s\n", images[0].ID)
 	if err != nil {
@@ -265,6 +273,10 @@ func TestOutputImagesFormatString(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
+	opts := imageOptions{
+		format:   "{{.ID}}",
+		truncate: true,
+	}
 	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
@@ -285,7 +297,7 @@ func TestOutputImagesFormatString(t *testing.T) {
 
 	// Tests output with format template
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:1], "{{.ID}}", store, nil, "", true, true, false, false, false)
+		return outputImages(getContext(), images[:1], store, nil, "", opts)
 	})
 	expectedOutput := images[0].ID
 	if err != nil {
@@ -299,6 +311,9 @@ func TestOutputImagesFormatTemplate(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
+	opts := imageOptions{
+		quiet: true,
+	}
 	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
@@ -319,7 +334,7 @@ func TestOutputImagesFormatTemplate(t *testing.T) {
 
 	// Tests quiet and non-truncated output
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:1], "", store, nil, "", false, false, false, true, false)
+		return outputImages(getContext(), images[:1], store, nil, "", opts)
 	})
 	expectedOutput := fmt.Sprintf("%-64s\n", images[0].ID)
 	if err != nil {
@@ -333,6 +348,9 @@ func TestOutputImagesArgNoMatch(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
+	opts := imageOptions{
+		truncate: true,
+	}
 	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
@@ -355,7 +373,7 @@ func TestOutputImagesArgNoMatch(t *testing.T) {
 	// because all images in the repository must have a tag, and here the tag is an
 	// empty string
 	_, err = captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:1], "", store, nil, "foo:", false, true, false, false, false)
+		return outputImages(getContext(), images[:1], store, nil, "foo:", opts)
 	})
 	if err == nil || err.Error() != "No such image foo:" {
 		t.Fatalf("expected error arg no match")
@@ -366,6 +384,10 @@ func TestOutputMultipleImages(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
+	opts := imageOptions{
+		quiet:    true,
+		truncate: true,
+	}
 	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		t.Fatal(err)
@@ -390,7 +412,7 @@ func TestOutputMultipleImages(t *testing.T) {
 
 	// Tests quiet and truncated output
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:2], "", store, nil, "", false, true, false, true, false)
+		return outputImages(getContext(), images[:2], store, nil, "", opts)
 	})
 	expectedOutput := fmt.Sprintf("%-64s\n%-64s\n", images[0].ID, images[1].ID)
 	if err != nil {

--- a/cmd/buildah/rmi_test.go
+++ b/cmd/buildah/rmi_test.go
@@ -86,6 +86,9 @@ func TestStorageImageIDTrue(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
+	opts := imageOptions{
+		quiet: true,
+	}
 	store, err := storage.GetStore(storeOptions)
 	if store != nil {
 		is.Transport.SetStore(store)
@@ -104,7 +107,7 @@ func TestStorageImageIDTrue(t *testing.T) {
 		t.Fatalf("Error reading images: %v", err)
 	}
 	id, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images, "", store, nil, "busybox:latest", false, false, false, true, false)
+		return outputImages(getContext(), images, store, nil, "busybox:latest", opts)
 	})
 	if err != nil {
 		t.Fatalf("Error getting id of image: %v", err)

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -69,6 +69,20 @@ load helpers
   buildah rmi -a -f
 }
 
+@test "images json test" {
+  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  run buildah --debug=false images --json
+  [ $(wc -l <<< "$output") -eq 12 ]
+  [ "${status}" -eq 0 ]
+ 
+  run buildah --debug=false images --json alpine
+  [ $(wc -l <<< "$output") -eq 6 ]
+  [ "${status}" -eq 0 ]
+  buildah rm -a
+  buildah rmi -a -f
+}
+
 @test "specify an existing image" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)


### PR DESCRIPTION
1. cmd/images: Disallow the input of image when using the -a option 

When using the --all option and having the image parameter input, an error should be returned.
```
➜  buildah git:(images-fix) sudo ./buildah images -a ubuntu
when using the --all switch, you may not pass any images names or IDs
```

2. cmd/images: Modify json option 

When you specify image and display it with the json option, it should display the contents of the specified image instead of displaying the contents of the entire image.

Before change:
```
➜  buildah git:(images-fix) sudo buildah images --json ubuntu
[
    {
        "id": "16508e5c265dcb5c05017a2a8a8228ae12b7b56b2cda0197ed5411bda200a961",
        "names": [
            "docker.io/library/ubuntu:latest"
        ]
    },
    {
        "id": "e1ddd7948a1c31709a23cc5b7dfe96e55fc364f90e1cebcde0773a1b5a30dcda",
        "names": [
            "docker.io/library/busybox:latest"
        ]
    },
    {
        "id": "71c43202b8ac897ff4d048d3b37bdf4eb543ec5c03fd017c3e12c616c6792206",
        "names": [
            "docker.io/library/nginx:latest"
        ]
    }
]
```

After change:
```
➜  buildah git:(images-fix) sudo ./buildah images --json ubuntu
{
    "id": "16508e5c265dcb5c05017a2a8a8228ae12b7b56b2cda0197ed5411bda200a961",
    "names": [
        "docker.io/library/ubuntu:latest"
    ]
}
```
Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>
