### PR TITLE
Add flags/arguments order verification to other commands

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -6,6 +6,7 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
+	buildahcli "github.com/projectatomic/buildah/pkg/cli"
 	"github.com/projectatomic/buildah/pkg/parse"
 	"github.com/urfave/cli"
 )
@@ -56,6 +57,9 @@ func addAndCopyCmd(c *cli.Context, extractLocalArchives bool) error {
 		return errors.Errorf("src must be specified")
 	}
 
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
+	}
 	if err := parse.ValidateFlags(c, addAndCopyFlags); err != nil {
 		return err
 	}

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -14,6 +14,7 @@ import (
 	is "github.com/containers/image/storage"
 	"github.com/containers/storage"
 	"github.com/pkg/errors"
+	buildahcli "github.com/projectatomic/buildah/pkg/cli"
 	"github.com/projectatomic/buildah/pkg/parse"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -109,6 +110,9 @@ func imagesCmd(c *cli.Context) error {
 			return errors.Errorf("when using the --all switch, you may not pass any images names or IDs")
 		}
 
+		if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+			return err
+		}
 		if len(args) == 1 {
 			name = args.Get(0)
 		} else {

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	buildahcli "github.com/projectatomic/buildah/pkg/cli"
 	"github.com/projectatomic/buildah/pkg/parse"
 	"github.com/urfave/cli"
 )
