### PR TITLE
chroot: create missing parent directories for volume mounts

### DIFF
--- a/chroot/run.go
+++ b/chroot/run.go
@@ -1075,11 +1075,14 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			// The target isn't there yet, so create it, and make a
 			// note to remove it later.
 			if srcinfo.IsDir() {
-				if err = os.Mkdir(target, 0111); err != nil {
+				if err = os.MkdirAll(target, 0111); err != nil {
 					return undoBinds, errors.Wrapf(err, "error creating mountpoint %q in mount namespace", target)
 				}
 				removes = append(removes, target)
 			} else {
+				if err = os.MkdirAll(filepath.Dir(target), 0111); err != nil {
+					return undoBinds, errors.Wrapf(err, "error ensuring parent of mountpoint %q (%q) is present in mount namespace", target, filepath.Dir(target))
+				}
 				var file *os.File
 				if file, err = os.OpenFile(target, os.O_WRONLY|os.O_CREATE, 0); err != nil {
 					return undoBinds, errors.Wrapf(err, "error creating mountpoint %q in mount namespace", target)

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -343,6 +343,13 @@ load helpers
 	run buildah --debug=false run -v ${TESTDIR}/was-empty:/var/not-empty:ro${zflag:+,${zflag}} $cid touch /var/not-empty/testfile
 	echo "$output"
 	[ "$status" -ne 0 ]
+	# Even if the parent directory doesn't exist yet, this should succeed.
+	run buildah --debug=false run -v ${TESTDIR}/was-empty:/var/multi-level/subdirectory        $cid touch /var/multi-level/subdirectory/testfile
+	echo "$output"
+	# And check the same for file volumes.
+	run buildah --debug=false run -v ${TESTDIR}/was-empty/testfile:/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
+	echo "$output"
+	[ "$status" -eq 0 ]
 }
 
 @test "run symlinks" {


### PR DESCRIPTION
When ensuring that the target for a volume mount is present, be sure to create any leading directories which are also not yet present.