### PR TITLE
nitpick: decrease cognitive complexity in buildah-bud

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -82,33 +82,33 @@ func budCmd(c *cli.Context) error {
 	}
 	contextDir := ""
 	cliArgs := c.Args()
-	if len(cliArgs) > 0 {
-		// The context directory could be a URL.  Try to handle that.
-		tempDir, subDir, err := imagebuildah.TempDirForURL("", "buildah", cliArgs[0])
-		if err != nil {
-			return errors.Wrapf(err, "error prepping temporary context directory")
-		}
-		if tempDir != "" {
-			// We had to download it to a temporary directory.
-			// Delete it later.
-			defer func() {
-				if err = os.RemoveAll(tempDir); err != nil {
-					logrus.Errorf("error removing temporary directory %q: %v", contextDir, err)
-				}
-			}()
-			contextDir = filepath.Join(tempDir, subDir)
-		} else {
-			// Nope, it was local.  Use it as is.
-			absDir, err := filepath.Abs(cliArgs[0])
-			if err != nil {
-				return errors.Wrapf(err, "error determining path to directory %q", cliArgs[0])
-			}
-			contextDir = absDir
-		}
-		cliArgs = cliArgs.Tail()
-	} else {
+	if len(cliArgs) == 0 {
 		return errors.Errorf("no context directory or URL specified")
 	}
+	// The context directory could be a URL.  Try to handle that.
+	tempDir, subDir, err := imagebuildah.TempDirForURL("", "buildah", cliArgs[0])
+	if err != nil {
+		return errors.Wrapf(err, "error prepping temporary context directory")
+	}
+	if tempDir != "" {
+		// We had to download it to a temporary directory.
+		// Delete it later.
+		defer func() {
+			if err = os.RemoveAll(tempDir); err != nil {
+				logrus.Errorf("error removing temporary directory %q: %v", contextDir, err)
+			}
+		}()
+		contextDir = filepath.Join(tempDir, subDir)
+	} else {
+		// Nope, it was local.  Use it as is.
+		absDir, err := filepath.Abs(cliArgs[0])
+		if err != nil {
+			return errors.Wrapf(err, "error determining path to directory %q", cliArgs[0])
+		}
+		contextDir = absDir
+	}
+	cliArgs = cliArgs.Tail()
+
 	if len(dockerfiles) == 0 {
 		dockerfiles = append(dockerfiles, filepath.Join(contextDir, "Dockerfile"))
 	}


### PR DESCRIPTION
**NOTE**: this is another suggestion I have. It doesn't mean I don't like the coding style - it's just my own opinion and if you think it's not vital feel free to close it. :smile: 

A small nitpick to `cmd/buildah/bud.go`.

from:
```
if cliArgs > 0 {
  ... // 5 LOC
} else {
  return error
}
```

to:
```
if cliArgs == 0 {
  return error
}
... // 5 LOC
```

The latter style makes the code flow better than with if-else (IMHO).

