### PR TITLE
Retain bounding set when running containers as non root

### DIFF
--- a/run.go
+++ b/run.go
@@ -868,9 +868,11 @@ func (b *Builder) configureUIDGID(g *generate.Generator, mountPoint string, opti
 		g.AddProcessAdditionalGid(gid)
 	}
 
-	// Remove capabilities if not running as root
+	// Remove capabilities if not running as root except Bounding set
 	if user.UID != 0 {
+		bounding := g.Config.Process.Capabilities.Bounding
 		g.ClearProcessCapabilities()
+		g.Config.Process.Capabilities.Bounding = bounding
 	}
 
 	return nil

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -283,3 +283,25 @@ load helpers
   buildah rm $cid
   buildah rmi env-image-docker env-image-oci
 }
+
+@test "user" {
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  bndoutput=$(buildah --debug=false run $cid grep CapBnd /proc/self/status)
+  buildah config --user 1000 $cid
+  run buildah --debug=false run $cid id -u
+  echo $output
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ 1000 ]]
+
+  run buildah --debug=false run $cid sh -c "grep CapEff /proc/self/status | cut -f2"
+  echo $output
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "0000000000000000" ]]
+
+  run buildah --debug=false run $cid grep CapBnd /proc/self/status
+  echo $output
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ $bndoutput ]]
+
+  buildah rm $cid
+}


### PR DESCRIPTION
We need to be able to run sudo commands inside of Dockerfile's
even when containers are setup with non root.

This patch retains the bounding set for containers run with non root user.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>