@@ -32,6 +33,9 @@ var (
 func mountCmd(c *cli.Context) error {
 	args := c.Args()
 
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
+	}
 	if err := parse.ValidateFlags(c, mountFlags); err != nil {
 		return err
 	}

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -12,6 +12,7 @@ import (
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/projectatomic/buildah"
+	buildahcli "github.com/projectatomic/buildah/pkg/cli"
 	"github.com/projectatomic/buildah/pkg/parse"
 	"github.com/projectatomic/buildah/util"
 	"github.com/urfave/cli"
@@ -81,6 +82,9 @@ func pushCmd(c *cli.Context) error {
 	args := c.Args()
 	if len(args) < 2 {
 		return errors.New("source and destination image IDs must be specified")
+	}
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
 	}
 	if err := parse.ValidateFlags(c, pushFlags); err != nil {
 		return err

--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	buildahcli "github.com/projectatomic/buildah/pkg/cli"
 	"github.com/projectatomic/buildah/pkg/parse"
 	"github.com/projectatomic/buildah/util"
 	"github.com/urfave/cli"
@@ -39,6 +40,10 @@ func rmCmd(c *cli.Context) error {
 	}
 	if len(args) > 0 && c.Bool("all") {
 		return errors.Errorf("when using the --all switch, you may not pass any containers names or IDs")
+	}
+
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
 	}
 	if err := parse.ValidateFlags(c, rmFlags); err != nil {
 		return err

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	"github.com/pkg/errors"
+	buildahcli "github.com/projectatomic/buildah/pkg/cli"
 	"github.com/projectatomic/buildah/pkg/parse"
 	"github.com/projectatomic/buildah/util"
 	"github.com/sirupsen/logrus"
@@ -61,6 +62,9 @@ func rmiCmd(c *cli.Context) error {
 		return errors.Errorf("when using the --all switch, you may not use --prune switch")
 	}
 
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
+	}
 	if err := parse.ValidateFlags(c, rmiFlags); err != nil {
 		return err
 	}

--- a/cmd/buildah/umount.go
+++ b/cmd/buildah/umount.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	buildahcli "github.com/projectatomic/buildah/pkg/cli"
 	"github.com/projectatomic/buildah/pkg/parse"
 	"github.com/urfave/cli"
 )
@@ -38,6 +39,9 @@ func umountCmd(c *cli.Context) error {
 	}
 	if len(args) > 0 && umountAll {
 		return errors.Errorf("when using the --all switch, you may not pass any container IDs")
+	}
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
 	}
 	if err := parse.ValidateFlags(c, umountFlags); err != nil {
 		return err

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -2,6 +2,17 @@
 
 load helpers
 
+@test "add-flags-order-verification" {
+  run buildah add container1 -q /tmp/container1
+  check_options_flag_err "-q"
+
+  run buildah add container1 --chown /tmp/container1 --quiet 
+  check_options_flag_err "--chown"
+
+  run buildah add container1 /tmp/container1 --quiet 
+  check_options_flag_err "--quiet"
+}
+
 @test "add-local-plain" {
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -2,6 +2,17 @@
 
 load helpers
 
+@test "copy-flags-order-verification" {
+  run buildah copy container1 -q /tmp/container1
+  check_options_flag_err "-q"
+
+  run buildah copy container1 --chown /tmp/container1 --quiet 
+  check_options_flag_err "--chown"
+
+  run buildah copy container1 /tmp/container1 --quiet 
+  check_options_flag_err "--quiet"
+}
+
 @test "copy-local-multiple" {
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -2,6 +2,20 @@
 
 load helpers
 
+@test "images-flags-order-verification" {
+  run buildah images --all
+  [ $status -eq 0 ]
+
+  run buildah images img1 -n
+  check_options_flag_err "-n"
+
+  run buildah images img1 --filter="service=redis" img2
+  check_options_flag_err "--filter=service=redis"
+
+  run buildah images img1 img2 img3 -q 
+  check_options_flag_err "-q"
+}
+
 @test "images" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -2,6 +2,17 @@
 
 load helpers
 
+@test "mount-flags-order-verification" {
+  run buildah mount cnt1 --notruncate path1
+  check_options_flag_err "--notruncate"
+
+  run buildah mount cnt1 --notruncate
+  check_options_flag_err "--notruncate"
+
+  run buildah mount cnt1 path1 --notruncate
+  check_options_flag_err "--notruncate"
+}
+
 @test "mount one container" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   run buildah --debug=false mount "$cid"

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -2,6 +2,20 @@
 
 load helpers
 
+@test "push-flags-order-verification" {
+  run buildah push img1 dest1 -q
+  check_options_flag_err "-q"
+
+  run buildah push img1 --tls-verify dest1
+  check_options_flag_err "--tls-verify"
+
+  run buildah push img1 dest1 arg3 --creds user1:pass1
+  check_options_flag_err "--creds"
+
+  run buildah push img1 --creds=user1:pass1 dest1 
+  check_options_flag_err "--creds=user1:pass1"
+}
+
 @test "push" {
   touch ${TESTDIR}/reference-time-file
   for source in scratch scratch-image; do

--- a/tests/rm.bats
+++ b/tests/rm.bats
@@ -2,6 +2,14 @@
 
 load helpers
 
+@test "rm-flags-order-verification" {
+  run buildah rm cnt1 -a
+  check_options_flag_err "-a"
+
+  run buildah rm cnt1 --all cnt2
+  check_options_flag_err "--all"
+}
+
 @test "remove multiple containers errors" {
   run buildah --debug=false rm mycontainer1 mycontainer2 mycontainer3
   [ "${lines[0]}" == "error removing container \"mycontainer1\": error reading build container: container not known" ]

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -2,6 +2,17 @@
 
 load helpers
 
+@test "rmi-flags-order-verification" {
+  run buildah rmi img1 -f
+  check_options_flag_err "-f"
+
+  run buildah rm img1 --all img2 
+  check_options_flag_err "--all"
+
+  run buildah rm img1 img2 --force
+  check_options_flag_err "--force"
+}
+
 @test "remove one image" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"

--- a/tests/umount.bats
+++ b/tests/umount.bats
@@ -2,6 +2,17 @@
 
 load helpers
 
+@test "umount-flags-order-verification" {
+  run buildah umount cnt1 -a
+  check_options_flag_err "-a"
+
+  run buildah umount cnt1 --all cnt2
+  check_options_flag_err "--all"
+
+  run buildah umount cnt1 cnt2 --all
+  check_options_flag_err "--all"
+}
+
 @test "umount one image" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid"


### PR DESCRIPTION
This is the third part of adding flags/args order verficiation.
In this part I am adding it to command lines that take no arguments or more than 1 arguments such as buildah-images, buildah-copy and etc.

I added some tests too to verify that it does what it's supposed to do.

- [x] add
- [x] copy
- [x] images
- [x] mount
- [x] push
- [x] rm
- [x] rmi
- [x] umount