### PR TITLE
buildah-images.md: Fix option contents

### DIFF
--- a/docs/buildah-images.md
+++ b/docs/buildah-images.md
@@ -37,7 +37,7 @@ Display the output in JSON format.
 
 Omit the table headings from the listing of images.
 
-**no-trunc**
+**--no-trunc, --notruncate**
 
 Do not truncate output.
 


### PR DESCRIPTION
Modify and complete the images function in the notruncate option.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>