### PR TITLE
Exclude --layers from the common bug cli flags

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -21,7 +21,7 @@ var (
 		Aliases:                []string{"bud"},
 		Usage:                  "Build an image using instructions in a Dockerfile",
 		Description:            budDescription,
-		Flags:                  append(buildahcli.BudFlags, buildahcli.FromAndBudFlags...),
+		Flags:                  append(append(buildahcli.BudFlags, buildahcli.LayerFlags...), buildahcli.FromAndBudFlags...),
 		Action:                 budCmd,
 		ArgsUsage:              "CONTEXT-DIRECTORY | URL",
 		SkipArgReorder:         true,
@@ -116,6 +116,9 @@ func budCmd(c *cli.Context) error {
 		dockerfiles = append(dockerfiles, filepath.Join(contextDir, "Dockerfile"))
 	}
 	if err := parse.ValidateFlags(c, buildahcli.BudFlags); err != nil {
+		return err
+	}
+	if err := parse.ValidateFlags(c, buildahcli.LayerFlags); err != nil {
 		return err
 	}
 	if err := parse.ValidateFlags(c, buildahcli.FromAndBudFlags); err != nil {

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -69,6 +69,13 @@ var (
 		},
 	}
 
+	LayerFlags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "layers",
+			Usage: fmt.Sprintf("cache intermediate layers during build. Use BUILDAH_LAYERS environment variable to override. (default %t)", UseLayers()),
+		},
+	}
+
 	BudFlags = []cli.Flag{
 		cli.StringSliceFlag{
 			Name:  "annotation",
@@ -129,10 +136,6 @@ var (
 		cli.StringSliceFlag{
 			Name:  "label",
 			Usage: "Set metadata for an image (default [])",
-		},
-		cli.BoolFlag{
-			Name:  "layers",
-			Usage: fmt.Sprintf("cache intermediate layers during build. Use BUILDAH_LAYERS environment variable to override. (default %t)", UseLayers()),
 		},
 		cli.BoolFlag{
 			Name:  "no-cache",


### PR DESCRIPTION
Other applications like podman would like to switch the the default value
for --layers.  Because we re-use this code, we just need to pop layers out
of the budflags.

Signed-off-by: baude <bbaude@redhat.com>