### PR TITLE
run container-diff tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,17 @@ env:
     - BUILDAH_ISOLATION=oci
     - BUILDAH_ISOLATION=chroot
     - BUILDAH_ISOLATION=rootless
+    - TRAVIS_ENV="-e TRAVIS=$TRAVIS
+      -e CI=$CI
+      -e TRAVIS_COMMIT=$TRAVIS_COMMIT
+      -e TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE
+      -e TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG
+      -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST
+      -e TRAVIS_PULL_REQUEST_SHA=$TRAVIS_PULL_REQUEST_SHA
+      -e TRAVIS_PULL_REQUEST_SLUG=$TRAVIS_PULL_REQUEST_SLUG
+      -e TRAVIS_BRANCH=$TRAVIS_BRANCH
+      -e TRAVIS_JOB_ID=$TRAVIS_JOB_ID
+      -e TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR"
 
 matrix:
   # If the latest unstable development version of go fails, that's OK.
@@ -25,11 +36,12 @@ services:
 before_install:
     - sudo add-apt-repository -y ppa:duggan/bats
     - sudo apt-get update
-    - sudo apt-get -qq install bats btrfs-tools git libapparmor-dev libc-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libselinux1-dev
+    - sudo apt-get -qq install bats btrfs-tools git libapparmor-dev libc-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libselinux1-dev realpath
     - sudo apt-get -qq remove libseccomp2
     - sudo apt-get -qq update
     - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
     - mkdir /home/travis/auth
+    - sudo mkdir -p /var/lib/containers/storage/overlay
 install:
     #  Let's create a self signed certificate and get it in the right places
     - hostname
@@ -68,3 +80,11 @@ script:
     - go test -c -tags "apparmor seccomp `./btrfs_tag.sh` `./libdm_tag.sh` `./ostree_tag.sh` `./selinux_tag.sh`" ./cmd/buildah
     - tmp=`mktemp -d`; mkdir $tmp/root $tmp/runroot; sudo PATH="$PATH" ./buildah.test -test.v -root $tmp/root -runroot $tmp/runroot -storage-driver vfs -signature-policy `pwd`/tests/policy.json -registries-conf `pwd`/tests/registries.conf
     - cd tests; travis_wait 60 sudo PATH="$PATH" ./test_runner.sh
+    - cd ..
+    - echo "Run container-diff tests in Fedora container..."
+    - echo "Travis/host environment:"
+    - env
+    - echo
+    - echo "Running tests in SPC using ./hack/run_build.sh"
+    - "./hack/run_build.sh"
+

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -1,0 +1,7 @@
+FROM fedora:latest
+RUN dnf -y update; dnf -y clean all
+RUN dnf -y install nginx --setopt install_weak_deps=false; dnf -y clean all
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+RUN echo "nginx on Fedora" > /usr/share/nginx/html/index.html
+EXPOSE 80
+CMD [ "/usr/sbin/nginx" ]

--- a/hack/run_build.sh
+++ b/hack/run_build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+# This script can be run manually - assuming password-less sudo access
+# and a docker-daemon running.  To play in the SPC, just
+# `export SPCCMD=bash` beforehand.
+
+SPCCMD="${SPCCMD:-./hack/spc_build.sh}"
+DISTRO="${DISTRO:-fedora}"
+FQIN="${DISTRO}:latest"
+sudo docker pull $FQIN &
+
+REPO_DIR=$(realpath "$(dirname $0)/../")  # assume parent directory of 'hack'
+REPO_NAME=$(basename $(git rev-parse --show-toplevel))
+# In Travis $PWD == $TRAVIS_BUILD_DIR == $HOME/$REPO_OWNER/$REPO_NAME
+TRAVIS_BUILD_DIR="/root/$REPO_NAME"
+WORKDIR="$TRAVIS_BUILD_DIR"
+
+# Volume-mounting the repo into the SPC makes a giant mess of permissions
+# on the host.  This really sucks for developers, so make a copy for use
+# in the SPC separate from the host, throw it away when this script exits.
+echo
+echo "Making temporary copy of $REPO_DIR that"
+echo "will appear in SPC as $WORKDIR"
+TMP_SPC_REPO_COPY=$(mktemp -p '' -d ${REPO_NAME}_XXXXXX)
+trap "sudo rm -rf $TMP_SPC_REPO_COPY" EXIT
+/usr/bin/rsync -avz --recursive --links --delete-after --quiet \
+               --delay-updates --whole-file --safe-links \
+               --perms --times "${REPO_DIR}/" "${TMP_SPC_REPO_COPY}/"\
+               --include=.git &
+
+SPC_ARGS="--interactive --rm --privileged --ipc=host --pid=host --net=host"
+
+VOL_ARGS="-v $TMP_SPC_REPO_COPY:$WORKDIR
+          -v /run:/run -v /etc/localtime:/etc/localtime
+          -v /var/log:/var/log -v /sys/fs/cgroup:/sys/fs/cgroup
+          -v /var/lib/containers:/var/lib/containers
+          -v /var/run/docker.sock:/var/run/docker.sock
+          --tmpfs /tmp:rw,nosuid,nodev,exec,relatime,mode=1777,size=50%
+          --workdir $WORKDIR"
+
+ENV_ARGS="-e HOME=/root -e SHELL=/bin/bash -e SPC=true -e DISTRO=$DISTRO -e WORKDIR=$WORKDIR"
+
+echo
+echo "Preparing to run \$SPCMD=$SPCCMD in a $DISTRO SPC."
+echo "Override either for a different experience."
+wait  # for backgrounded processes to finish
+echo
+set -x
+sudo docker run -t $SPC_ARGS $VOL_ARGS $ENV_ARGS $TRAVIS_ENV $FQIN $SPCCMD

