### PR TITLE
Use random string for getting a unique container name

### DIFF
--- a/new.go
+++ b/new.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/stringid"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/openshift/imagebuilder"
@@ -262,19 +263,11 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 	if options.Container != "" {
 		name = options.Container
 	} else {
-		var err2 error
 		if image != "" {
 			name = imageNamePrefix(image) + "-" + name
 		}
-		suffix := 1
-		tmpName := name
-		for errors.Cause(err2) != storage.ErrContainerUnknown {
-			_, err2 = store.Container(tmpName)
-			if err2 == nil {
-				suffix++
-				tmpName = fmt.Sprintf("%s-%d", name, suffix)
-			}
-		}
+		suffix := stringid.GenerateRandomID()
+		tmpName := fmt.Sprintf("%s-%s", name, suffix)
 		name = tmpName
 	}
 


### PR DESCRIPTION
Currently a buildah bud unique container name is found by incrementing
a counter and checking if that container exists. This causes a race
where that name may be claimed by another run by the time the
container is created.

This change replaces the incremented counter with a random string, so
that no duplicate name check is required.

Fixes #1004

Signed-off-by: Steve Baker <sbaker@redhat.com>