### PR TITLE
Add signature policy to push tests

### DIFF
--- a/tests/push.bats
+++ b/tests/push.bats
@@ -69,8 +69,8 @@ load helpers
 }
 
 @test "push without destination" {
-  buildah pull busybox
-  run buildah push busybox
+  buildah pull --signature-policy ${TESTSDIR}/policy.json busybox
+  run buildah push --signature-policy ${TESTSDIR}/policy.json busybox
   echo "$output"
   [ "$status" -eq 1 ]
   echo "$output" | grep -q "docker://busybox"


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Adds signature-policy to push without a destination tests.  This is tripping up our test system and I'm not sure how they ever passed without this.