--- a/hack/spc_build.sh
+++ b/hack/spc_build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+
+if [[ "$SPC" != "true" ]]
+then
+    echo "This script is intended to be executed in an SPC,"
+    echo "by run_ci_tests.sh. Using it otherwise may result"
+    echo "in unpleasant side-effects."
+    exit 1
+fi
+
+echo
+echo "Build Environment:"
+env
+
+set +x
+
+echo "Updating image and deps..."
+dnf -y update --best --allowerasing
+dnf -y install dnf-plugins-core
+dnf -y copr enable lsm5/container-diff
+dnf -y install autoconf automake btrfs-progs-devel \
+   buildah \
+   container-diff device-mapper-devel golang go-md2man \
+   git glibc-static gpgme-devel hostname iproute \
+   iputils libassuan-devel libseccomp-static make \
+   moby-engine openssl
+
+# build buildah binary in fedora and run tests
+echo "Cleanup buildah repo and build again in fedora..."
+make clean
+mv vendor src
+mkdir -p $(pwd)/_build/src/github.com/projectatomic
+ln -s $(pwd) $(pwd)/_build/src/github.com/projectatomic/buildah
+make GOPATH=$(pwd)/_build:$(pwd) all TAGS="seccomp containers_image_ostree_stub"
+GOPATH=$(pwd)/_build:$(pwd) go test -c -tags "seccomp `./btrfs_tag.sh` `./libdm_tag.sh` `./ostree_tag.sh` `./selinux_tag.sh`" ./cmd/buildah
+tmp=$(mktemp -d); mkdir $tmp/root $tmp/runroot; PATH="$PATH" ./buildah.test -test.v -root $tmp/root -runroot $tmp/runroot -storage-driver vfs -signature-policy $(pwd)/tests/policy.json -registries-conf $(pwd)/tests/registries.conf
+
+echo "docker login to local registry..."
+echo testpassword | docker login localhost:5000 --username testuser --password-stdin
+
+echo "docker build dockerfile..."
+docker build -f hack/Dockerfile -t docker-test-image .
+
+echo "buildah bud dockerfile..."
+./buildah --registries-conf tests/registries.conf bud --file hack/Dockerfile -t buildah-test-image .
+
+echo "buildah tag buildah-test-image..."
+./buildah tag buildah-test-image localhost:5000/buildah-test-image
+
+echo "buildah push buildah-test-image..."
+./buildah push --cert-dir /home/travis/auth --tls-verify=false --authfile /root/.docker/config.json buildah-test-image localhost:5000/buildah-test-image
+
+echo "docker pull buildah-test-image..."
+docker pull localhost:5000/buildah-test-image
+
+echo "Running container-diff..."
+container-diff diff --type=rpm daemon://localhost:5000/buildah-test-image daemon://docker-test-image
+


### PR DESCRIPTION
This commit will cause Travis to spawn a fedora container
which will build a Dockerfile using docker and buildah bud
and then compare both images using container-diff

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


I'm thinking of moving the stuff in `.travis.yml` to the Fedora container, but that's for later.

@nalind @TomSweeneyRedHat @mrunalp PTAL