### PR TITLE
Fix arg usage in buildah-tag

### DIFF
--- a/cmd/buildah/tag.go
+++ b/cmd/buildah/tag.go
@@ -14,7 +14,7 @@ var (
 		Usage:                  "Add an additional name to a local image",
 		Description:            tagDescription,
 		Action:                 tagCmd,
-		ArgsUsage:              "IMAGE-NAME [IMAGE-NAME ...]",
+		ArgsUsage:              "IMAGE-NAME NEW-IMAGE-NAME",
 		SkipArgReorder:         true,
 		UseShortOptionHandling: true,
 	}


### PR DESCRIPTION
From [`./docs/buildah-tags.md`](https://github.com/projectatomic/buildah/blob/master/docs/buildah-tag.md) it looks like `buildah-tags` takes two arguments which isn't aligned with what `buildah tags -h` outputs: `IMAGE-NAME [IMAGE-NAME ... ]`.

This commit fixes `ArgUsage` to be according to what the docs say.