### PR TITLE
*: Return image-pulling errors from pullImage and resolveImage

### DIFF
--- a/pull.go
+++ b/pull.go
@@ -190,8 +190,8 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 	}()
 
 	logrus.Debugf("copying %q to %q", spec, destName)
-	err = cp.Image(ctx, policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter, sc, nil, ""))
-	if err == nil {
+	pullError := cp.Image(ctx, policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter, sc, nil, ""))
+	if pullError == nil {
 		return destRef, nil
 	}
 
@@ -206,9 +206,9 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 		return nil, err
 	}
 	if !hasRegistryInName && len(searchRegistries) == 0 {
-		return nil, errors.Errorf("image name provided is a short name and no search registries are defined in %s.", registryPath)
+		return nil, errors.Errorf("image name provided is a short name and no search registries are defined in %s: %s", registryPath, pullError)
 	}
-	return nil, errors.Errorf("unable to find image in the registries defined in %q", registryPath)
+	return nil, pullError
 }
 
 // getImageDigest creates an image object and uses the hex value of the digest as the image ID

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -93,7 +93,7 @@ load helpers
   run buildah bud --signature-policy ${TESTSDIR}/policy.json --force-rm --layers -t test1 -f Dockerfile.non-existent-registry ${TESTSDIR}/bud/use-layers
   echo "$output"
   [ "$status" -ne 0 ]
-  [[ "$output" =~ "image not known" ]]
+  [[ "$output" =~ "no such host" ]]
 }
 
 @test "bud from base image should have base image ENV also" {

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -13,8 +13,12 @@ misconfigured.
 
 #### Symptom
 ```console
-$ sudo buildah bud -f Dockerfile 
+$ sudo buildah bud -f Dockerfile .
 STEP 1: FROM alpine
+error creating build container: 2 errors occurred:
+
+* Error determining manifest MIME type for docker://localhost/alpine:latest: pinging docker registry returned: Get https://localhost/v2/: dial tcp [::1]:443: connect: connection refused
+* Error determining manifest MIME type for docker://registry.access.redhat.com/alpine:latest: Error reading manifest latest in registry.access.redhat.com/alpine: unknown: Not Found
 error building: error creating build container: no such image "alpine" in registry: image not known
 ```
 
@@ -22,7 +26,8 @@ error building: error creating build container: no such image "alpine" in regist
 
   * Verify that the `/etc/containers/registries.conf` file exists.  If not, verify that the containers-common package is installed.
   * Verify that the entries in the `[registries.search]` section of the /etc/containers/registries file are valid and reachable.
-
+  * Verify that the image you requested is either fully qualified, or that it exists on one of your search registries.
+  * Verify that the image is public or that you have logged in to at least one search registry which contains the private image.
 ---
 ### 2) http: server gave HTTP response to HTTPS client
 


### PR DESCRIPTION
This is a port of containers/libpod#1456 to buildah.

Instead of throwing out the upstream error message, save it and return it if we can't come up with a more-specific suggestion.  This makes debugging easier.

This slightly unwinds the approach from #747.  We tried to be helpful there, but we don't want to lump all of the things that could go wrong with a multi-registry pull into a single "unable to find" suggestion.

Using multierror for `resolveImage` gives us both pretty formatting (when we print this for the user) and programmatic access (for any callers that need to inspect the constituent errors).  This is our first direct dependency on multierror, but we've been vendoring it for a while now because opencontainers/runtime-tools uses it for config validation.

I don't have example output, because I don't have btrfs/ioctl.h or glib-2.0 on my RHEL 7.5 CSB laptop.  If someone wants to build with this patch and post example output with the new code (assuming it works at all ;), that would be helpful.

Fixes #849.