### PR TITLE
chroot isolation: chroot() before setting up seccomp

### DIFF
--- a/bind/mount.go
+++ b/bind/mount.go
@@ -133,6 +133,7 @@ func SetupIntermediateMountNamespace(spec *specs.Spec, bundlePath string) (unmou
 	if err = unix.Mount(rootPath, rootfs, "", unix.MS_BIND|unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
 		return unmountAll, errors.Wrapf(err, "error bind mounting root filesystem from %q to %q", rootPath, rootfs)
 	}
+	logrus.Debugf("bind mounted %q to %q", rootPath, rootfs)
 	unmount = append([]string{rootfs}, unmount...)
 	spec.Root.Path = rootfs
 

--- a/chroot/seccomp.go
+++ b/chroot/seccomp.go
@@ -105,7 +105,7 @@ func setSeccomp(spec *specs.Spec) error {
 		for _, name := range rule.Names {
 			scnum, err := libseccomp.GetSyscallFromName(name)
 			if err != nil {
-				logrus.Debugf("error mapping syscall %q to a syscall, ignoring %q rule for %q", name, rule.Action)
+				logrus.Debugf("error mapping syscall %q to a syscall, ignoring %q rule for %q", name, rule.Action, name)
 				continue
 			}
 			scnames[scnum] = name

--- a/run.go
+++ b/run.go
@@ -1017,6 +1017,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	if spec.Process.Cwd == "" {
 		spec.Process.Cwd = DefaultWorkingDir
 	}
+	logrus.Debugf("ensuring working directory %q exists", filepath.Join(mountPoint, spec.Process.Cwd))
 	if err = os.MkdirAll(filepath.Join(mountPoint, spec.Process.Cwd), 0755); err != nil {
 		return errors.Wrapf(err, "error ensuring working directory %q exists", spec.Process.Cwd)
 	}


### PR DESCRIPTION
Make the chroot() call before applying a seccomp filter, which might not allow us to do it.  Add more debugging messages.